### PR TITLE
fix: different behavior for time.After in go 1.18

### DIFF
--- a/pkg/isb/jetstream/writer_test.go
+++ b/pkg/isb/jetstream/writer_test.go
@@ -157,9 +157,10 @@ func TestJetStreamBufferWriterBufferFull(t *testing.T) {
 	bw, err := NewJetStreamBufferWriter(ctx, defaultJetStreamClient, streamName, streamName, streamName, WithMaxLength(10), WithBufferUsageLimit(0.2))
 	assert.NoError(t, err)
 	jw, _ := bw.(*jetStreamWriter)
+	timeout := time.After(10 * time.Second)
 	for jw.isFull.Load() {
 		select {
-		case <-time.After(10 * time.Second):
+		case <-timeout:
 			t.Fatalf("expected not to be full")
 		default:
 			time.Sleep(500 * time.Millisecond)
@@ -174,9 +175,10 @@ func TestJetStreamBufferWriterBufferFull(t *testing.T) {
 	for _, errMsg := range errs {
 		assert.Nil(t, errMsg) // Buffer not full, expect no error
 	}
+	timeout = time.After(10 * time.Second)
 	for !jw.isFull.Load() {
 		select {
-		case <-time.After(10 * time.Second):
+		case <-timeout:
 			t.Fatalf("expected to be full")
 		default:
 			time.Sleep(500 * time.Millisecond)

--- a/pkg/sources/http/http.go
+++ b/pkg/sources/http/http.go
@@ -173,11 +173,12 @@ func (h *httpSource) GetName() string {
 
 func (h *httpSource) Read(ctx context.Context, count int64) ([]*isb.ReadMessage, error) {
 	msgs := []*isb.ReadMessage{}
+	timeout := time.After(h.readTimeout)
 	for i := int64(0); i < count; i++ {
 		select {
 		case m := <-h.messages:
 			msgs = append(msgs, m)
-		case <-time.After(h.readTimeout):
+		case <-timeout:
 			h.logger.Debugw("Timed out waiting for messages to read.", zap.Duration("waited", h.readTimeout), zap.Int("read", len(msgs)))
 			return msgs, nil
 		}


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

`Time.After()` is changed to count from every time it gets called.