### PR TITLE
Added name to service spec

### DIFF
--- a/pkg/apis/numaflow/v1alpha1/const.go
+++ b/pkg/apis/numaflow/v1alpha1/const.go
@@ -88,10 +88,12 @@ const (
 	// Watermark
 	EnvWatermarkOn = "NUMAFLOW_WATERMARK_ON"
 
-	PathVarRun        = "/var/run/numaflow"
-	VertexMetricsPort = 2469
-	VertexHTTPSPort   = 8443
-	DaemonServicePort = 4327
+	PathVarRun            = "/var/run/numaflow"
+	VertexMetricsPort     = 2469
+	VertexMetricsPortName = "metrics"
+	VertexHTTPSPort       = 8443
+	VertexHTTPSPortName   = "https"
+	DaemonServicePort     = 4327
 
 	DefaultRequeueAfter = 10 * time.Second
 

--- a/pkg/apis/numaflow/v1alpha1/vertex_type_test.go
+++ b/pkg/apis/numaflow/v1alpha1/vertex_type_test.go
@@ -110,7 +110,7 @@ func TestGetVertexReplicas(t *testing.T) {
 }
 
 func TestGetHeadlessSvcSpec(t *testing.T) {
-	s := testVertex.getServiceObj(testVertex.GetHeadlessServiceName(), true, VertexMetricsPort)
+	s := testVertex.getServiceObj(testVertex.GetHeadlessServiceName(), true, VertexMetricsPort, VertexMetricsPortName)
 	assert.Equal(t, s.Name, testVertex.GetHeadlessServiceName())
 	assert.Equal(t, s.Namespace, testVertex.Namespace)
 	assert.Equal(t, 1, len(s.Spec.Ports))

--- a/pkg/apis/numaflow/v1alpha1/vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/vertex_types.go
@@ -73,22 +73,14 @@ func (v Vertex) GetHeadlessServiceName() string {
 }
 
 func (v Vertex) GetServiceObjs() []*corev1.Service {
-	svcs := []*corev1.Service{v.getServiceObj(v.GetHeadlessServiceName(), true, VertexMetricsPort)}
+	svcs := []*corev1.Service{v.getServiceObj(v.GetHeadlessServiceName(), true, VertexMetricsPort, VertexMetricsPortName)}
 	if x := v.Spec.Source; x != nil && x.HTTP != nil && x.HTTP.Service {
-		svcs = append(svcs, v.getServiceObj(v.Name, false, VertexHTTPSPort))
+		svcs = append(svcs, v.getServiceObj(v.Name, false, VertexHTTPSPort, VertexHTTPSPortName))
 	}
 	return svcs
 }
 
-func (v Vertex) getServiceObj(name string, headless bool, port int) *corev1.Service {
-	var servicePortName string
-	if port == VertexMetricsPort {
-		servicePortName = "metrics"
-	} else if port == VertexHTTPSPort {
-		servicePortName = "https"
-	} else {
-		servicePortName = "service"
-	}
+func (v Vertex) getServiceObj(name string, headless bool, port int, servicePortName string) *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       v.Namespace,

--- a/pkg/apis/numaflow/v1alpha1/vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/vertex_types.go
@@ -81,6 +81,14 @@ func (v Vertex) GetServiceObjs() []*corev1.Service {
 }
 
 func (v Vertex) getServiceObj(name string, headless bool, port int) *corev1.Service {
+	var servicePortName string
+	if port == VertexMetricsPort {
+		servicePortName = "metrics"
+	} else if port == VertexHTTPSPort {
+		servicePortName = "https"
+	} else {
+		servicePortName = "service"
+	}
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       v.Namespace,
@@ -96,7 +104,7 @@ func (v Vertex) getServiceObj(name string, headless bool, port int) *corev1.Serv
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
-				{Port: int32(port), TargetPort: intstr.FromInt(port)},
+				{Port: int32(port), TargetPort: intstr.FromInt(port), Name: servicePortName},
 			},
 			Selector: map[string]string{
 				KeyPartOf:       Project,


### PR DESCRIPTION
I was working on a document for metrics and there was an ask to figure out how to scrape the metrics using the prometheus operator. As part of the exercise I had created some k8s serviceMonitors to monitor services(based on labels) and scrape the corresponding metric. While doing so I figured that the serviceMonitor expected a `name` field on the service spec Port object. Added the same.

This has been tested by running a sample pipeline in my local k3d cluster