### PR TITLE
chore: Replaced node info text with rich format

### DIFF
--- a/ui/src/components/pipeline/Pipeline.tsx
+++ b/ui/src/components/pipeline/Pipeline.tsx
@@ -164,18 +164,10 @@ export function Pipeline() {
       vertexWatermark
     ) {
       pipeline.spec.vertices.map((vertex) => {
-        const podsLength = vertexPods.has(vertex.name)
-          ? vertexPods.get(vertex.name)
-          : 0;
         const newNode = {} as Node;
         newNode.id = vertex.name;
-        let label;
-        if (podsLength === 1) {
-          label = `${vertex.name} - ${podsLength} pod`;
-        } else {
-          label = `${vertex.name} - ${podsLength} pods`;
-        }
-        newNode.data = { label: label };
+        newNode.data = { name: vertex.name};
+        newNode.data.podnum = vertexPods.has(vertex.name) ? vertexPods.get(vertex.name) : 0;
         newNode.position = { x: 0, y: 0 };
         // change this in the future if you would like to make it draggable
         newNode.draggable = false;

--- a/ui/src/components/pipeline/graph/Node.css
+++ b/ui/src/components/pipeline/graph/Node.css
@@ -38,3 +38,22 @@
 .node-watermark-tooltip {
     text-align: center;
 }
+
+.node-info {
+    white-space: nowrap;
+    font-size: 1.3em;
+}
+
+.node-icon {
+    width: 1em;
+    height: 1em;
+    display: inline-block;
+    vertical-align: middle;
+    position: relative;
+    margin-left: 2px;
+    margin-right: 3px;
+}
+
+.node-podnum {
+    font-weight: bold;
+}

--- a/ui/src/components/pipeline/graph/NodeUtil.tsx
+++ b/ui/src/components/pipeline/graph/NodeUtil.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import icon from '../../../images/icon.png';
+
+// Returns the component for node info value
+export function GetNodeInfoValueComponent(nodeData) {
+    const label = nodeData?.podnum <= 1 ? "pod" : "pods";
+    return (
+        <span className="node-info">
+            {nodeData?.name} -
+            <img className="node-icon" src={icon}/>
+            <span className="node-podnum">{nodeData?.podnum} {label}</span>
+        </span>
+    );
+}

--- a/ui/src/components/pipeline/graph/SinkNode.tsx
+++ b/ui/src/components/pipeline/graph/SinkNode.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { Handle, NodeProps, Position } from "react-flow-renderer";
 import { Tooltip } from "@mui/material";
 import "./Node.css";
+import { GetNodeInfoValueComponent } from "./NodeUtil"
 
 const SinkNode = ({
   data,
@@ -59,7 +60,7 @@ const SinkNode = ({
           position={targetPosition}
           isConnectable={isConnectable}
         />
-        {data?.label}
+        {GetNodeInfoValueComponent(data)}
       </div>
     </div>
   );

--- a/ui/src/components/pipeline/graph/SourceNode.tsx
+++ b/ui/src/components/pipeline/graph/SourceNode.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { Handle, NodeProps, Position } from "react-flow-renderer";
 import { Tooltip } from "@mui/material";
 import "./Node.css";
+import { GetNodeInfoValueComponent } from "./NodeUtil"
 
 const SourceNode = ({
   data,
@@ -54,8 +55,7 @@ const SourceNode = ({
             {data?.vertexMetrics?.ratePerMin}/sec
           </div>
         </Tooltip>
-
-        {data?.label}
+        {GetNodeInfoValueComponent(data)}
         <Handle
           type="source"
           position={sourcePosition}

--- a/ui/src/components/pipeline/graph/UDFNode.tsx
+++ b/ui/src/components/pipeline/graph/UDFNode.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { Handle, NodeProps, Position } from "react-flow-renderer";
 import { Tooltip } from "@mui/material";
 import "./Node.css";
+import { GetNodeInfoValueComponent } from "./NodeUtil"
 
 const UDFNode = ({
   data,
@@ -60,7 +61,7 @@ const UDFNode = ({
           position={targetPosition}
           isConnectable={isConnectable}
         />
-        {data?.label}
+        {GetNodeInfoValueComponent(data)}
         <Handle
           type="source"
           position={sourcePosition}


### PR DESCRIPTION
Changes
- Made "<n> pod" bold font
- Added numaproj icon inline. will replace it with another asset when it's ready
- Ensure separation of logic (in react) and ui (in css)

Signed-off-by: Qianbo Huai <qianbo@gmail.com>

![Screen Shot 2022-10-07 at 2 41 34 AM](https://user-images.githubusercontent.com/1668492/194527864-eb7a63f3-81fa-493d-9d25-c2c11676db10.png)
