### PR TITLE
chore: reference the Payload directly when writing to Redis ISB to avoid extra marshaling

### DIFF
--- a/pkg/isb/stores/redis/read.go
+++ b/pkg/isb/stores/redis/read.go
@@ -325,11 +325,7 @@ func getHeaderAndBody(field string, value interface{}) (msg isb.Message, err err
 		return msg, fmt.Errorf("header unmarshal error %w", err)
 	}
 
-	err = msg.Body.UnmarshalBinary([]byte(value.(string)))
-	if err != nil {
-		return msg, fmt.Errorf("body unmarshal error (%v) %w", []byte(value.(string)), err)
-	}
-
+	msg.Body.Payload = []byte(value.(string))
 	return msg, nil
 }
 

--- a/pkg/isb/stores/redis/read_test.go
+++ b/pkg/isb/stores/redis/read_test.go
@@ -54,7 +54,7 @@ func TestRedisQRead_Read(t *testing.T) {
 	for _, msg := range messages {
 		err := client.Client.XAdd(ctx, &redis.XAddArgs{
 			Stream: rqr.GetStreamName(),
-			Values: []interface{}{msg.Header, msg.Body},
+			Values: []interface{}{msg.Header, msg.Body.Payload},
 		}).Err()
 		assert.NoError(t, err)
 	}
@@ -86,7 +86,7 @@ func TestRedisCheckBacklog(t *testing.T) {
 	for _, msg := range messages {
 		err := client.Client.XAdd(ctx, &redis.XAddArgs{
 			Stream: rqr.GetStreamName(),
-			Values: []interface{}{msg.Header, msg.Body},
+			Values: []interface{}{msg.Header, msg.Body.Payload},
 		}).Err()
 		assert.NoError(t, err)
 	}
@@ -455,7 +455,7 @@ func writeTestMessages(ctx context.Context, client *redisclient.RedisClient, mes
 		for _, message := range messages {
 			client.Client.XAdd(ctx, &redis.XAddArgs{
 				Stream: streamName,
-				Values: []interface{}{message.Header, message.Body},
+				Values: []interface{}{message.Header, message.Body.Payload},
 			})
 		}
 	}()

--- a/pkg/isb/stores/redis/write_test.go
+++ b/pkg/isb/stores/redis/write_test.go
@@ -417,7 +417,7 @@ func TestXTrimOnIsFull(t *testing.T) {
 	for _, msg := range messages {
 		err := client.Client.XAdd(ctx, &redis.XAddArgs{
 			Stream: rqw.GetStreamName(),
-			Values: []interface{}{msg.Header, msg.Body},
+			Values: []interface{}{msg.Header, msg.Body.Payload},
 		}).Err()
 		assert.NoError(t, err)
 	}
@@ -482,7 +482,7 @@ func TestSetWriteInfo(t *testing.T) {
 	for _, msg := range messages {
 		err := client.Client.XAdd(ctx, &redis.XAddArgs{
 			Stream: rqw.GetStreamName(),
-			Values: []interface{}{msg.Header, msg.Body},
+			Values: []interface{}{msg.Header, msg.Body.Payload},
 		}).Err()
 		assert.NoError(t, err)
 	}
@@ -550,7 +550,7 @@ func forwardDataAndVerify(ctx context.Context, t *testing.T, fromStepWrite *Buff
 	// Read messages and validate the content
 	assert.Len(t, readMessages, 17)
 	assert.Equal(t, []interface{}{writeMessages[0].Header.PaneInfo, writeMessages[1].Header.PaneInfo, writeMessages[2].Header.PaneInfo, writeMessages[3].Header.PaneInfo, writeMessages[4].Header.PaneInfo}, []interface{}{readMessages[0].Header.PaneInfo, readMessages[1].Header.PaneInfo, readMessages[2].Header.PaneInfo, readMessages[3].Header.PaneInfo, readMessages[4].Header.PaneInfo})
-	assert.Equal(t, []interface{}{writeMessages[0].Body, writeMessages[1].Body, writeMessages[2].Body, writeMessages[3].Body, writeMessages[4].Body}, []interface{}{readMessages[0].Body, readMessages[1].Body, readMessages[2].Body, readMessages[3].Body, readMessages[4].Body})
+	assert.Equal(t, []interface{}{writeMessages[0].Body.Payload, writeMessages[1].Body.Payload, writeMessages[2].Body.Payload, writeMessages[3].Body.Payload, writeMessages[4].Body.Payload}, []interface{}{readMessages[0].Body.Payload, readMessages[1].Body.Payload, readMessages[2].Body.Payload, readMessages[3].Body.Payload, readMessages[4].Body.Payload})
 
 	_, _ = fromStepWrite.Write(ctx, writeMessages[18:20])
 


### PR DESCRIPTION
Closes: #204 

This PR reference the `Payload` directly in `isb.message.body` to avoid extra marshaling in Redis ISB implementation. Note that we need to revisit it when `Body` structure changes for [this](https://github.com/numaproj/numaflow/pull/213#issuecomment-1278016520) reason. 

`Testing`: Unit tests.

Signed-off-by: Hao (xdevxhao@gmail.com)

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
