### PR TITLE
fix: Show human-readable timestamps in Daemon Service log

### DIFF
--- a/pkg/shared/logging/log.go
+++ b/pkg/shared/logging/log.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	zap "go.uber.org/zap"
+	zapcore "go.uber.org/zap/zapcore"
 )
 
 // NewLogger returns a new zap.SugaredLogger
@@ -18,6 +19,7 @@ func NewLogger() *zap.SugaredLogger {
 	}
 	// Config customization goes here if any
 	config.OutputPaths = []string{"stdout"}
+	config.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout(time.RFC3339)
 	logger, err := config.Build()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Signed-off-by: Akhil <akhil.choudhary2000@gmail.com>

Will show Daemon Service log shows timestamp in human-readable timestamps instead of epoch values.
