### PR TITLE
feat: support disabling TLS and changing port for UX server

### DIFF
--- a/cmd/commands/server.go
+++ b/cmd/commands/server.go
@@ -6,12 +6,15 @@ import (
 )
 
 func NewServerCommand() *cobra.Command {
+	var insecure bool
+
 	command := &cobra.Command{
 		Use:   "server",
 		Short: "Start a Numaflow server",
 		Run: func(cmd *cobra.Command, args []string) {
-			svrcmd.Start()
+			svrcmd.Start(insecure)
 		},
 	}
+	command.Flags().BoolVar(&insecure, "insecure", false, "Whether to disable on TLS, defaults to false.")
 	return command
 }

--- a/cmd/commands/server.go
+++ b/cmd/commands/server.go
@@ -7,14 +7,19 @@ import (
 
 func NewServerCommand() *cobra.Command {
 	var insecure bool
+	var port int
 
 	command := &cobra.Command{
 		Use:   "server",
 		Short: "Start a Numaflow server",
 		Run: func(cmd *cobra.Command, args []string) {
-			svrcmd.Start(insecure)
+			if !cmd.Flags().Changed("port") && insecure {
+				port = 8080
+			}
+			svrcmd.Start(insecure, port)
 		},
 	}
 	command.Flags().BoolVar(&insecure, "insecure", false, "Whether to disable on TLS, defaults to false.")
+	command.Flags().IntVarP(&port, "port", "p", 8443, "Port to listen on, defaults to 8443 or 8080 if insecure is set")
 	return command
 }

--- a/cmd/commands/server.go
+++ b/cmd/commands/server.go
@@ -21,7 +21,7 @@ func NewServerCommand() *cobra.Command {
 			svrcmd.Start(insecure, port)
 		},
 	}
-	command.Flags().BoolVar(&insecure, "insecure", false, "Whether to disable on TLS, defaults to false.")
+	command.Flags().BoolVar(&insecure, "insecure", false, "Whether to disable TLS, defaults to false.")
 	command.Flags().IntVarP(&port, "port", "p", 8443, "Port to listen on, defaults to 8443 or 8080 if insecure is set")
 	return command
 }

--- a/cmd/commands/server.go
+++ b/cmd/commands/server.go
@@ -6,8 +6,10 @@ import (
 )
 
 func NewServerCommand() *cobra.Command {
-	var insecure bool
-	var port int
+	var (
+		insecure bool
+		port     int
+	)
 
 	command := &cobra.Command{
 		Use:   "server",

--- a/server/cmd/start.go
+++ b/server/cmd/start.go
@@ -20,7 +20,7 @@ var (
 	}
 )
 
-func Start(insecure bool) {
+func Start(insecure bool, port int) {
 	logger := logging.NewLogger().Named("server")
 	router := gin.New()
 	router.Use(gin.Logger())
@@ -29,12 +29,11 @@ func Start(insecure bool) {
 	routes.Routes(router)
 	router.Use(UrlRewrite(router))
 	server := http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
 		Handler: router,
 	}
 
 	if insecure {
-		server.Addr = fmt.Sprintf(":%d", 8080)
-
 		logger.Infof("Starting server (TLS disabled) on %s", server.Addr)
 		if err := server.ListenAndServe(); err != nil {
 			panic(err)
@@ -44,8 +43,6 @@ func Start(insecure bool) {
 		if err != nil {
 			panic(err)
 		}
-
-		server.Addr = fmt.Sprintf(":%d", 8443)
 		server.TLSConfig = &tls.Config{Certificates: []tls.Certificate{*cert}, MinVersion: tls.VersionTLS12}
 
 		logger.Infof("Starting server on %s", server.Addr)


### PR DESCRIPTION
Closes #227

* Adds support for disabling TLS with `--insecure` (server will listen by default at 8080)
* Adds support for overriding the default port with `--port=8081` or `-p 8081`.
