### PR TITLE
fix: watermark watcher leak

### DIFF
--- a/pkg/watermark/fetch/edge_fetcher.go
+++ b/pkg/watermark/fetch/edge_fetcher.go
@@ -78,7 +78,7 @@ func (e *edgeFetcher) GetWatermark(inputOffset isb.Offset) processor.Watermark {
 		if t != -1 && t < epoch {
 			epoch = t
 		}
-		if p.IsDeleted() && (offset > p.offsetTimeline.GetHeadOffset()) {
+		if !p.IsActive() && (offset > p.offsetTimeline.GetHeadOffset()) {
 			// if the pod is not active and the current offset is ahead of all offsets in Timeline
 			e.processorManager.DeleteProcessor(p.entity.GetID())
 		}

--- a/pkg/watermark/fetch/edge_fetcher.go
+++ b/pkg/watermark/fetch/edge_fetcher.go
@@ -78,7 +78,6 @@ func (e *edgeFetcher) GetWatermark(inputOffset isb.Offset) processor.Watermark {
 		if t != -1 && t < epoch {
 			epoch = t
 		}
-		// TODO: can we delete an inactive processor?
 		if p.IsDeleted() && (offset > p.offsetTimeline.GetHeadOffset()) {
 			// if the pod is not active and the current offset is ahead of all offsets in Timeline
 			e.processorManager.DeleteProcessor(p.entity.GetID())

--- a/pkg/watermark/fetch/edge_fetcher.go
+++ b/pkg/watermark/fetch/edge_fetcher.go
@@ -78,7 +78,7 @@ func (e *edgeFetcher) GetWatermark(inputOffset isb.Offset) processor.Watermark {
 		if t != -1 && t < epoch {
 			epoch = t
 		}
-		if !p.IsActive() && (offset > p.offsetTimeline.GetHeadOffset()) {
+		if p.IsDeleted() && (offset > p.offsetTimeline.GetHeadOffset()) {
 			// if the pod is not active and the current offset is ahead of all offsets in Timeline
 			e.processorManager.DeleteProcessor(p.entity.GetID())
 		}

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -133,10 +133,11 @@ func (v *ProcessorManager) refreshingProcessors() {
 // startHeatBeatWatcher starts the processor Heartbeat Watcher to listen to the processor bucket and update the processor
 // Heartbeat map. In the processor heartbeat bucket we have the structure key: processor-name, value: processor-heartbeat.
 func (v *ProcessorManager) startHeatBeatWatcher() {
-	watchCh := v.hbWatcher.Watch(v.ctx)
+	watchCh, stopped := v.hbWatcher.Watch(v.ctx)
 	for {
 		select {
 		case <-v.ctx.Done():
+			<-stopped
 			// main process exit
 			// close both watcher
 			v.otWatcher.Close()

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -18,10 +18,13 @@ import (
 // ProcessorManager manages the point of view of Vn-1 from Vn vertex processors (or source processor). The code is running on Vn vertex.
 // It has the mapping of all the processors which in turn has all the information about each processor timelines.
 type ProcessorManager struct {
-	ctx        context.Context
-	hbWatcher  store.WatermarkKVWatcher
-	otWatcher  store.WatermarkKVWatcher
-	heartbeat  *ProcessorHeartbeat
+	ctx       context.Context
+	hbWatcher store.WatermarkKVWatcher
+	otWatcher store.WatermarkKVWatcher
+	// heartbeat just tracks the heartbeat of each processing unit. we use it to mark a processing unit's status (e.g, inactive)
+	heartbeat *ProcessorHeartbeat
+	// processors has reference to the actual processing unit (ProcessorEntity) which includes offset timeline which is
+	// used for tracking watermark.
 	processors map[string]*ProcessorToFetch
 	lock       sync.RWMutex
 	log        *zap.SugaredLogger

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -147,8 +147,7 @@ func (v *ProcessorManager) startHeatBeatWatcher() {
 	watchCh, stopped := v.hbWatcher.Watch(v.ctx)
 	for {
 		select {
-		case <-v.ctx.Done():
-			<-stopped
+		case <-stopped:
 			// main process exit
 			// close both watcher
 			v.otWatcher.Close()

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -73,7 +73,6 @@ func (v *ProcessorManager) GetProcessor(processor string) *ProcessorToFetch {
 }
 
 // DeleteProcessor deletes a processor.
-// Note: This operation is not used anywhere ATM.
 func (v *ProcessorManager) DeleteProcessor(processor string) {
 	v.lock.Lock()
 	defer v.lock.Unlock()

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -125,7 +125,7 @@ func (v *ProcessorManager) refreshingProcessors() {
 			// it's possible the pod has exited unexpectedly, so we need to delete the pod
 			// NOTE: the pod entry still remains in the heartbeat store (bucket)
 			// TODO: how to delete the pod from the heartbeat store?
-			v.log.Infow("Deleting", zap.String("key", pName), zap.String(pName, p.String()))
+			v.log.Infow("Processor has been inactive for 10 heartbeats, deleting...", zap.String("key", pName), zap.String(pName, p.String()))
 			p.setStatus(_deleted)
 			p.stopTimeLineWatcher()
 			v.heartbeat.Delete(pName)

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -98,7 +98,6 @@ func (v *ProcessorManager) startRefreshingProcessors() {
 	for {
 		select {
 		case <-v.ctx.Done():
-
 			return
 		case <-ticker.C:
 			v.refreshingProcessors()

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -120,7 +120,10 @@ func (v *ProcessorManager) refreshingProcessors() {
 		if time.Now().Unix()-pTime > v.opts.podHeartbeatRate {
 			// if the pod's last heartbeat is greater than podHeartbeatRate
 			// then the pod is not considered as live
+			v.log.Infow("The processor becomes inactive", zap.String("key", pName), zap.String(pName, p.String()))
 			p.setStatus(_inactive)
+			p.stopTimeLineWatcher()
+			v.heartbeat.Delete(pName)
 		} else {
 			p.setStatus(_active)
 			debugStr.WriteString(fmt.Sprintf("[%s] ", pName))

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -98,6 +98,7 @@ func (v *ProcessorManager) startRefreshingProcessors() {
 	for {
 		select {
 		case <-v.ctx.Done():
+
 			return
 		case <-ticker.C:
 			v.refreshingProcessors()
@@ -136,6 +137,9 @@ func (v *ProcessorManager) startHeatBeatWatcher() {
 	for {
 		select {
 		case <-v.ctx.Done():
+			// main process exit
+			// close both watcher
+			v.otWatcher.Close()
 			v.hbWatcher.Close()
 			return
 		case value := <-watchCh:

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -179,6 +179,7 @@ func (v *ProcessorManager) startHeatBeatWatcher() {
 				} else {
 					v.log.Infow("Deleting", zap.String("key", value.Key()), zap.String(value.Key(), p.String()))
 					p.setStatus(_deleted)
+					p.stopTimeLineWatcher()
 					v.heartbeat.Delete(value.Key())
 				}
 			case store.KVPurge:

--- a/pkg/watermark/fetch/processor_manager_inmem_test.go
+++ b/pkg/watermark/fetch/processor_manager_inmem_test.go
@@ -163,6 +163,23 @@ func TestFetcherWithSameOTBucket_InMem(t *testing.T) {
 	// so "p1" will be considered as a new processors and a new offsetTimeline watcher for "p1" will be created
 	_ = testBuffer.GetWatermark(isb.SimpleOffset(func() string { return strconv.FormatInt(testOffset+1, 10) }))
 	p1 := testBuffer.processorManager.GetProcessor("p1")
+
+	assert.NotNil(t, p1)
+	assert.True(t, p1.IsActive())
+	assert.NotNil(t, p1.offsetTimeline)
+	// wait till the offsetTimeline has been populated
+	newP1head := p1.offsetTimeline.GetHeadOffset()
+	for newP1head == -1 {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("expected head offset to not be equal to -1, %s", ctx.Err())
+		default:
+			time.Sleep(1 * time.Millisecond)
+			newP1head = p1.offsetTimeline.GetHeadOffset()
+		}
+	}
+	// because we keep the kv updates history in the in mem watermark
+	// the new watcher will read all the history data to create this new offsetTimeline
 	assert.Equal(t, int64(100), p1.offsetTimeline.GetHeadOffset())
 
 	// publish a new watermark 101

--- a/pkg/watermark/fetch/processor_manager_inmem_test.go
+++ b/pkg/watermark/fetch/processor_manager_inmem_test.go
@@ -228,4 +228,5 @@ func TestFetcherWithSameOTBucket_InMem(t *testing.T) {
 	// added 101 in the previous steps for p1, so the head should be 101 after resume
 	assert.Equal(t, int64(101), p1.offsetTimeline.GetHeadOffset())
 	wg.Wait()
+	cancel()
 }

--- a/pkg/watermark/fetch/processor_manager_inmem_test.go
+++ b/pkg/watermark/fetch/processor_manager_inmem_test.go
@@ -122,11 +122,11 @@ func TestFetcherWithSameOTBucket_InMem(t *testing.T) {
 	assert.Equal(t, 2, len(allProcessors))
 	assert.True(t, allProcessors["p1"].IsDeleted())
 	assert.True(t, allProcessors["p2"].IsActive())
+	// "p1" should be deleted after this GetWatermark offset=101
+	// because "p1" offsetTimeline's head offset=100, which is < inputOffset 103
 	_ = testBuffer.GetWatermark(isb.SimpleOffset(func() string { return strconv.FormatInt(testOffset+3, 10) }))
 	allProcessors = testBuffer.processorManager.GetAllProcessors()
-	// we don't delete inactive processors from processor manager, so the length should still be 2
-	assert.Equal(t, 2, len(allProcessors))
-	assert.True(t, allProcessors["p1"].IsDeleted())
+	assert.Equal(t, 1, len(allProcessors))
 	assert.True(t, allProcessors["p2"].IsActive())
 
 	time.Sleep(time.Second)
@@ -159,7 +159,8 @@ func TestFetcherWithSameOTBucket_InMem(t *testing.T) {
 	}
 	assert.True(t, allProcessors["p1"].IsActive())
 	assert.True(t, allProcessors["p2"].IsActive())
-	// "p1" should still have the same offsetTimeline
+	// "p1" has been deleted from vertex.Processors
+	// so "p1" will be considered as a new processors and a new offsetTimeline watcher for "p1" will be created
 	_ = testBuffer.GetWatermark(isb.SimpleOffset(func() string { return strconv.FormatInt(testOffset+1, 10) }))
 	p1 := testBuffer.processorManager.GetProcessor("p1")
 	assert.Equal(t, int64(100), p1.offsetTimeline.GetHeadOffset())

--- a/pkg/watermark/fetch/processor_manager_inmem_test.go
+++ b/pkg/watermark/fetch/processor_manager_inmem_test.go
@@ -50,10 +50,8 @@ func TestFetcherWithSameOTBucket_InMem(t *testing.T) {
 
 	hbWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_PROCESSORS", hbWatcherCh)
 	assert.NoError(t, err)
-	defer hbWatcher.Close()
 	otWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_OT", otWatcherCh)
 	assert.NoError(t, err)
-	defer otWatcher.Close()
 	var testVertex = NewProcessorManager(ctx, store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher), WithPodHeartbeatRate(1), WithRefreshingProcessorsRate(1), WithSeparateOTBuckets(false))
 	var testBuffer = NewEdgeFetcher(ctx, "testBuffer", testVertex).(*edgeFetcher)
 
@@ -230,5 +228,4 @@ func TestFetcherWithSameOTBucket_InMem(t *testing.T) {
 	// added 101 in the previous steps for p1, so the head should be 101 after resume
 	assert.Equal(t, int64(101), p1.offsetTimeline.GetHeadOffset())
 	wg.Wait()
-	cancel()
 }

--- a/pkg/watermark/fetch/processor_manager_test.go
+++ b/pkg/watermark/fetch/processor_manager_test.go
@@ -95,10 +95,8 @@ func TestFetcherWithSameOTBucket(t *testing.T) {
 	// create watchers for heartbeat and offset timeline
 	hbWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, "testFetch", keyspace+"_PROCESSORS", defaultJetStreamClient)
 	assert.NoError(t, err)
-	defer hbWatcher.Close()
 	otWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, "testFetch", keyspace+"_OT", defaultJetStreamClient)
 	assert.NoError(t, err)
-	defer otWatcher.Close()
 	var testVertex = NewProcessorManager(ctx, store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher), WithPodHeartbeatRate(1), WithRefreshingProcessorsRate(1), WithSeparateOTBuckets(false))
 	var testBuffer = NewEdgeFetcher(ctx, "testBuffer", testVertex).(*edgeFetcher)
 
@@ -272,12 +270,6 @@ func TestFetcherWithSameOTBucket(t *testing.T) {
 
 	wg.Wait()
 	cancel()
-
-	// wait for all the ctx.Done() is completed
-	// we don't have wg on the Watch functions go routine..
-	// TODO: opened an issue https://github.com/numaproj/numaflow/issues/224
-	//   fix tests after we revisit the watermark store and watcher closing logic
-	time.Sleep(3 * time.Second)
 }
 
 func TestFetcherWithSeparateOTBucket(t *testing.T) {

--- a/pkg/watermark/fetch/processor_manager_test.go
+++ b/pkg/watermark/fetch/processor_manager_test.go
@@ -166,12 +166,12 @@ func TestFetcherWithSameOTBucket(t *testing.T) {
 	assert.Equal(t, 2, len(allProcessors))
 	assert.True(t, allProcessors["p1"].IsDeleted())
 	assert.True(t, allProcessors["p2"].IsActive())
+	// "p1" should be deleted after this GetWatermark offset=101
+	// because "p1" offsetTimeline's head offset=100, which is < inputOffset 103
 	_ = testBuffer.GetWatermark(isb.SimpleOffset(func() string { return strconv.FormatInt(testOffset+3, 10) }))
 	allProcessors = testBuffer.processorManager.GetAllProcessors()
-	// we don't delete inactive processors, so the length should still be 2
-	assert.Equal(t, 2, len(allProcessors))
+	assert.Equal(t, 1, len(allProcessors))
 	assert.True(t, allProcessors["p2"].IsActive())
-	assert.False(t, allProcessors["p1"].IsActive())
 
 	time.Sleep(time.Second)
 	// resume after one second
@@ -203,12 +203,25 @@ func TestFetcherWithSameOTBucket(t *testing.T) {
 
 	assert.True(t, allProcessors["p1"].IsActive())
 	assert.True(t, allProcessors["p2"].IsActive())
-	// "p1" status is back to active, the offset timeline should be preserved
+	// "p1" has been deleted from vertex.Processors
+	// so "p1" will be considered as a new processors and a new offsetTimeline watcher for "p1" will be created
 	_ = testBuffer.GetWatermark(isb.SimpleOffset(func() string { return strconv.FormatInt(testOffset+1, 10) }))
 	p1 := testBuffer.processorManager.GetProcessor("p1")
 	assert.NotNil(t, p1)
 	assert.True(t, p1.IsActive())
 	assert.NotNil(t, p1.offsetTimeline)
+	// wait till the offsetTimeline has been populated
+	newP1head := p1.offsetTimeline.GetHeadOffset()
+	for newP1head == -1 {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("expected head offset to not be equal to -1, %s", ctx.Err())
+		default:
+			time.Sleep(1 * time.Millisecond)
+			newP1head = p1.offsetTimeline.GetHeadOffset()
+		}
+	}
+	// because the bucket hasn't been cleaned up, the new watcher will read all the history data to create this new offsetTimeline
 	assert.Equal(t, int64(100), p1.offsetTimeline.GetHeadOffset())
 
 	// publish a new watermark 101

--- a/pkg/watermark/fetch/processor_to_fetch.go
+++ b/pkg/watermark/fetch/processor_to_fetch.go
@@ -100,8 +100,11 @@ func (p *ProcessorToFetch) startTimeLineWatcher() {
 	watchCh := p.otWatcher.Watch(p.ctx)
 
 	go func() {
-		if p.IsDeleted() {
-			close(stopCh)
+		for {
+			if p.IsDeleted() {
+				close(stopCh)
+				break
+			}
 		}
 	}()
 

--- a/pkg/watermark/fetch/processor_to_fetch.go
+++ b/pkg/watermark/fetch/processor_to_fetch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -105,6 +106,7 @@ func (p *ProcessorToFetch) startTimeLineWatcher() {
 				cancel()
 				return
 			}
+			time.Sleep(1 * time.Second)
 		}
 	}()
 

--- a/pkg/watermark/fetch/processor_to_fetch.go
+++ b/pkg/watermark/fetch/processor_to_fetch.go
@@ -96,9 +96,20 @@ func (p *ProcessorToFetch) IsDeleted() bool {
 }
 
 func (p *ProcessorToFetch) startTimeLineWatcher() {
+	var stopCh = make(chan struct{})
 	watchCh := p.otWatcher.Watch(p.ctx)
+
+	go func() {
+		if p.IsDeleted() {
+			close(stopCh)
+		}
+	}()
+
 	for {
 		select {
+		case <-stopCh:
+			p.otWatcher.Close()
+			return
 		case <-p.ctx.Done():
 			p.otWatcher.Close()
 			return

--- a/pkg/watermark/fetch/processor_to_fetch.go
+++ b/pkg/watermark/fetch/processor_to_fetch.go
@@ -107,10 +107,9 @@ func (p *ProcessorToFetch) startTimeLineWatcher() {
 
 	for {
 		select {
-		case <-p.ctx.Done():
+		case <-stopped:
 			// no need to close ot watcher here because the ot watcher is shared for the given vertex
 			// the parent ctx will close the ot watcher
-			<-stopped
 			return
 		case value := <-watchCh:
 			// TODO: why will value will be nil?

--- a/pkg/watermark/fetch/processor_to_fetch.go
+++ b/pkg/watermark/fetch/processor_to_fetch.go
@@ -97,7 +97,7 @@ func (p *ProcessorToFetch) IsDeleted() bool {
 
 func (p *ProcessorToFetch) startTimeLineWatcher() {
 	ctx, cancel := context.WithCancel(p.ctx)
-	watchCh := p.otWatcher.Watch(ctx)
+	watchCh, stopped := p.otWatcher.Watch(ctx)
 
 	go func() {
 		for {
@@ -113,6 +113,7 @@ func (p *ProcessorToFetch) startTimeLineWatcher() {
 		case <-ctx.Done():
 			// no need to close ot watcher here because the ot watcher is shared for the given vertex
 			// the parent ctx will close the ot watcher
+			<-stopped
 			return
 		case value := <-watchCh:
 			// TODO: why will value will be nil?

--- a/pkg/watermark/fetch/processor_to_fetch.go
+++ b/pkg/watermark/fetch/processor_to_fetch.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sync"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -37,6 +36,7 @@ func (s status) String() string {
 // ProcessorToFetch is the smallest unit of entity (from which we fetch data) that does inorder processing or contains inorder data.
 type ProcessorToFetch struct {
 	ctx            context.Context
+	cancel         context.CancelFunc
 	entity         processor.ProcessorEntitier
 	status         status
 	offsetTimeline *OffsetTimeline
@@ -51,8 +51,10 @@ func (p *ProcessorToFetch) String() string {
 
 // NewProcessorToFetch creates ProcessorToFetch.
 func NewProcessorToFetch(ctx context.Context, processor processor.ProcessorEntitier, capacity int, watcher store.WatermarkKVWatcher) *ProcessorToFetch {
+	ctx, cancel := context.WithCancel(ctx)
 	p := &ProcessorToFetch{
 		ctx:            ctx,
+		cancel:         cancel,
 		entity:         processor,
 		status:         _active,
 		offsetTimeline: NewOffsetTimeline(ctx, capacity),
@@ -96,23 +98,16 @@ func (p *ProcessorToFetch) IsDeleted() bool {
 	return p.status == _deleted
 }
 
-func (p *ProcessorToFetch) startTimeLineWatcher() {
-	ctx, cancel := context.WithCancel(p.ctx)
-	watchCh, stopped := p.otWatcher.Watch(ctx)
+func (p *ProcessorToFetch) stopTimeLineWatcher() {
+	p.cancel()
+}
 
-	go func() {
-		for {
-			if p.IsDeleted() {
-				cancel()
-				return
-			}
-			time.Sleep(1 * time.Second)
-		}
-	}()
+func (p *ProcessorToFetch) startTimeLineWatcher() {
+	watchCh, stopped := p.otWatcher.Watch(p.ctx)
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-p.ctx.Done():
 			// no need to close ot watcher here because the ot watcher is shared for the given vertex
 			// the parent ctx will close the ot watcher
 			<-stopped

--- a/pkg/watermark/publish/publisher.go
+++ b/pkg/watermark/publish/publisher.go
@@ -149,7 +149,7 @@ func (p *publish) GetLatestWatermark() processor.Watermark {
 func (p *publish) publishHeartbeat() {
 	ticker := time.NewTicker(time.Second * time.Duration(p.opts.podHeartbeatRate))
 	defer ticker.Stop()
-	p.log.Infow("Refreshing ActiveProcessors ticker started")
+	p.log.Infow("Publishing Heartbeat ticker started")
 	for {
 		select {
 		case <-p.ctx.Done():

--- a/pkg/watermark/store/interface.go
+++ b/pkg/watermark/store/interface.go
@@ -64,7 +64,7 @@ type WatermarkKVEntry interface {
 
 // WatermarkKVWatcher watches the KV bucket for watermark progression.
 type WatermarkKVWatcher interface {
-	Watch(context.Context) <-chan WatermarkKVEntry
+	Watch(context.Context) (<-chan WatermarkKVEntry, <-chan struct{})
 	GetKVName() string
 	Close()
 }

--- a/pkg/watermark/store/interface.go
+++ b/pkg/watermark/store/interface.go
@@ -64,6 +64,7 @@ type WatermarkKVEntry interface {
 
 // WatermarkKVWatcher watches the KV bucket for watermark progression.
 type WatermarkKVWatcher interface {
+	// Watch starts the watermark kv watcher and return a watching on kv channel and a watcher stopped channel.
 	Watch(context.Context) (<-chan WatermarkKVEntry, <-chan struct{})
 	GetKVName() string
 	Close()

--- a/pkg/watermark/store/interface.go
+++ b/pkg/watermark/store/interface.go
@@ -64,7 +64,7 @@ type WatermarkKVEntry interface {
 
 // WatermarkKVWatcher watches the KV bucket for watermark progression.
 type WatermarkKVWatcher interface {
-	// Watch starts the watermark kv watcher and return a watching on kv channel and a watcher stopped channel.
+	// Watch starts the watermark kv watcher and returns a kv updates channel and a watcher stopped channel.
 	Watch(context.Context) (<-chan WatermarkKVEntry, <-chan struct{})
 	GetKVName() string
 	Close()

--- a/pkg/watermark/store/jetstream/kv_watch.go
+++ b/pkg/watermark/store/jetstream/kv_watch.go
@@ -96,7 +96,7 @@ func (k kvEntry) Operation() store.KVWatchOp {
 }
 
 // Watch watches the key-value store (aka bucket).
-func (k *jetStreamWatch) Watch(ctx context.Context) <-chan store.WatermarkKVEntry {
+func (k *jetStreamWatch) Watch(ctx context.Context) (<-chan store.WatermarkKVEntry, <-chan struct{}) {
 	kvWatcher, err := k.kv.WatchAll()
 	for err != nil {
 		k.log.Errorw("WatchAll failed", zap.String("watcher", k.GetKVName()), zap.Error(err))
@@ -105,6 +105,7 @@ func (k *jetStreamWatch) Watch(ctx context.Context) <-chan store.WatermarkKVEntr
 	}
 
 	var updates = make(chan store.WatermarkKVEntry)
+	var stopped = make(chan struct{})
 	go func() {
 		for {
 			select {
@@ -118,6 +119,7 @@ func (k *jetStreamWatch) Watch(ctx context.Context) <-chan store.WatermarkKVEntr
 					k.log.Infow("WatchAll successfully stopped", zap.String("watcher", k.GetKVName()))
 				}
 				close(updates)
+				close(stopped)
 				return
 			case value := <-kvWatcher.Updates():
 				// if channel is closed, nil could come in
@@ -144,7 +146,7 @@ func (k *jetStreamWatch) Watch(ctx context.Context) <-chan store.WatermarkKVEntr
 			}
 		}
 	}()
-	return updates
+	return updates, stopped
 }
 
 // GetKVName returns the KV store (bucket) name.

--- a/pkg/watermark/store/noop/kv_watch.go
+++ b/pkg/watermark/store/noop/kv_watch.go
@@ -20,14 +20,10 @@ func (no noOpWatch) Watch(ctx context.Context) (<-chan store.WatermarkKVEntry, <
 	retChan := make(chan store.WatermarkKVEntry)
 	stopped := make(chan struct{})
 	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(retChan)
-				close(stopped)
-				return
-			}
-		}
+		<-ctx.Done()
+		close(retChan)
+		close(stopped)
+		return
 	}()
 	return retChan, stopped
 }

--- a/pkg/watermark/store/noop/kv_watch.go
+++ b/pkg/watermark/store/noop/kv_watch.go
@@ -23,6 +23,7 @@ func (no noOpWatch) Watch(ctx context.Context) (<-chan store.WatermarkKVEntry, <
 		for {
 			select {
 			case <-ctx.Done():
+				close(retChan)
 				close(stopped)
 				return
 			}

--- a/pkg/watermark/store/noop/kv_watch.go
+++ b/pkg/watermark/store/noop/kv_watch.go
@@ -23,7 +23,6 @@ func (no noOpWatch) Watch(ctx context.Context) (<-chan store.WatermarkKVEntry, <
 		<-ctx.Done()
 		close(retChan)
 		close(stopped)
-		return
 	}()
 	return retChan, stopped
 }

--- a/pkg/watermark/store/noop/kv_watch.go
+++ b/pkg/watermark/store/noop/kv_watch.go
@@ -16,9 +16,19 @@ func NewKVOpWatch() store.WatermarkKVWatcher {
 }
 
 // Watch returns a blocking channel.
-func (no noOpWatch) Watch(ctx context.Context) <-chan store.WatermarkKVEntry {
+func (no noOpWatch) Watch(ctx context.Context) (<-chan store.WatermarkKVEntry, <-chan struct{}) {
 	retChan := make(chan store.WatermarkKVEntry)
-	return retChan
+	stopped := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(stopped)
+				return
+			}
+		}
+	}()
+	return retChan, stopped
 }
 
 func (no noOpWatch) GetKVName() string {

--- a/pkg/window/keyed/keyed_test.go
+++ b/pkg/window/keyed/keyed_test.go
@@ -46,6 +46,7 @@ func TestKeyedWindow_AddKey(t *testing.T) {
 				kw.AddKey(k)
 			}
 			kw.AddKey(tt.input)
+			assert.Equal(t, len(tt.expectedKeys), len(kw.Keys))
 			for k := range tt.expectedKeys {
 				_, ok := kw.Keys[k]
 				assert.True(t, ok)

--- a/pkg/window/keyed/keyed_test.go
+++ b/pkg/window/keyed/keyed_test.go
@@ -1,6 +1,7 @@
 package keyed
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -73,7 +74,7 @@ func TestKeyedWindow_Partitions(t *testing.T) {
 		{
 			name: "with_some_existing_keys",
 			given: &KeyedWindow{
-				Keys: map[string]string{"key2": "key2", "key3": "key3"},
+				Keys: map[string]string{"key2": "key2", "key3": "key3", "key4": "key4"},
 			},
 			expected: []partition.ID{
 				{
@@ -86,6 +87,11 @@ func TestKeyedWindow_Partitions(t *testing.T) {
 					Start: time.Unix(60, 0),
 					End:   time.Unix(120, 0),
 				},
+				{
+					Key:   "key4",
+					Start: time.Unix(60, 0),
+					End:   time.Unix(120, 0),
+				},
 			},
 		},
 	}
@@ -94,6 +100,11 @@ func TestKeyedWindow_Partitions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			kw.Keys = tt.given.Keys
 			ret := kw.Partitions()
+			// the kw.Keys is a map so the order of the output is random
+			// use sort to sort the ret array by key
+			sort.Slice(ret, func(i int, j int) bool {
+				return ret[i].Key < ret[j].Key
+			})
 			for idx, s := range tt.expected {
 				assert.EqualValues(t, ret[idx], s)
 			}


### PR DESCRIPTION
- fix: https://github.com/numaproj/numaflow/issues/220
- also previous fix for the issue https://github.com/numaproj/numaflow/issues/224 has a bug. fixed again in this PR.
- add a stopped channel for the watermark watcher to guarantee the watcher stops before connection closes.
- update keyed_test.go

# Flow (based on my observation)

## If The Pod Terminates Properly

When a pod in Vn-1 terminates, the pod is deleted from the Vn-1_Vn heartbeat store.
https://github.com/numaproj/numaflow/blob/3ec5785e0db1bac5be2f7243eb5b45bcf10279b5/pkg/watermark/publish/publisher.go#L178

The Vn pod heartbeat watcher receives the delete op, sets the pod status to _delete, stops the pod offsetTimeline watcher, and removes the pod from heartbeat map (so refreshing heartbeat go routine no longer updates on this deleted pod).
https://github.com/numaproj/numaflow/blob/3ec5785e0db1bac5be2f7243eb5b45bcf10279b5/pkg/watermark/fetch/processor_manager.go#L182-L193

stop the pod offsetTimeline watcher calls the cancel function and stops the watcher.
https://github.com/numaproj/numaflow/blob/3ec5785e0db1bac5be2f7243eb5b45bcf10279b5/pkg/watermark/fetch/processor_to_fetch.go#L53-L57
https://github.com/numaproj/numaflow/blob/3ec5785e0db1bac5be2f7243eb5b45bcf10279b5/pkg/watermark/fetch/processor_to_fetch.go#L101-L103
https://github.com/numaproj/numaflow/blob/46aae1d62b7a795ad171c45433ef7321794f5c7b/pkg/watermark/store/jetstream/kv_watch.go#L112
https://github.com/numaproj/numaflow/blob/46aae1d62b7a795ad171c45433ef7321794f5c7b/pkg/watermark/store/jetstream/kv_watch.go#L122
https://github.com/numaproj/numaflow/blob/46aae1d62b7a795ad171c45433ef7321794f5c7b/pkg/watermark/fetch/processor_to_fetch.go#L105-L113



Although the Vn-1 pod has been deleted, the events up to some watermark `w1` has already been processed. Therefore, we still preserve the in-mem offset timeline for the deleted pod until the head watermark of this pod has been consumed.
https://github.com/numaproj/numaflow/blob/425b6bbfaaf9885cf210197b84079b72ef7eafcb/pkg/watermark/fetch/edge_fetcher.go#L81-L84

## If The Pod Crashes
If a pod's heartbeat stops after 10 heartbeat refreshes, we consider the pod as crashed. 
https://github.com/numaproj/numaflow/blob/3ec5785e0db1bac5be2f7243eb5b45bcf10279b5/pkg/watermark/fetch/processor_manager.go#L120-L128

# test run:

simple pipeline
cat pod from 1 -> 4 -> 1
<img width="1704" alt="image" src="https://user-images.githubusercontent.com/19543684/196923277-38ab727e-eb06-4ad1-9e43-9af5a14070c6.png">

cat pod from 1 -> 10 -> 1
<img width="1557" alt="image" src="https://user-images.githubusercontent.com/19543684/197071860-f38832a2-3348-438f-879d-bdf54da5f106.png">


out pod from 1 -> 4 -> 1
<img width="1704" alt="image" src="https://user-images.githubusercontent.com/19543684/196923561-60eea860-0fb3-465d-bbcf-6fe31afb8d14.png">

out pod from 10 -> 1
<img width="1704" alt="image" src="https://user-images.githubusercontent.com/19543684/196925049-1d195253-ced3-4f5b-b4a9-27ba78a914af.png">