### PR TITLE
chore: refactor to include partition.ID for reducer

### DIFF
--- a/pkg/reduce/pnf/processandforward.go
+++ b/pkg/reduce/pnf/processandforward.go
@@ -69,7 +69,7 @@ func (p *ProcessAndForward) Process(ctx context.Context) error {
 		defer wg.Done()
 		// FIXME: we need to fix https://github.com/numaproj/numaflow-go/blob/main/pkg/function/service.go#L101
 		ctx = metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{functionsdk.DatumKey: p.PartitionID.Key}))
-		p.result, err = p.UDF.Reduce(ctx, p.pbqReader.ReadCh())
+		p.result, err = p.UDF.Reduce(ctx, nil, p.pbqReader.ReadCh())
 	}()
 
 	// wait for the reduce method to return

--- a/pkg/reduce/pnf/processandforward.go
+++ b/pkg/reduce/pnf/processandforward.go
@@ -20,12 +20,10 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	functionsdk "github.com/numaproj/numaflow-go/pkg/function"
 	"github.com/numaproj/numaflow/pkg/isb"
 	"github.com/numaproj/numaflow/pkg/pbq"
 	"github.com/numaproj/numaflow/pkg/pbq/partition"
 	udfreducer "github.com/numaproj/numaflow/pkg/udf/reducer"
-	"google.golang.org/grpc/metadata"
 )
 
 // ProcessAndForward reads messages from pbq, invokes udf using grpc, forwards the results to ISB, and then publishes
@@ -61,19 +59,10 @@ func NewProcessAndForward(ctx context.Context,
 
 // Process method reads messages from the supplied PBQ, invokes UDF to reduce the result.
 func (p *ProcessAndForward) Process(ctx context.Context) error {
-	var wg sync.WaitGroup
 	var err error
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		// FIXME: we need to fix https://github.com/numaproj/numaflow-go/blob/main/pkg/function/service.go#L101
-		ctx = metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{functionsdk.DatumKey: p.PartitionID.Key}))
-		p.result, err = p.UDF.Reduce(ctx, nil, p.pbqReader.ReadCh())
-	}()
-
-	// wait for the reduce method to return
-	wg.Wait()
+	// FIXME: we need to fix https://github.com/numaproj/numaflow-go/blob/main/pkg/function/service.go#L101
+	p.result, err = p.UDF.Reduce(ctx, &p.PartitionID, p.pbqReader.ReadCh())
 	return err
 }
 

--- a/pkg/reduce/pnf/processandforward.go
+++ b/pkg/reduce/pnf/processandforward.go
@@ -62,6 +62,7 @@ func (p *ProcessAndForward) Process(ctx context.Context) error {
 	var err error
 
 	// FIXME: we need to fix https://github.com/numaproj/numaflow-go/blob/main/pkg/function/service.go#L101
+	// blocking call, only returns the result after it has read all the messages from pbq
 	p.result, err = p.UDF.Reduce(ctx, &p.PartitionID, p.pbqReader.ReadCh())
 	return err
 }

--- a/pkg/reduce/readloop/ordered_test.go
+++ b/pkg/reduce/readloop/ordered_test.go
@@ -33,7 +33,7 @@ func (f myForwardTest) Apply(ctx context.Context, message *isb.ReadMessage) ([]*
 func TestOrderedProcessing(t *testing.T) {
 
 	// Test Reducer returns the messages as is
-	identityReducer := reducer.ReduceFunc(func(ctx context.Context, input <-chan *isb.ReadMessage) ([]*isb.Message, error) {
+	identityReducer := reducer.ReduceFunc(func(ctx context.Context, partitionID *partition.ID, input <-chan *isb.ReadMessage) ([]*isb.Message, error) {
 		messages := make([]*isb.Message, 0)
 		for msg := range input {
 			messages = append(messages, &msg.Message)

--- a/pkg/reduce/reduce_test.go
+++ b/pkg/reduce/reduce_test.go
@@ -66,7 +66,9 @@ func (f CounterReduceTest) Reduce(ctx context.Context, partitionID *partition.ID
 	ret := &isb.Message{
 		Header: isb.Header{
 			PaneInfo: isb.PaneInfo{
-				EventTime: time.Now(),
+				StartTime: partitionID.Start,
+				EndTime:   partitionID.End,
+				EventTime: partitionID.End,
 			},
 			ID:  "msgID",
 			Key: "result",
@@ -98,7 +100,9 @@ func (s SumReduceTest) Reduce(ctx context.Context, partitionID *partition.ID, me
 	ret := &isb.Message{
 		Header: isb.Header{
 			PaneInfo: isb.PaneInfo{
-				EventTime: time.Now(),
+				StartTime: partitionID.Start,
+				EndTime:   partitionID.End,
+				EventTime: partitionID.End,
 			},
 			ID:  "msgID",
 			Key: "result",
@@ -128,7 +132,9 @@ func (m MaxReduceTest) Reduce(ctx context.Context, partitionID *partition.ID, me
 	ret := &isb.Message{
 		Header: isb.Header{
 			PaneInfo: isb.PaneInfo{
-				EventTime: time.Now(),
+				StartTime: partitionID.Start,
+				EndTime:   partitionID.End,
+				EventTime: partitionID.End,
 			},
 			ID:  "msgID",
 			Key: "result",

--- a/pkg/reduce/reduce_test.go
+++ b/pkg/reduce/reduce_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/numaproj/numaflow/pkg/isb"
 	"github.com/numaproj/numaflow/pkg/isb/stores/simplebuffer"
 	"github.com/numaproj/numaflow/pkg/pbq"
+	"github.com/numaproj/numaflow/pkg/pbq/partition"
 	"github.com/numaproj/numaflow/pkg/pbq/store"
 	"github.com/numaproj/numaflow/pkg/watermark/fetch"
 	"github.com/numaproj/numaflow/pkg/watermark/processor"
@@ -54,7 +55,7 @@ type CounterReduceTest struct {
 }
 
 // Reduce returns a result with the count of messages
-func (f CounterReduceTest) Reduce(ctx context.Context, messageStream <-chan *isb.ReadMessage) ([]*isb.Message, error) {
+func (f CounterReduceTest) Reduce(ctx context.Context, partitionID *partition.ID, messageStream <-chan *isb.ReadMessage) ([]*isb.Message, error) {
 	count := 0
 	for range messageStream {
 		count += 1
@@ -84,7 +85,7 @@ func (f CounterReduceTest) WhereTo(s string) ([]string, error) {
 type SumReduceTest struct {
 }
 
-func (s SumReduceTest) Reduce(ctx context.Context, messageStream <-chan *isb.ReadMessage) ([]*isb.Message, error) {
+func (s SumReduceTest) Reduce(ctx context.Context, partitionID *partition.ID, messageStream <-chan *isb.ReadMessage) ([]*isb.Message, error) {
 	sum := 0
 	for msg := range messageStream {
 		var payload PayloadForTest
@@ -112,7 +113,7 @@ func (s SumReduceTest) Reduce(ctx context.Context, messageStream <-chan *isb.Rea
 type MaxReduceTest struct {
 }
 
-func (m MaxReduceTest) Reduce(ctx context.Context, messageStream <-chan *isb.ReadMessage) ([]*isb.Message, error) {
+func (m MaxReduceTest) Reduce(ctx context.Context, partitionID *partition.ID, messageStream <-chan *isb.ReadMessage) ([]*isb.Message, error) {
 	mx := math.MinInt64
 	for msg := range messageStream {
 		var payload PayloadForTest

--- a/pkg/reduce/reduce_test.go
+++ b/pkg/reduce/reduce_test.go
@@ -386,7 +386,7 @@ func fetcherAndPublisher(ctx context.Context, toBuffers map[string]isb.BufferWri
 	otWatcher, _ := inmem.NewInMemWatch(ctx, pipelineName, keyspace+"_OT", otWatcherCh)
 
 	var pm = fetch.NewProcessorManager(ctx, wmstore.BuildWatermarkStoreWatcher(hbWatcher, otWatcher), fetch.WithPodHeartbeatRate(1), fetch.WithRefreshingProcessorsRate(1), fetch.WithSeparateOTBuckets(false))
-	var f = fetch.NewEdgeFetcher(ctx, "from", pm)
+	var f = fetch.NewEdgeFetcher(ctx, fromBuffer.GetName(), pm)
 	return f, publishers
 }
 

--- a/pkg/udf/function/uds_grpc.go
+++ b/pkg/udf/function/uds_grpc.go
@@ -3,9 +3,11 @@ package function
 import (
 	"context"
 	"fmt"
-	"github.com/numaproj/numaflow/pkg/udf/applier"
 	"sync"
 	"time"
+
+	"github.com/numaproj/numaflow/pkg/pbq/partition"
+	"github.com/numaproj/numaflow/pkg/udf/applier"
 
 	functionpb "github.com/numaproj/numaflow-go/pkg/apis/proto/function/v1"
 	functionsdk "github.com/numaproj/numaflow-go/pkg/function"
@@ -103,7 +105,7 @@ func (u *udsGRPCBasedUDF) Apply(ctx context.Context, readMessage *isb.ReadMessag
 // should we pass metadata information ?
 
 // Reduce accepts a channel of isbMessages and returns the aggregated result
-func (u *udsGRPCBasedUDF) Reduce(ctx context.Context, messageStream <-chan *isb.ReadMessage) ([]*isb.Message, error) {
+func (u *udsGRPCBasedUDF) Reduce(ctx context.Context, partitionID *partition.ID, messageStream <-chan *isb.ReadMessage) ([]*isb.Message, error) {
 	datumCh := make(chan *functionpb.Datum)
 	var wg sync.WaitGroup
 	var result []*functionpb.Datum

--- a/pkg/udf/function/uds_grpc.go
+++ b/pkg/udf/function/uds_grpc.go
@@ -160,6 +160,12 @@ readLoop:
 		key := datum.Key
 		writeMessage := &isb.Message{
 			Header: isb.Header{
+				PaneInfo: isb.PaneInfo{
+					EventTime: partitionID.End,
+					StartTime: partitionID.Start,
+					EndTime:   partitionID.End,
+					IsLate:    false,
+				},
 				Key: key,
 			},
 			Body: isb.Body{

--- a/pkg/udf/function/uds_grpc.go
+++ b/pkg/udf/function/uds_grpc.go
@@ -111,6 +111,8 @@ func (u *udsGRPCBasedUDF) Reduce(ctx context.Context, partitionID *partition.ID,
 	var result []*functionpb.Datum
 	var err error
 
+	ctx = metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{functionsdk.DatumKey: partitionID.Key}))
+
 	// invoke the reduceFn method with datumCh channel
 	wg.Add(1)
 	go func() {

--- a/pkg/udf/function/uds_grpc_test.go
+++ b/pkg/udf/function/uds_grpc_test.go
@@ -284,7 +284,7 @@ func TestGRPCBasedUDF_BasicReduceWithMockClient(t *testing.T) {
 			close(messageCh)
 		}()
 
-		got, err := u.Reduce(ctx, messageCh)
+		got, err := u.Reduce(ctx, nil, messageCh)
 
 		assert.Len(t, got, 1)
 		assert.NoError(t, err)
@@ -329,7 +329,7 @@ func TestGRPCBasedUDF_BasicReduceWithMockClient(t *testing.T) {
 			close(messageCh)
 		}()
 
-		_, err := u.Reduce(ctx, messageCh)
+		_, err := u.Reduce(ctx, nil, messageCh)
 
 		assert.ErrorIs(t, err, ApplyUDFErr{
 			UserUDFErr: false,
@@ -366,7 +366,7 @@ func TestGRPCBasedUDF_BasicReduceWithMockClient(t *testing.T) {
 
 		messageCh := make(chan *isb.ReadMessage)
 
-		_, err := u.Reduce(ctx, messageCh)
+		_, err := u.Reduce(ctx, nil, messageCh)
 
 		assert.Error(t, err, ctx.Err())
 	})
@@ -430,7 +430,7 @@ func TestHGRPCBasedUDF_Reduce(t *testing.T) {
 
 	u := NewMockUDSGRPCBasedUDF(mockClient)
 
-	result, err := u.Reduce(ctx, messageCh)
+	result, err := u.Reduce(ctx, nil, messageCh)
 
 	var resultPayload testutils.PayloadForTest
 	_ = json.Unmarshal(result[0].Payload, &resultPayload)

--- a/pkg/udf/function/uds_grpc_test.go
+++ b/pkg/udf/function/uds_grpc_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/numaproj/numaflow-go/pkg/function/clienttest"
 	"github.com/numaproj/numaflow/pkg/isb"
 	"github.com/numaproj/numaflow/pkg/isb/testutils"
+	"github.com/numaproj/numaflow/pkg/pbq/partition"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
@@ -284,7 +285,13 @@ func TestGRPCBasedUDF_BasicReduceWithMockClient(t *testing.T) {
 			close(messageCh)
 		}()
 
-		got, err := u.Reduce(ctx, nil, messageCh)
+		partitionID := &partition.ID{
+			Start: time.Unix(60, 0),
+			End:   time.Unix(120, 0),
+			Key:   "test",
+		}
+
+		got, err := u.Reduce(ctx, partitionID, messageCh)
 
 		assert.Len(t, got, 1)
 		assert.NoError(t, err)
@@ -329,7 +336,13 @@ func TestGRPCBasedUDF_BasicReduceWithMockClient(t *testing.T) {
 			close(messageCh)
 		}()
 
-		_, err := u.Reduce(ctx, nil, messageCh)
+		partitionID := &partition.ID{
+			Start: time.Unix(60, 0),
+			End:   time.Unix(120, 0),
+			Key:   "test",
+		}
+
+		_, err := u.Reduce(ctx, partitionID, messageCh)
 
 		assert.ErrorIs(t, err, ApplyUDFErr{
 			UserUDFErr: false,
@@ -366,7 +379,12 @@ func TestGRPCBasedUDF_BasicReduceWithMockClient(t *testing.T) {
 
 		messageCh := make(chan *isb.ReadMessage)
 
-		_, err := u.Reduce(ctx, nil, messageCh)
+		partitionID := &partition.ID{
+			Start: time.Unix(60, 0),
+			End:   time.Unix(120, 0),
+			Key:   "test",
+		}
+		_, err := u.Reduce(ctx, partitionID, messageCh)
 
 		assert.Error(t, err, ctx.Err())
 	})
@@ -430,7 +448,13 @@ func TestHGRPCBasedUDF_Reduce(t *testing.T) {
 
 	u := NewMockUDSGRPCBasedUDF(mockClient)
 
-	result, err := u.Reduce(ctx, nil, messageCh)
+	partitionID := &partition.ID{
+		Start: time.Unix(60, 0),
+		End:   time.Unix(120, 0),
+		Key:   "test",
+	}
+
+	result, err := u.Reduce(ctx, partitionID, messageCh)
 
 	var resultPayload testutils.PayloadForTest
 	_ = json.Unmarshal(result[0].Payload, &resultPayload)

--- a/pkg/udf/reducer/reducer.go
+++ b/pkg/udf/reducer/reducer.go
@@ -2,18 +2,20 @@ package reducer
 
 import (
 	"context"
+
 	"github.com/numaproj/numaflow/pkg/isb"
+	"github.com/numaproj/numaflow/pkg/pbq/partition"
 )
 
 // Reducer applies the HTTPBasedUDF on the read message and gives back a new message. Any UserError will be retried here, while
 // InternalErr can be returned and could be retried by the callee.
 type Reducer interface {
-	Reduce(ctx context.Context, messageStream <-chan *isb.ReadMessage) ([]*isb.Message, error)
+	Reduce(ctx context.Context, partitionID *partition.ID, messageStream <-chan *isb.ReadMessage) ([]*isb.Message, error)
 }
 
 // ReduceFunc utility function used to create a Reducer implementation
-type ReduceFunc func(context.Context, <-chan *isb.ReadMessage) ([]*isb.Message, error)
+type ReduceFunc func(context.Context, *partition.ID, <-chan *isb.ReadMessage) ([]*isb.Message, error)
 
-func (a ReduceFunc) Reduce(ctx context.Context, messageStream <-chan *isb.ReadMessage) ([]*isb.Message, error) {
-	return a(ctx, messageStream)
+func (a ReduceFunc) Reduce(ctx context.Context, partitionID *partition.ID, messageStream <-chan *isb.ReadMessage) ([]*isb.Message, error) {
+	return a(ctx, partitionID, messageStream)
 }


### PR DESCRIPTION
Fixes #233 

Signed-off-by: Vigith Maurice <vigith@gmail.com>

We need to pass the partition information to the reducer so the return message will have the right `PaneInfo`