### PR TITLE
fix: validate only one isbsvc implementation type is defined. Fixes #269

### DIFF
--- a/pkg/reconciler/isbsvc/validate.go
+++ b/pkg/reconciler/isbsvc/validate.go
@@ -16,7 +16,7 @@ func ValidateInterStepBufferService(isbs *dfv1.InterStepBufferService) error {
 	}
 	if isbs.Spec.Redis != nil {
 		if isbs.Spec.Redis.Native != nil && isbs.Spec.Redis.External != nil {
-			return fmt.Errorf(`native" and "external" can not be defined together`)
+			return fmt.Errorf(`"native" and "external" can not be defined together`)
 		}
 		if isbs.Spec.Redis.Native == nil && isbs.Spec.Redis.External == nil {
 			return fmt.Errorf(`either "native" or "external" must be defined`)

--- a/pkg/reconciler/isbsvc/validate.go
+++ b/pkg/reconciler/isbsvc/validate.go
@@ -9,17 +9,17 @@ import (
 // ValidateInterStepBufferService accepts an isbs and performs validation against it
 func ValidateInterStepBufferService(isbs *dfv1.InterStepBufferService) error {
 	if isbs.Spec.Redis != nil && isbs.Spec.JetStream != nil {
-		return fmt.Errorf("invalid spec: \"spec.redis\" and \"spec.jetstream\" can not be defined together")
+		return fmt.Errorf(`invalid spec: "spec.redis" and "spec.jetstream" can not be defined together`)
 	}
 	if isbs.Spec.Redis == nil && isbs.Spec.JetStream == nil {
-		return fmt.Errorf("invalid spec: either \"spec.redis\" or \"spec.jetstream\" needs to be specified")
+		return fmt.Errorf(`invalid spec: either "spec.redis" or "spec.jetstream" needs to be specified`)
 	}
 	if isbs.Spec.Redis != nil {
 		if isbs.Spec.Redis.Native != nil && isbs.Spec.Redis.External != nil {
-			return fmt.Errorf("\"native\" and \"external\" can not be defined together")
+			return fmt.Errorf(`native" and "external" can not be defined together`)
 		}
 		if isbs.Spec.Redis.Native == nil && isbs.Spec.Redis.External == nil {
-			return fmt.Errorf("either \"native\" or \"external\" must be defined")
+			return fmt.Errorf(`either "native" or "external" must be defined`)
 		}
 		if native := isbs.Spec.Redis.Native; native != nil {
 			if native.Version == "" {

--- a/pkg/reconciler/isbsvc/validate.go
+++ b/pkg/reconciler/isbsvc/validate.go
@@ -23,13 +23,13 @@ func ValidateInterStepBufferService(isbs *dfv1.InterStepBufferService) error {
 		}
 		if native := isbs.Spec.Redis.Native; native != nil {
 			if native.Version == "" {
-				return fmt.Errorf("invalid spec: \"spec.redis.native.version\" is not defined")
+				return fmt.Errorf(`invalid spec: "spec.redis.native.version" is not defined`)
 			}
 		}
 	}
 	if x := isbs.Spec.JetStream; x != nil {
 		if x.Version == "" {
-			return fmt.Errorf("invalid spec: \"spec.jetstream.version\" is not defined")
+			return fmt.Errorf(`invalid spec: "spec.jetstream.version" is not defined`)
 		}
 	}
 	return nil

--- a/pkg/reconciler/isbsvc/validate.go
+++ b/pkg/reconciler/isbsvc/validate.go
@@ -8,6 +8,9 @@ import (
 
 // ValidateInterStepBufferService accepts an isbs and performs validation against it
 func ValidateInterStepBufferService(isbs *dfv1.InterStepBufferService) error {
+	if isbs.Spec.Redis != nil && isbs.Spec.JetStream != nil {
+		return fmt.Errorf("invalid spec: \"spec.redis\" and \"spec.jetstream\" can not be defined together")
+	}
 	if isbs.Spec.Redis == nil && isbs.Spec.JetStream == nil {
 		return fmt.Errorf("invalid spec: either \"spec.redis\" or \"spec.jetstream\" needs to be specified")
 	}

--- a/pkg/reconciler/isbsvc/validate_test.go
+++ b/pkg/reconciler/isbsvc/validate_test.go
@@ -47,7 +47,7 @@ func TestValidateInterStepBuffer(t *testing.T) {
 		isbs.Spec.Redis = testRedisIsbs.DeepCopy().Spec.Redis
 		err := ValidateInterStepBufferService(isbs)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "\"spec.redis\" and \"spec.jetstream\" can not be defined together")
+		assert.Contains(t, err.Error(), `spec.redis" and "spec.jetstream" can not be defined together`)
 	})
 
 	t.Run("test missing spec.redis", func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestValidateInterStepBuffer(t *testing.T) {
 		isbs.Spec.Redis = nil
 		err := ValidateInterStepBufferService(isbs)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "either \"spec.redis\" or \"spec.jetstream\" needs to be specified")
+		assert.Contains(t, err.Error(), `either "spec.redis" or "spec.jetstream" needs to be specified`)
 	})
 
 	t.Run("test missing version", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestValidateInterStepBuffer(t *testing.T) {
 		isbs.Spec.Redis.Native.Version = ""
 		err := ValidateInterStepBufferService(isbs)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "\"spec.redis.native.version\" is not defined")
+		assert.Contains(t, err.Error(), `spec.redis.native.version" is not defined`)
 	})
 
 	t.Run("test both native and external configured", func(t *testing.T) {

--- a/pkg/reconciler/isbsvc/validate_test.go
+++ b/pkg/reconciler/isbsvc/validate_test.go
@@ -42,6 +42,14 @@ func TestValidateInterStepBuffer(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("test both redis and jetstream configured", func(t *testing.T) {
+		isbs := testJetStreamIsbs.DeepCopy()
+		isbs.Spec.Redis = testRedisIsbs.DeepCopy().Spec.Redis
+		err := ValidateInterStepBufferService(isbs)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "\"spec.redis\" and \"spec.jetstream\" can not be defined together")
+	})
+
 	t.Run("test missing spec.redis", func(t *testing.T) {
 		isbs := testRedisIsbs.DeepCopy()
 		isbs.Spec.Redis = nil

--- a/pkg/reconciler/isbsvc/validate_test.go
+++ b/pkg/reconciler/isbsvc/validate_test.go
@@ -63,7 +63,7 @@ func TestValidateInterStepBuffer(t *testing.T) {
 		isbs.Spec.Redis.Native.Version = ""
 		err := ValidateInterStepBufferService(isbs)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), `spec.redis.native.version" is not defined`)
+		assert.Contains(t, err.Error(), `"spec.redis.native.version" is not defined`)
 	})
 
 	t.Run("test both native and external configured", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: David Seapy <dseapy@gmail.com>

Fixes #269

Validates only one isbsvc implementation type is defined
