### PR TITLE
fix: watermark consumer fix

### DIFF
--- a/pkg/daemon/server/daemon_server.go
+++ b/pkg/daemon/server/daemon_server.go
@@ -92,7 +92,7 @@ func (ds *daemonServer) Run(ctx context.Context) error {
 
 func (ds *daemonServer) newGRPCServer(isbSvcClient isbsvc.ISBService) (*grpc.Server, error) {
 	// "Prometheus histograms are a great way to measure latency distributions of your RPCs.
-	// However, since it is bad practice to have metrics of high cardinality the latency monitoring metrics are disabled by default.
+	// However, since it is a bad practice to have metrics of high cardinality the latency monitoring metrics are disabled by default.
 	// To enable them please call the following in your server initialization code:"
 	grpc_prometheus.EnableHandlingTimeHistogram()
 

--- a/pkg/watermark/fetch/edge_fetcher.go
+++ b/pkg/watermark/fetch/edge_fetcher.go
@@ -35,7 +35,11 @@ func NewEdgeFetcher(ctx context.Context, edgeName string, processorManager *Proc
 
 // GetHeadWatermark returns the watermark using the HeadOffset (the latest offset among all processors). This
 // can be used in showing the watermark progression for a vertex when not consuming the messages
-// directly (eg. UX, tests,)
+// directly (eg. UX, tests)
+// NOTE
+//   - We don't use this function in the regular pods in the vertex.
+//   - UX only uses GetHeadWatermark, so the `p.IsDeleted()` check in the GetWatermark never happens.
+//     Meaning, in the UX (daemon service) we never delete any processor.
 func (e *edgeFetcher) GetHeadWatermark() processor.Watermark {
 	var debugString strings.Builder
 	var headOffset int64 = math.MinInt64

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -58,7 +58,7 @@ func NewProcessorManager(ctx context.Context, watermarkStoreWatcher store.Waterm
 	return v
 }
 
-// addProcessor adds a new processor.
+// addProcessor adds a new processor. If the given processor already exists, the value will be updated.
 func (v *ProcessorManager) addProcessor(processor string, p *ProcessorToFetch) {
 	v.lock.Lock()
 	defer v.lock.Unlock()
@@ -161,7 +161,7 @@ func (v *ProcessorManager) startHeatBeatWatcher() {
 			case store.KVPut:
 				// do we have such a processor
 				p := v.GetProcessor(value.Key())
-				if p == nil {
+				if p == nil || p.IsDeleted() {
 					// if p is nil, create a new processor
 					// A fromProcessor needs to be added to v.processors
 					// The fromProcessor may have been deleted

--- a/pkg/watermark/publish/publisher.go
+++ b/pkg/watermark/publish/publisher.go
@@ -83,9 +83,10 @@ func (p *publish) PublishWatermark(wm processor.Watermark, offset isb.Offset) {
 	}
 	// update p.headWatermark only if wm > p.headWatermark
 	if wm.After(time.Time(p.headWatermark)) {
+		p.log.Debugw("New watermark updated for head water mark", zap.String("head", p.headWatermark.String()), zap.String("new", wm.String()))
 		p.headWatermark = wm
 	} else {
-		p.log.Infow("New watermark is ignored because it's older than the current watermark", zap.String("head", p.headWatermark.String()), zap.String("new", wm.String()))
+		p.log.Debugw("New watermark is ignored because it's older than the current watermark", zap.String("head", p.headWatermark.String()), zap.String("new", wm.String()))
 		return
 	}
 

--- a/pkg/watermark/publish/publisher.go
+++ b/pkg/watermark/publish/publisher.go
@@ -86,7 +86,7 @@ func (p *publish) PublishWatermark(wm processor.Watermark, offset isb.Offset) {
 		p.log.Debugw("New watermark updated for head water mark", zap.String("head", p.headWatermark.String()), zap.String("new", wm.String()))
 		p.headWatermark = wm
 	} else {
-		p.log.Debugw("New watermark is ignored because it's older than the current watermark", zap.String("head", p.headWatermark.String()), zap.String("new", wm.String()))
+		p.log.Infow("New watermark is ignored because it's older than the current watermark", zap.String("head", p.headWatermark.String()), zap.String("new", wm.String()))
 		return
 	}
 

--- a/pkg/watermark/store/jetstream/kv_watch.go
+++ b/pkg/watermark/store/jetstream/kv_watch.go
@@ -24,7 +24,7 @@ type jetStreamWatch struct {
 
 var _ store.WatermarkKVWatcher = (*jetStreamWatch)(nil)
 
-// NewKVJetStreamKVWatch returns KVJetStreamWatch specific to Jetstream which implements the WatermarkKVWatcher interface.
+// NewKVJetStreamKVWatch returns KVJetStreamWatch specific to JetStream which implements the WatermarkKVWatcher interface.
 func NewKVJetStreamKVWatch(ctx context.Context, pipelineName string, kvBucketName string, client jsclient.JetStreamClient, opts ...JSKVWatcherOption) (store.WatermarkKVWatcher, error) {
 	var err error
 	conn, err := client.Connect(ctx)


### PR DESCRIPTION
fix: #251 
All cases use simple pipeline and JetStream isbsvc
# Test on main branch when disabling daemon service
initial state: in(1) cat(1) out(1)
<img width="1557" alt="image" src="https://user-images.githubusercontent.com/19543684/198011305-362f2290-3f7f-4218-bbd0-bba3d148d2fe.png">
scale down: in(0) cat(0) out(0)
<img width="1557" alt="image" src="https://user-images.githubusercontent.com/19543684/198011458-2fcc8756-487c-4de3-9a35-12782fa23d33.png">
scale up: in(1) cat(1) out(1)
<img width="1557" alt="image" src="https://user-images.githubusercontent.com/19543684/198011562-1780b561-ef1d-49f0-af4a-a6e46dd65a28.png">
scale up: in(2) cat(2) out(2)
<img width="1557" alt="image" src="https://user-images.githubusercontent.com/19543684/198011666-cc8d1eef-5ea0-4ac3-ae2c-05136109cb62.png">

Based on above observation, I assume the regular pods in the vertex are working as expected.

# Test on this branch with the fix
Explanation: When a processor exits, we keep the offsetTimeline until all the offset in the offsetTimeline are outdated, and then delete the processor from the processor manager. This operation is executed in the "GetWatermark" function. However, in the UX, we only use GetHeadWatermark function, so the exited processor never gets deleted in the processor manager of the daemon service. When we scale up again and add back the processor, because we only check on `processor is nil`, the new coming back processor is not added back properly to the processor manager. Hence, the watcher is lost for the coming back processor, and the watermark in the UI stops updating.

Actual test:
initial state: in(1) cat(1) out(1)

```
{"level":"info","ts":1666782273.4887934,"logger":"numaflow","caller":"fetch/processor_manager.go:172","msg":"v.AddProcessor successfully added a new fromProcessor","fromProcessor":"simple-pipeline-in-0"}
{"level":"info","ts":1666782274.5278976,"logger":"numaflow","caller":"fetch/processor_manager.go:172","msg":"v.AddProcessor successfully added a new fromProcessor","fromProcessor":"simple-pipeline-cat-0"}
{"level":"info","ts":1666782274.5298617,"logger":"numaflow","caller":"fetch/processor_manager.go:172","msg":"v.AddProcessor successfully added a new fromProcessor","fromProcessor":"simple-pipeline-out-0"}
```
<img width="1557" alt="image" src="https://user-images.githubusercontent.com/19543684/198013087-37dce605-fcd0-471d-a48d-de5cea64f372.png">
scale down: in(0) cat(0) out(0)

```
{"level":"info","ts":1666782290.613133,"logger":"numaflow","caller":"fetch/processor_manager.go:191","msg":"Deleting","key":"simple-pipeline-out-0","simple-pipeline-out-0":"simple-pipeline-out-0 status:active, timeline: [1666782287:1666782289608293487] -> [1666782286:1666782288602169497] -> [1666782285:1666782287594846020] -> [1666782284:1666782286591291306] -> [1666782283:1666782285585891914] -> [1666782282:1666782284581331796] -> [1666782281:1666782283578595421] -> [1666782280:1666782282573982646] -> [1666782278:1666782280565193576] -> [1666782277:1666782279561633753]"}
{"level":"info","ts":1666782290.6132045,"logger":"numaflow","caller":"jetstream/kv_watch.go:113","msg":"stopping WatchAll","pipeline":"simple-pipeline","kvBucketName":"simple-pipeline-default-simple-pipeline-out_SINK_OT","watcher":"simple-pipeline-default-simple-pipeline-out_SINK_OT"}
{"level":"info","ts":1666782290.6182003,"logger":"numaflow","caller":"jetstream/kv_watch.go:119","msg":"WatchAll successfully stopped","pipeline":"simple-pipeline","kvBucketName":"simple-pipeline-default-simple-pipeline-out_SINK_OT","watcher":"simple-pipeline-default-simple-pipeline-out_SINK_OT"}
{"level":"info","ts":1666782290.9000976,"logger":"numaflow","caller":"jetstream/default_jetstream_client.go:58","msg":"Nats: connected to nats server"}
{"level":"info","ts":1666782290.900885,"logger":"numaflow","caller":"jetstream/in_cluster_jetstream_client.go:70","msg":"Starting Nats JetStream auto reconnection daemon..."}
{"level":"info","ts":1666782290.9045897,"logger":"numaflow","caller":"jetstream/in_cluster_jetstream_client.go:93","msg":"Exited Nats JetStream auto reconnection daemon..."}
{"level":"info","ts":1666782291.6131392,"logger":"numaflow","caller":"fetch/processor_manager.go:191","msg":"Deleting","key":"simple-pipeline-in-0","simple-pipeline-in-0":"simple-pipeline-in-0 status:active, timeline: [1666782290:110] -> [1666782289:105] -> [1666782288:100] -> [1666782287:95] -> [1666782286:90] -> [1666782285:85] -> [1666782284:80] -> [1666782283:75] -> [1666782282:70] -> [1666782281:65]"}
{"level":"info","ts":1666782291.6139848,"logger":"numaflow","caller":"jetstream/kv_watch.go:113","msg":"stopping WatchAll","pipeline":"simple-pipeline","kvBucketName":"simple-pipeline-default-simple-pipeline-in-cat_OT","watcher":"simple-pipeline-default-simple-pipeline-in-cat_OT"}
{"level":"info","ts":1666782291.6157627,"logger":"numaflow","caller":"jetstream/kv_watch.go:119","msg":"WatchAll successfully stopped","pipeline":"simple-pipeline","kvBucketName":"simple-pipeline-default-simple-pipeline-in-cat_OT","watcher":"simple-pipeline-default-simple-pipeline-in-cat_OT"}
{"level":"info","ts":1666782291.6178179,"logger":"numaflow","caller":"fetch/processor_manager.go:191","msg":"Deleting","key":"simple-pipeline-cat-0","simple-pipeline-cat-0":"simple-pipeline-cat-0 status:active, timeline: [1666782289:110] -> [1666782288:105] -> [1666782287:100] -> [1666782286:95] -> [1666782285:90] -> [1666782284:85] -> [1666782283:80] -> [1666782282:75] -> [1666782281:70] -> [1666782280:65]"}
{"level":"info","ts":1666782291.6179025,"logger":"numaflow","caller":"jetstream/kv_watch.go:113","msg":"stopping WatchAll","pipeline":"simple-pipeline","kvBucketName":"simple-pipeline-default-simple-pipeline-cat-out_OT","watcher":"simple-pipeline-default-simple-pipeline-cat-out_OT"}
{"level":"info","ts":1666782291.620023,"logger":"numaflow","caller":"jetstream/kv_watch.go:119","msg":"WatchAll successfully stopped","pipeline":"simple-pipeline","kvBucketName":"simple-pipeline-default-simple-pipeline-cat-out_OT","watcher":"simple-pipeline-default-simple-pipeline-cat-out_OT"}
```
<img width="1557" alt="image" src="https://user-images.githubusercontent.com/19543684/198013125-df5f6c64-e4c2-4989-aa2d-4be0b71785de.png">
scale up: in(1) cat(1) out(1)  

```
{"level":"info","ts":1666782318.689903,"logger":"numaflow","caller":"fetch/processor_manager.go:172","msg":"v.AddProcessor successfully added a new fromProcessor","fromProcessor":"simple-pipeline-cat-0"}
{"level":"info","ts":1666782318.7181356,"logger":"numaflow","caller":"fetch/processor_manager.go:172","msg":"v.AddProcessor successfully added a new fromProcessor","fromProcessor":"simple-pipeline-out-0"}
{"level":"info","ts":1666782318.7189388,"logger":"numaflow","caller":"fetch/processor_manager.go:172","msg":"v.AddProcessor successfully added a new fromProcessor","fromProcessor":"simple-pipeline-in-0"}
```
<img width="1557" alt="image" src="https://user-images.githubusercontent.com/19543684/198013157-a9bae366-3d0f-4a6d-a3f8-387e5d5fb0be.png">



# NOTE
Failed to reproduce the `KV_simple-pipeline-default-simple-pipeline-in_SOURCE_OT` keeps zero issue locally. 