### PR TITLE
feat: add pandoc to required tools development doc. Closes #276

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -7,14 +7,11 @@ This doc explains how to set up a development environment for Numaflow.
 1. [`go`](https://golang.org/doc/install) 1.19+
 1. [`git`](https://help.github.com/articles/set-up-git/)
 1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-1. [`protoc`](https://github.com/protocolbuffers/protobuf) for compiling protocol buffers
-1. [`pandoc`](https://pandoc.org/installing.html) for generating API markdown
+1. [`protoc`](https://github.com/protocolbuffers/protobuf) 3.19 for compiling protocol buffers
+1. [`pandoc`](https://pandoc.org/installing.html) 2.17 for generating API markdown
 1. [`Node.js®`](https://nodejs.org/en/) for running the UI
 1. [`yarn`](https://classic.yarnpkg.com/en/)
 1. [`k3d`](https://k3d.io/) for local development, if needed
-
-*To ensure local code generation is consistent with the CI checks, see `PROTOC_VERSION` and `PANDOC_VERSION` in
-[`ci.yaml`](../.github/workflows/ci.yaml)*
 
 ### Create a k8s cluster with k3d if needed
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,9 +8,13 @@ This doc explains how to set up a development environment for Numaflow.
 1. [`git`](https://help.github.com/articles/set-up-git/)
 1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 1. [`protoc`](https://github.com/protocolbuffers/protobuf) for compiling protocol buffers
+1. [`pandoc`](https://pandoc.org/installing.html) for generating API markdown
 1. [`Node.js®`](https://nodejs.org/en/) for running the UI
 1. [`yarn`](https://classic.yarnpkg.com/en/)
 1. [`k3d`](https://k3d.io/) for local development, if needed
+
+*To ensure local code generation is consistent with the CI checks, see `PROTOC_VERSION` and `PANDOC_VERSION` in
+[`ci.yaml`](../.github/workflows/ci.yaml)*
 
 ### Create a k8s cluster with k3d if needed
 


### PR DESCRIPTION
Signed-off-by: David Seapy <dseapy@gmail.com>

Closes #276.

Adds `pandoc` requirement to the development markdown.  Also references CI versions of pandoc and protoc, to help developers ensure CI code gen will match code gen on their local environment.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
