### PR TITLE
chore: use milliseconds in HTTP event-time header

### DIFF
--- a/docs/sources/http.md
+++ b/docs/sources/http.md
@@ -81,10 +81,10 @@ curl -kq -X POST -H "x-numaflow-id: ${id}" -d "hello world" ${http-source-url}
 
 ## x-numaflow-event-time
 
-By default, the time of the date coming to the HTTP source is used as the event time, it could be set by putting an HTTP header `x-numaflow-event-time` with value of the number of seconds elapsed since January 1, 1970 UTC.
+By default, the time of the date coming to the HTTP source is used as the event time, it could be set by putting an HTTP header `x-numaflow-event-time` with value of the number of milliseconds elapsed since January 1, 1970 UTC.
 
 ```sh
-curl -kq -X POST -H "x-numaflow-event-time: 1663006726" -d "hello world" ${http-source-url}
+curl -kq -X POST -H "x-numaflow-event-time: 1663006726000" -d "hello world" ${http-source-url}
 ```
 
 ## Auth

--- a/pkg/sources/http/http.go
+++ b/pkg/sources/http/http.go
@@ -135,7 +135,7 @@ func New(vertexInstance *dfv1.VertexInstance, writers []isb.BufferWriter, fetchW
 				_, _ = w.Write([]byte(err.Error()))
 				return
 			}
-			eventTime = time.Unix(i, 0)
+			eventTime = time.UnixMilli(i)
 		}
 		m := &isb.ReadMessage{
 			Message: isb.Message{
@@ -199,7 +199,7 @@ func (h *httpSource) GetName() string {
 	return h.name
 }
 
-func (h *httpSource) Read(ctx context.Context, count int64) ([]*isb.ReadMessage, error) {
+func (h *httpSource) Read(_ context.Context, count int64) ([]*isb.ReadMessage, error) {
 	msgs := []*isb.ReadMessage{}
 	var latest time.Time
 	timeout := time.After(h.readTimeout)


### PR DESCRIPTION
Signed-off-by: Vigith Maurice <vigith@gmail.com>

Now that we support millisecond watermark progression, the HTTP event-time header can also be more granular