### PR TITLE
Chore: run in sdks-e2e tests, python-udsink log check before go-udsink

### DIFF
--- a/test/sdks-e2e/sdks_test.go
+++ b/test/sdks-e2e/sdks_test.go
@@ -54,8 +54,8 @@ func (s *SDKsSuite) TestUDFunctionAndSink() {
 		Expect().
 		Status(204)
 
-	w.Expect().VertexPodLogContains("go-udsink", "hello", PodLogCheckOptionWithContainer("udsink"), PodLogCheckOptionWithCount(3)).
-		VertexPodLogContains("python-udsink", "hello", PodLogCheckOptionWithContainer("udsink"), PodLogCheckOptionWithCount(3))
+	w.Expect().VertexPodLogContains("python-udsink", "hello", PodLogCheckOptionWithContainer("udsink"), PodLogCheckOptionWithCount(3)).
+		VertexPodLogContains("go-udsink", "hello", PodLogCheckOptionWithContainer("udsink"), PodLogCheckOptionWithCount(3))
 }
 
 func TestHTTPSuite(t *testing.T) {


### PR DESCRIPTION
This change attempts to fix E2E test failure scenario 3 in https://github.com/numaproj/numaflow/issues/210#issuecomment-1293627883

Every once in a while(about one occurrence every ~10 executions) our sdks-e2e tests fail with log validation error. The error is always thrown by VertexPodLogContains check and it's always thrown by the python-udsink, never go-udsink.

Looking at the log, I can see the failure was caused by context being closed before our default timeout. I suspect the reason why it's always python-udsink, could be because python-udsink is the very last check of the E2E test and the github E2E test infrastruct could terminate the test early before tests are done.

To verify my hypothesis, I made this code change to see if I can get a failure from go-udsink. Magically after this change, the error is gone. I tested it by running the E2E tests for 25+ times.

I still don't know why making this switch helps remove the failure. But I hope pushing this out could help reduce a little bit of manual rerun efforts.

Signed-off-by: Keran Yang <yangkr920208@gmail.com>

Explain what this PR does.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
