### PR TITLE
chore: set GOMEMLIMIT and increase graceshutdownperiod

### DIFF
--- a/pkg/apis/numaflow/v1alpha1/jetstream_buffer_service.go
+++ b/pkg/apis/numaflow/v1alpha1/jetstream_buffer_service.go
@@ -178,7 +178,7 @@ func (j JetStreamBufferService) GetStatefulSetSpec(req GetJetStreamStatefulSetSp
 				ServiceAccountName:            j.ServiceAccountName,
 				Affinity:                      j.Affinity,
 				ShareProcessNamespace:         pointer.Bool(true),
-				TerminationGracePeriodSeconds: pointer.Int64(60),
+				TerminationGracePeriodSeconds: pointer.Int64(120),
 				Volumes: []corev1.Volume{
 					{Name: "pid", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 					{
@@ -229,6 +229,7 @@ func (j JetStreamBufferService) GetStatefulSetSpec(req GetJetStreamStatefulSetSp
 							{Name: "SERVER_NAME", Value: "$(POD_NAME)"},
 							{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
 							{Name: "CLUSTER_ADVERTISE", Value: "$(POD_NAME)." + req.ServiceName + ".$(POD_NAMESPACE).svc.cluster.local"},
+							{Name: "GOMEMLIMIT", ValueFrom: &corev1.EnvVarSource{ResourceFieldRef: &corev1.ResourceFieldSelector{ContainerName: "main", Resource: "limits.memory"}}},
 							{Name: "JS_KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: req.ServerEncryptionSecretName}, Key: JetStreamServerSecretEncryptionKey}}},
 						},
 						VolumeMounts: []corev1.VolumeMount{

--- a/pkg/apis/numaflow/v1alpha1/jetstream_buffer_service_test.go
+++ b/pkg/apis/numaflow/v1alpha1/jetstream_buffer_service_test.go
@@ -61,7 +61,7 @@ func TestJetStreamGetStatefulSetSpec(t *testing.T) {
 		for _, e := range spec.Template.Spec.Containers[0].Env {
 			envNames = append(envNames, e.Name)
 		}
-		for _, e := range []string{"POD_NAME", "SERVER_NAME", "POD_NAMESPACE", "CLUSTER_ADVERTISE", "JS_KEY"} {
+		for _, e := range []string{"POD_NAME", "SERVER_NAME", "POD_NAMESPACE", "CLUSTER_ADVERTISE", "GOMEMLIMIT", "JS_KEY"} {
 			assert.Contains(t, envNames, e)
 		}
 	})


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

Sets `GOMEMLIMIT` environment variable which makes the Go GC be aware of memory limits (go 1.19).


<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
