### PR TITLE
chore: vertex controller stop watching pod create events

### DIFF
--- a/pkg/reconciler/cmd/start.go
+++ b/pkg/reconciler/cmd/start.go
@@ -173,7 +173,10 @@ func Start(namespaced bool, managedNamespace string) {
 	}
 
 	// Watch Pods
-	if err := vertexController.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{OwnerType: &dfv1.Vertex{}, IsController: true}); err != nil {
+	if err := vertexController.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{OwnerType: &dfv1.Vertex{}, IsController: true},
+		predicate.Funcs{
+			CreateFunc: func(event.CreateEvent) bool { return false }, // Do not watch pod create events
+		}); err != nil {
 		logger.Fatalw("Unable to watch Pods", zap.Error(err))
 	}
 


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

Vertex controller watches all the managed pod related events including create/delete, etc. When a vertex pod is deleted, the controller sees the event, and then creates a new pod. However, the new pod creating also generates an event, and the controller starts a new reconciliation loop, in this case, you sometimes see the race conditions, that multiple pods are created in a short period of time after a pod termination, then it is eventually stabilized to be running only 1 pod. Even though it's just a short period of time, the multiple new created pods might still have started processing data, and might that cause unexpected behavior especially for a reduce vertex.

This PR makes the controller stop watching pod creating event, which will avoid this situation from happening. 

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
