### PR TITLE
chore: add error metrics for WAL

### DIFF
--- a/pkg/pbq/store/wal/metrics.go
+++ b/pkg/pbq/store/wal/metrics.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	LabelPartitionKey = "partitionKey"
+	labelPartitionKey = "partitionKey"
 )
 
 // TODO - Adjust metric bucket range after we get more map reduce use cases.
@@ -39,36 +39,42 @@ var filesCount = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help:      "Total number of wal files/partitions (including both active and closed)",
 }, []string{})
 
-var activeFilesCount = promauto.NewGaugeVec(prometheus.GaugeOpts(prometheus.CounterOpts{
+var activeFilesCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Subsystem: "pbq_wal",
 	Name:      "active_wal_files_total",
 	Help:      "Total number of active wal files/partitions",
-}), []string{})
+}, []string{})
 
 var garbageCollectingTime = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Subsystem: "pbq_wal",
 	Name:      "wal_garbage_collecting_time",
 	Help:      "Garbage Collecting time of a pbq wal (100 to 5000 microseconds)",
 	Buckets:   prometheus.ExponentialBucketsRange(100, 5000, 5),
-}, []string{LabelPartitionKey})
+}, []string{labelPartitionKey})
 
 var fileSyncWaitTime = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Subsystem: "pbq_wal",
 	Name:      "wal_file_sync_wait_time",
 	Help:      "File Sync wait time (1 to 60 milliseconds)",
 	Buckets:   prometheus.ExponentialBucketsRange(1, 60, 5),
-}, []string{LabelPartitionKey})
+}, []string{labelPartitionKey})
 
 var entryWriteTime = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Subsystem: "pbq_wal",
 	Name:      "wal_entry_write_time",
 	Help:      "Entry write time (1 to 60 milliseconds)",
 	Buckets:   prometheus.ExponentialBucketsRange(1, 60, 5),
-}, []string{LabelPartitionKey})
+}, []string{labelPartitionKey})
 
 var lifespan = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Subsystem: "pbq_wal",
 	Name:      "wal_lifespan",
 	Help:      "Lifespan of a pbq wal (1 to 20 minutes)",
 	Buckets:   prometheus.ExponentialBucketsRange(1, 20, 5),
-}, []string{LabelPartitionKey})
+}, []string{labelPartitionKey})
+
+var walErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+	Subsystem: "pbq_wal",
+	Name:      "wal_errors",
+	Help:      "Errors encountered",
+}, []string{"kind"})


### PR DESCRIPTION
Signed-off-by: Vigith Maurice <vigith@gmail.com>

We were missing `E` from RED family of metrics.