### PR TITLE
feat: support setting a base href for UX Server. Closes #229

### DIFF
--- a/cmd/commands/server.go
+++ b/cmd/commands/server.go
@@ -28,6 +28,7 @@ func NewServerCommand() *cobra.Command {
 		port             int
 		namespaced       bool
 		managedNamespace string
+		baseHRef         string
 	)
 
 	command := &cobra.Command{
@@ -37,12 +38,13 @@ func NewServerCommand() *cobra.Command {
 			if !cmd.Flags().Changed("port") && insecure {
 				port = 8080
 			}
-			svrcmd.Start(insecure, port, namespaced, managedNamespace)
+			svrcmd.Start(insecure, port, namespaced, managedNamespace, baseHRef)
 		},
 	}
 	command.Flags().BoolVar(&insecure, "insecure", false, "Whether to disable TLS, defaults to false.")
 	command.Flags().IntVarP(&port, "port", "p", 8443, "Port to listen on, defaults to 8443 or 8080 if insecure is set")
 	command.Flags().BoolVar(&namespaced, "namespaced", false, "Whether to run in namespaced scope, defaults to false.")
 	command.Flags().StringVar(&managedNamespace, "managed-namespace", sharedutil.LookupEnvStringOr("NAMESPACE", "numaflow-system"), "The namespace that the server watches when \"--namespaced\" is \"true\".")
+	command.Flags().StringVar(&baseHRef, "base-href", "/", "Base href in index.html.  Useful for when the server is running behind a reverse proxy under a path other than /")
 	return command
 }

--- a/server/cmd/start.go
+++ b/server/cmd/start.go
@@ -114,8 +114,8 @@ func setBaseHRef(filename string, baseHRef string) error {
 		return err
 	}
 
-	prevHRef := "<base href=\"/\">"
-	newHRef := fmt.Sprintf("<base href=\"%s\">", baseHRef)
+	prevHRef := `<base href="/">`
+	newHRef := fmt.Sprintf(`<base href="%s">`, baseHRef)
 	file = bytes.Replace(file, []byte(prevHRef), []byte(newHRef), -1)
 
 	err = os.WriteFile(filename, file, 0666)

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,6 +2,7 @@
   "name": "ui",
   "version": "0.1.0",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <base href="/">
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/ui/src/components/namespaces/Namespaces.tsx
+++ b/ui/src/components/namespaces/Namespaces.tsx
@@ -16,7 +16,7 @@ import "./Namespaces.css";
 
 
 export function Namespaces() {
-  const { data } = useFetch("/api/v1/namespaces");
+  const { data } = useFetch("api/v1/namespaces");
 
   return (
     <div className="Namespaces">

--- a/ui/src/components/pipeline/Pipeline.tsx
+++ b/ui/src/components/pipeline/Pipeline.tsx
@@ -63,7 +63,7 @@ export function Pipeline() {
       Promise.all(
         pipeline?.spec?.vertices.map((vertex) => {
           return fetch(
-            `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertex.name}/pods`
+            `api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertex.name}/pods`
           )
             .then((response) => response.json())
             .then((json) => {
@@ -81,7 +81,7 @@ export function Pipeline() {
       Promise.all(
         pipeline?.spec?.vertices.map((vertex) => {
           return fetch(
-            `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertex.name}/metrics`
+            `api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertex.name}/metrics`
           )
             .then((response) => response.json())
             .then((json) => {
@@ -126,7 +126,7 @@ export function Pipeline() {
       Promise.all(
         pipeline?.spec?.vertices.map((vertex) => {
           return fetch(
-            `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertex.name}/watermark`
+            `api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertex.name}/watermark`
           )
             .then((response) => response.json())
             .then((json) => {

--- a/ui/src/components/poddetail/podlogs/PodLogs.tsx
+++ b/ui/src/components/poddetail/podlogs/PodLogs.tsx
@@ -88,7 +88,7 @@ export function PodLogs({ namespaceId, podName, containerName }: PodLogsProps) {
     setLogRequestKey(requestKey);
     setLogs(["Loading logs..."]);
     fetch(
-      `/api/v1/namespaces/${namespaceId}/pods/${podName}/log?container=${containerName}&follow=true&tailLines=${MAX_LOGS}`
+      `api/v1/namespaces/${namespaceId}/pods/${podName}/log?container=${containerName}&follow=true&tailLines=${MAX_LOGS}`
     )
       .then((response) => {
         if (response && response.body) {

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -23,7 +23,10 @@ const theme = createTheme({
 
 });
 
-
+// todo: should have a basename, i.e.: <BrowserRouter basename="/numaflow">
+// however it shouldn't be /numaflow but rather dynamic & be what base href is
+// ref: https://stackoverflow.com/questions/55007809/dynamic-basename-with-browserrouter-in-react-router-dom
+// can't think of a really clean way to do this while supporting arbitrary long subpaths for base href
 root.render(
   <React.StrictMode>
     <BrowserRouter>

--- a/ui/src/utils/fetchWrappers/edgeInfoFetch.ts
+++ b/ui/src/utils/fetchWrappers/edgeInfoFetch.ts
@@ -15,7 +15,7 @@ export const useEdgesInfoFetch = (
     loading: fetchLoading,
     error,
   } = useFetch(
-    `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/edges?refreshKey=${requestKey}`
+    `api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/edges?refreshKey=${requestKey}`
   );
 
   useEffect(() => {

--- a/ui/src/utils/fetchWrappers/namespaceFetch.ts
+++ b/ui/src/utils/fetchWrappers/namespaceFetch.ts
@@ -9,7 +9,7 @@ export const useNamespaceFetch = (namespaceId: string | undefined) => {
     data,
     loading: fetchLoading,
     error,
-  } = useFetch(`/api/v1/namespaces/${namespaceId}/pipelines`);
+  } = useFetch(`api/v1/namespaces/${namespaceId}/pipelines`);
 
   useEffect(() => {
     if (fetchLoading) {

--- a/ui/src/utils/fetchWrappers/pipelineFetch.ts
+++ b/ui/src/utils/fetchWrappers/pipelineFetch.ts
@@ -15,7 +15,7 @@ export const usePipelineFetch = (
     loading: fetchLoading,
     error,
   } = useFetch(
-    `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}?refreshKey=${requestKey}`
+    `api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}?refreshKey=${requestKey}`
   );
 
   useEffect(() => {

--- a/ui/src/utils/fetchWrappers/podsDetailFetch.ts
+++ b/ui/src/utils/fetchWrappers/podsDetailFetch.ts
@@ -14,7 +14,7 @@ export const usePodsDetailFetch = (namespaceId: string, requestKey: string) => {
     loading: fetchLoading,
     error,
   } = useFetch(
-    `/api/v1/metrics/namespaces/${namespaceId}/pods?refreshKey=${requestKey}`
+    `api/v1/metrics/namespaces/${namespaceId}/pods?refreshKey=${requestKey}`
   );
 
   useEffect(() => {

--- a/ui/src/utils/fetchWrappers/podsFetch.ts
+++ b/ui/src/utils/fetchWrappers/podsFetch.ts
@@ -16,7 +16,7 @@ export const usePodsFetch = (
     loading: fetchLoading,
     error,
   } = useFetch(
-    `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertexId}/pods`
+    `api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertexId}/pods`
   );
 
   useEffect(() => {


### PR DESCRIPTION
Signed-off-by: David Seapy <dseapy@gmail.com>

Closes #229 
Adds support for base href for UX Server.
Useful for allowing it to be run under a path other than `/` behind a reverse proxy.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
