### PR TITLE
fix: getWatermark to  return-1 if any processor returns -1 

### DIFF
--- a/pkg/reduce/reduce_test.go
+++ b/pkg/reduce/reduce_test.go
@@ -770,9 +770,7 @@ func fetcherAndPublisher(ctx context.Context, toBuffers map[string]isb.BufferWri
 			case <-ctx.Done():
 				return
 			default:
-				for key := range publishers {
-					_ = hb.PutKV(ctx, key, []byte(fmt.Sprintf("%d", time.Now().Unix())))
-				}
+				_ = hb.PutKV(ctx, fromBuffer.GetName(), []byte(fmt.Sprintf("%d", time.Now().Unix())))
 				time.Sleep(time.Duration(1) * time.Second)
 			}
 		}

--- a/pkg/watermark/fetch/edge_fetcher.go
+++ b/pkg/watermark/fetch/edge_fetcher.go
@@ -99,8 +99,9 @@ func (e *edgeFetcher) GetWatermark(inputOffset isb.Offset) processor.Watermark {
 	for _, p := range allProcessors {
 		debugString.WriteString(fmt.Sprintf("[Processor: %v] \n", p))
 		var t = p.offsetTimeline.GetEventTime(inputOffset)
-		if t == -1 { // this is a bug
+		if t == -1 { // watermark cannot be computed, perhaps a new processing unit was added or offset fell off the timeline
 			epoch = t
+			break
 		} else if t < epoch {
 			epoch = t
 		}

--- a/pkg/watermark/fetch/edge_fetcher.go
+++ b/pkg/watermark/fetch/edge_fetcher.go
@@ -101,7 +101,6 @@ func (e *edgeFetcher) GetWatermark(inputOffset isb.Offset) processor.Watermark {
 		var t = p.offsetTimeline.GetEventTime(inputOffset)
 		if t == -1 { // watermark cannot be computed, perhaps a new processing unit was added or offset fell off the timeline
 			epoch = t
-			break
 		} else if t < epoch {
 			epoch = t
 		}

--- a/pkg/watermark/fetch/edge_fetcher.go
+++ b/pkg/watermark/fetch/edge_fetcher.go
@@ -109,6 +109,10 @@ func (e *edgeFetcher) GetWatermark(inputOffset isb.Offset) processor.Watermark {
 			e.processorManager.DeleteProcessor(p.entity.GetName())
 		}
 	}
+	// if there are no processors
+	if epoch == math.MaxInt64 {
+		epoch = -1
+	}
 	e.log.Debugf("%s[%s] get watermark for offset %d: %+v", debugString.String(), e.bufferName, offset, epoch)
 
 	return processor.Watermark(time.UnixMilli(epoch))

--- a/pkg/watermark/fetch/edge_fetcher.go
+++ b/pkg/watermark/fetch/edge_fetcher.go
@@ -99,7 +99,9 @@ func (e *edgeFetcher) GetWatermark(inputOffset isb.Offset) processor.Watermark {
 	for _, p := range allProcessors {
 		debugString.WriteString(fmt.Sprintf("[Processor: %v] \n", p))
 		var t = p.offsetTimeline.GetEventTime(inputOffset)
-		if t != -1 && t < epoch {
+		if t == -1 { // this is a bug
+			epoch = t
+		} else if t < epoch {
 			epoch = t
 		}
 		if p.IsDeleted() && (offset > p.offsetTimeline.GetHeadOffset()) {

--- a/pkg/watermark/fetch/edge_fetcher.go
+++ b/pkg/watermark/fetch/edge_fetcher.go
@@ -110,10 +110,6 @@ func (e *edgeFetcher) GetWatermark(inputOffset isb.Offset) processor.Watermark {
 			e.processorManager.DeleteProcessor(p.entity.GetName())
 		}
 	}
-	// if the offset is smaller than every offset in the timeline, set the value to be -1
-	if epoch == math.MaxInt64 {
-		epoch = -1
-	}
 	e.log.Debugf("%s[%s] get watermark for offset %d: %+v", debugString.String(), e.bufferName, offset, epoch)
 
 	return processor.Watermark(time.UnixMilli(epoch))


### PR DESCRIPTION
Signed-off-by: Yashash H L <yashashhl25@gmail.com>

while fetching watermark return `-1`, if the offset timeline store returns `-1` for any processor.