### PR TITLE
chore: use resources.limits for cpu/mem percentage calculation

### DIFF
--- a/ui/src/utils/fetchWrappers/podsFetch.ts
+++ b/ui/src/utils/fetchWrappers/podsFetch.ts
@@ -34,7 +34,7 @@ export const usePodsFetch = (
         const containers: string[] = [];
         const containerSpecMap = new Map<string, PodContainerSpec>();
         raw.spec?.containers?.forEach((rawC: any) => {
-          const cpu = rawC.resources?.requests?.cpu;
+          const cpu = rawC.resources?.limits?.cpu;
           let cpuParsed: undefined | number;
           if (cpu) {
             try {
@@ -43,7 +43,7 @@ export const usePodsFetch = (
               cpuParsed = undefined;
             }
           }
-          const memory = rawC.resources?.requests?.memory;
+          const memory = rawC.resources?.limits?.memory;
           let memoryParsed: undefined | number;
           if (memory) {
             try {


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

Currently cpu/mem usage is calculated baed on the `resources.requests.cpu/mem`, which is not accurate. Changing to use `resources.limits.cpu/mem`.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
