### PR TITLE
chore: validate if pipeline or vertex name too long

### DIFF
--- a/pkg/reconciler/pipeline/validate.go
+++ b/pkg/reconciler/pipeline/validate.go
@@ -171,6 +171,10 @@ func ValidatePipeline(pl *dfv1.Pipeline) error {
 		if err := validateVertex(v); err != nil {
 			return err
 		}
+		// The length of "{pipeline}-{vertex}-headless" can not be longer than 63.
+		if errs := k8svalidation.IsDNS1035Label(fmt.Sprintf("%s-%s-headless", pl.Name, v.Name)); len(errs) > 0 {
+			return fmt.Errorf("the length of the pipeline name plus the vertex name is over the max limit. (%s-%s), %v", pl.Name, v.Name, errs)
+		}
 	}
 	return nil
 }

--- a/pkg/reconciler/pipeline/validate_test.go
+++ b/pkg/reconciler/pipeline/validate_test.go
@@ -162,6 +162,14 @@ func TestValidatePipeline(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("test pipeline name too long", func(t *testing.T) {
+		testObj := testPipeline.DeepCopy()
+		testObj.Name = "very-very-very-loooooooooooooooooooooooooooooooooooog"
+		err := ValidatePipeline(testObj)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "over the max limit")
+	})
+
 	t.Run("parallelism on non-reduce vertex", func(t *testing.T) {
 		testObj := testPipeline.DeepCopy()
 		testObj.Spec.Edges[0].Parallelism = pointer.Int32(3)


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

If the length of pipeline + vertex is too long, the pod name/service name might be over the limit (63), which will cause pod or service creating failure.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
