### PR TITLE
chore: updating watermark fetch logic for UI

### DIFF
--- a/pkg/watermark/fetch/edge_fetcher_test.go
+++ b/pkg/watermark/fetch/edge_fetcher_test.go
@@ -141,8 +141,8 @@ func TestBuffer_GetWatermark(t *testing.T) {
 			if got := b.GetWatermark(isb.SimpleStringOffset(func() string { return strconv.FormatInt(tt.args.offset, 10) })); time.Time(got).In(location) != time.UnixMilli(tt.want).In(location) {
 				t.Errorf("GetWatermark() = %v, want %v", got, processor.Watermark(time.UnixMilli(tt.want)))
 			}
-			// this will always be 14 because the timeline has been populated ahead of time
-			assert.Equal(t, time.Time(b.GetHeadWatermark()).In(location), time.UnixMilli(14).In(location))
+			// this will always be 17 because the timeline has been populated ahead of time
+			assert.Equal(t, time.Time(b.GetHeadWatermark()).In(location), time.UnixMilli(17).In(location))
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Yashash H L <yashashhl25@gmail.com>

Since we are fetching the watermark using head offset, in the UI sometimes we see the watermark value for the map vertex is less than the watermark value for the immediate reduce vertex, which is misleading.  

<img width="1387" alt="Screenshot 2023-01-07 at 8 55 15 PM" src="https://user-images.githubusercontent.com/109710325/211159121-efaf4e22-6371-46cf-8c86-b2d3a39a6961.png">

This is because the map vertex's offset timeline store has a lower event time for the head offset than that of the reduce vertex.

Instead, if we use the latest watermark from the offset timeline store, we will not see this issue.
<img width="1396" alt="Screenshot 2023-01-07 at 8 58 46 PM" src="https://user-images.githubusercontent.com/109710325/211159124-3b8f88a8-0e6d-4238-ac88-712dbccc0404.png">
