### PR TITLE
fix: Use a copied object to update

### DIFF
--- a/pkg/reconciler/isbsvc/controller.go
+++ b/pkg/reconciler/isbsvc/controller.go
@@ -65,7 +65,8 @@ func (r *interStepBufferServiceReconciler) Reconcile(ctx context.Context, req ct
 		log.Errorw("Reconcile error", zap.Error(reconcileErr))
 	}
 	if r.needsUpdate(isbs, isbsCopy) {
-		if err := r.client.Update(ctx, isbsCopy); err != nil {
+		// Update with a DeepCopy because .Status will be cleaned up.
+		if err := r.client.Update(ctx, isbsCopy.DeepCopy()); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/reconciler/pipeline/controller.go
+++ b/pkg/reconciler/pipeline/controller.go
@@ -76,14 +76,14 @@ func (r *pipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	log := r.logger.With("namespace", pl.Namespace).With("pipeline", pl.Name)
 	plCopy := pl.DeepCopy()
 	ctx = logging.WithLogger(ctx, log)
-
 	result, reconcileErr := r.reconcile(ctx, plCopy)
 	if reconcileErr != nil {
 		log.Errorw("Reconcile error", zap.Error(reconcileErr))
 	}
 	plCopy.Status.LastUpdated = metav1.Now()
 	if needsUpdate(pl, plCopy) {
-		if err := r.client.Update(ctx, plCopy); err != nil {
+		// Update with a DeepCopy because .Status will be cleaned up.
+		if err := r.client.Update(ctx, plCopy.DeepCopy()); err != nil {
 			return result, err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

In controller-runtime, when doing `client.Update()`, the object being updated will be mutated, in our case, the object.Status will be cleaned up, and that makes the following up `Status().Update()` does nothing. The problem was hidden and didn't cause any issue because there were multiple reconciliations due to the object updates, and eventually those reconciliations made the .Status field updated correctly.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
