### PR TITLE
chore: rename WAL function names

### DIFF
--- a/pkg/reduce/pbq/store/wal/segment_test.go
+++ b/pkg/reduce/pbq/store/wal/segment_test.go
@@ -57,7 +57,7 @@ func Test_writeReadHeader(t *testing.T) {
 	fName := wal.fp.Name()
 	assert.NoError(t, err)
 	// read will fail because the file was opened only in write only mode
-	_, err = wal.readHeader()
+	_, err = wal.readWALHeader()
 	assert.Error(t, err)
 	err = wal.Close()
 	fmt.Println(fName)
@@ -66,7 +66,7 @@ func Test_writeReadHeader(t *testing.T) {
 	openWAL, err := wal.walStores.openWAL(fName)
 	assert.NoError(t, err)
 	// we have already read the header in OpenWAL
-	_, err = openWAL.readHeader()
+	_, err = openWAL.readWALHeader()
 	assert.Error(t, err)
 
 	// compare the original ID with read ID
@@ -109,13 +109,13 @@ func Test_encodeDecodeHeader(t *testing.T) {
 			wal, err := stores.CreateStore(context.Background(), *tt.id)
 			assert.NoError(t, err)
 			newWal := wal.(*WAL)
-			got, err := newWal.encodeHeader(tt.id)
-			if !tt.wantErr(t, err, fmt.Sprintf("encodeHeader(%v)", tt.id)) {
+			got, err := newWal.encodeWALHeader(tt.id)
+			if !tt.wantErr(t, err, fmt.Sprintf("encodeWALHeader(%v)", tt.id)) {
 				return
 			}
-			result, err := decodeHeader(got)
+			result, err := decodeWALHeader(got)
 			assert.NoError(t, err)
-			assert.Equalf(t, tt.id, result, "encodeHeader(%v)", tt.id)
+			assert.Equalf(t, tt.id, result, "encodeWALHeader(%v)", tt.id)
 			err = newWal.Close()
 			assert.NoError(t, err)
 		})
@@ -148,7 +148,7 @@ func Test_writeReadEntry(t *testing.T) {
 	assert.NoError(t, err)
 	newWal := store.(*WAL)
 	// we have already read the header in OpenWAL
-	_, err = newWal.readHeader()
+	_, err = newWal.readWALHeader()
 	assert.Error(t, err)
 
 	actualMessages, finished, err := newWal.Read(10000)
@@ -165,7 +165,7 @@ func Test_writeReadEntry(t *testing.T) {
 	actualOffset, err := actualMessage.ReadOffset.Sequence()
 	assert.NoError(t, err)
 	assert.Equalf(t, expectedOffset, actualOffset, "Read(%v)", message.ReadOffset)
-	assert.Equalf(t, message.Watermark, actualMessage.Watermark, "encodeEntry(%v)", message.Watermark)
+	assert.Equalf(t, message.Watermark, actualMessage.Watermark, "encodeReadMessage(%v)", message.Watermark)
 
 	// Start to write an entry again
 	err = newWal.Write(&message)
@@ -210,20 +210,20 @@ func Test_encodeDecodeEntry(t *testing.T) {
 			assert.NoError(t, err)
 			newWal := wal.(*WAL)
 
-			got, err := newWal.encodeEntry(tt.message)
-			if !tt.wantErr(t, err, fmt.Sprintf("encodeEntry(%v)", tt.message)) {
+			got, err := newWal.encodeReadMessage(tt.message)
+			if !tt.wantErr(t, err, fmt.Sprintf("encodeReadMessage(%v)", tt.message)) {
 				return
 			}
 
-			result, _, err := decodeEntry(bytes.NewReader(got.Bytes()))
+			result, _, err := decodeReadMessage(bytes.NewReader(got.Bytes()))
 			assert.NoError(t, err)
-			assert.Equalf(t, tt.message.Message, result.Message, "encodeEntry(%v)", tt.message.Message)
+			assert.Equalf(t, tt.message.Message, result.Message, "encodeReadMessage(%v)", tt.message.Message)
 			expectedOffset, err := tt.message.ReadOffset.Sequence()
 			assert.NoError(t, err)
 			actualOffset, err := result.ReadOffset.Sequence()
 			assert.NoError(t, err)
-			assert.Equalf(t, expectedOffset, actualOffset, "encodeEntry(%v)", tt.message.ReadOffset)
-			assert.Equalf(t, tt.message.Watermark, result.Watermark, "encodeEntry(%v)", tt.message.Watermark)
+			assert.Equalf(t, expectedOffset, actualOffset, "encodeReadMessage(%v)", tt.message.ReadOffset)
+			assert.Equalf(t, tt.message.Watermark, result.Watermark, "encodeReadMessage(%v)", tt.message.Watermark)
 			err = newWal.Close()
 			assert.NoError(t, err)
 		})
@@ -269,7 +269,7 @@ func Test_batchSyncWithMaxBatchSize(t *testing.T) {
 	assert.NoError(t, err)
 	newWal := store.(*WAL)
 	// we have already read the header in OpenWAL
-	_, err = newWal.readHeader()
+	_, err = newWal.readWALHeader()
 	assert.Error(t, err)
 
 	actualMessages, finished, err := newWal.Read(10000)
@@ -286,7 +286,7 @@ func Test_batchSyncWithMaxBatchSize(t *testing.T) {
 	actualOffset, err := actualMessage.ReadOffset.Sequence()
 	assert.NoError(t, err)
 	assert.Equalf(t, expectedOffset, actualOffset, "Read(%v)", message.ReadOffset)
-	assert.Equalf(t, message.Watermark, actualMessage.Watermark, "encodeEntry(%v)", message.Watermark)
+	assert.Equalf(t, message.Watermark, actualMessage.Watermark, "encodeReadMessage(%v)", message.Watermark)
 
 	// Start to write an entry again
 	err = newWal.Write(&message)
@@ -335,7 +335,7 @@ func Test_batchSyncWithSyncDuration(t *testing.T) {
 	assert.NoError(t, err)
 	newWal := store.(*WAL)
 	// we have already read the header in OpenWAL
-	_, err = newWal.readHeader()
+	_, err = newWal.readWALHeader()
 	assert.Error(t, err)
 
 	actualMessages, finished, err := newWal.Read(10000)
@@ -352,7 +352,7 @@ func Test_batchSyncWithSyncDuration(t *testing.T) {
 	actualOffset, err := actualMessage.ReadOffset.Sequence()
 	assert.NoError(t, err)
 	assert.Equalf(t, expectedOffset, actualOffset, "Read(%v)", message.ReadOffset)
-	assert.Equalf(t, message.Watermark, actualMessage.Watermark, "encodeEntry(%v)", message.Watermark)
+	assert.Equalf(t, message.Watermark, actualMessage.Watermark, "encodeReadMessage(%v)", message.Watermark)
 
 	// Start to write an entry again
 	err = newWal.Write(&message)

--- a/pkg/reduce/pbq/store/wal/stores.go
+++ b/pkg/reduce/pbq/store/wal/stores.go
@@ -120,7 +120,7 @@ func (ws *walStores) openOrCreateWAL(id *partition.ID) (*WAL, error) {
 			numOfUnsyncedMsgs: 0,
 		}
 
-		err = wal.writeHeader()
+		err = wal.writeWALHeader()
 		if err != nil {
 			return nil, err
 		}
@@ -146,7 +146,7 @@ func (ws *walStores) openOrCreateWAL(id *partition.ID) (*WAL, error) {
 			walStores:         ws,
 			numOfUnsyncedMsgs: 0,
 		}
-		readPartition, err := wal.readHeader()
+		readPartition, err := wal.readWALHeader()
 		if err != nil {
 			return nil, err
 		}
@@ -204,7 +204,7 @@ func (ws *walStores) openWAL(filePath string) (*WAL, error) {
 		walStores: ws,
 	}
 
-	w.partitionID, err = w.readHeader()
+	w.partitionID, err = w.readWALHeader()
 
 	return w, err
 }


### PR DESCRIPTION
We were abusing the word `entry`. We need to differentiate between WAL header v/s ReadMessage header and its body.