### PR TITLE
feat: namespace search

### DIFF
--- a/ui/src/components/namespaces/NamespaceRowContent.tsx
+++ b/ui/src/components/namespaces/NamespaceRowContent.tsx
@@ -10,31 +10,57 @@ interface NamespaceRowContentProps {
 
 export function NamespaceRowContent(props: NamespaceRowContentProps) {
   const { namespaceId } = props;
-  const { pipelines } = useNamespaceFetch(namespaceId);
-  return (
-    <div className={"NamespaceRowContent"} data-testid="namespace-row-content">
-      <Box
-        sx={{
-          margin: 1,
-          fontWeight: 500,
-          fontSize: "1rem",
-        }}
-      >
-        <List>
-          {pipelines &&
-            pipelines.map((pipelineId) => {
-              return (
-                <ListItem key={pipelineId}>
-                  <Link
-                    to={`/namespaces/${namespaceId}/pipelines/${pipelineId}`}
-                  >
-                    {pipelineId}
-                  </Link>
-                </ListItem>
-              );
-            })}
-        </List>
-      </Box>
-    </div>
-  );
+
+  if (namespaceId === "") {
+      return (
+          <div className={"NamespaceRowContent"} data-testid="namespace-row-content">
+              <Box
+                  sx={{
+                      margin: 1,
+                      fontWeight: 500,
+                      fontSize: "1rem",
+                  }}
+              >
+                  <List>
+                      <ListItem>
+                          <div>Search for a namespace to get the pipelines</div>
+                      </ListItem>
+                  </List>
+              </Box>
+          </div>
+      );
+  } else {
+      const {pipelines} = useNamespaceFetch(namespaceId);
+      return (
+          <div className={"NamespaceRowContent"} data-testid="namespace-row-content">
+              <Box
+                  sx={{
+                      margin: 1,
+                      fontWeight: 500,
+                      fontSize: "1rem",
+                  }}
+              >
+                  <List>
+                      {pipelines &&
+                          pipelines.map((pipelineId) => {
+                              return (
+                                  <ListItem key={pipelineId}>
+                                      <Link
+                                          to={`/namespaces/${namespaceId}/pipelines/${pipelineId}`}
+                                      >
+                                          {pipelineId}
+                                      </Link>
+                                  </ListItem>
+                              );
+                          })}
+                      {!pipelines.length &&
+                          <ListItem>
+                              <div>No pipelines in the provided namespaces</div>
+                          </ListItem>
+                      }
+                  </List>
+              </Box>
+          </div>
+      );
+  }
 }

--- a/ui/src/components/namespaces/Namespaces.test.tsx
+++ b/ui/src/components/namespaces/Namespaces.test.tsx
@@ -1,26 +1,19 @@
 import {Namespaces} from "./Namespaces"
 import {fireEvent, render, screen, waitFor} from "@testing-library/react"
-import {useFetch} from "../../utils/fetchWrappers/fetch";
 import {useNamespaceFetch} from "../../utils/fetchWrappers/namespaceFetch";
 import {BrowserRouter} from "react-router-dom";
 
-jest.mock("../../utils/fetchWrappers/fetch");
-const mockedUseFetch = useFetch as jest.MockedFunction<typeof useFetch>;
 jest.mock("../../utils/fetchWrappers/namespaceFetch");
 const mockedUseNamespaceFetch = useNamespaceFetch as jest.MockedFunction<typeof useNamespaceFetch>;
 
 
 describe("Namespaces screen", () => {
     it("Load namespaces screen", async () => {
-        mockedUseFetch.mockReturnValueOnce({data: ["namespace-1", "namespace-2"], error: false, loading: false});
         mockedUseNamespaceFetch.mockReturnValue({pipelines: ["simple-pipeline"], error: false, loading: false});
         render(<BrowserRouter><Namespaces/></BrowserRouter>)
-        expect(screen.getByText("namespace-1")).toBeVisible();
-        expect(screen.getByText("namespace-2")).toBeVisible();
-        fireEvent.click(screen.getByTestId("namespace-row-namespace-1"))
-        await waitFor(() => expect(screen.getByTestId("namespace-row-body-namespace-1")).toBeVisible());
+        expect(screen.getByText("Search for a namespace to get the pipelines")).toBeVisible();
+        fireEvent.click(screen.getByTestId("namespace-search"))
         await waitFor(() => expect(screen.getByTestId("namespace-row-content")).toBeVisible());
-
-
+        fireEvent.click(screen.getByTestId("namespace-clear"))
     })
 })

--- a/ui/src/components/namespaces/Namespaces.tsx
+++ b/ui/src/components/namespaces/Namespaces.tsx
@@ -1,22 +1,23 @@
-import Table from "@mui/material/Table";
-import TableBody from "@mui/material/TableBody";
-import TableCell from "@mui/material/TableCell";
-import TableContainer from "@mui/material/TableContainer";
-import TableHead from "@mui/material/TableHead";
-import TableRow from "@mui/material/TableRow";
-import Paper from "@mui/material/Paper";
-import { useFetch } from "../../utils/fetchWrappers/fetch";
-import { useState } from "react";
+import {useEffect, useState} from "react";
 import { NamespaceRowContent } from "./NamespaceRowContent";
-import IconButton from "@mui/material/IconButton";
-import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
-import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import Collapse from "@mui/material/Collapse";
 import "./Namespaces.css";
-
+import {Button, TableBody, Table, TableCell, TableContainer, TableHead, TableRow, Paper, TextField} from "@mui/material";
+import ClearIcon from '@mui/icons-material/Clear'
+import SearchIcon from '@mui/icons-material/Search';
 
 export function Namespaces() {
-  const { data } = useFetch("/api/v1/namespaces");
+    const [value, setValue] = useState("");
+    const [namespace, setNamespace] = useState("");
+    const handle = (namespaceVal) => {
+        localStorage.setItem("namespace", namespaceVal);
+    };
+    useEffect(() => {
+        const prevVal = localStorage.getItem("namespace");
+        if (prevVal) {
+            setValue(prevVal);
+            setNamespace(prevVal);
+        }
+    }, []);
 
   return (
     <div className="Namespaces">
@@ -24,71 +25,52 @@ export function Namespaces() {
         <Table aria-label="collapsible table">
           <TableHead>
             <TableRow>
-              <TableCell />
               <TableCell
-                style={{
-                  fontWeight: "bold",
-                  fontSize: "1rem",
-                }}
               >
-                Namespace
+                  <div style={{display: "flex", flexDirection: "row"}}>
+                  <TextField
+                      InputLabelProps={{ shrink: true }}
+                      label="Namespace"
+                      placeholder="enter a namespace"
+                      variant="standard"
+                      style={{width: "200px"}}
+                      value={value}
+                      onChange={e => {setValue(e.target.value)}}
+                  />
+                  <Button
+                      data-testid="namespace-search"
+                      onClick={() => {
+                          handle(value);
+                          setNamespace(value);
+                      }}
+                      style={{marginTop: "15px", height: "30px"}}
+                  >
+                      <SearchIcon/>
+                  </Button>
+                  <Button
+                      data-testid="namespace-clear"
+                      onClick={() => {
+                          handle("");
+                          setNamespace("");
+                          setValue("");
+                      }}
+                      style={{marginTop: "15px", height: "30px"}}
+                  >
+                      <ClearIcon/>
+                  </Button>
+                  </div>
               </TableCell>
             </TableRow>
           </TableHead>
-            {data &&
-              data.map((namespace: string) => {
-                return <NamespaceRow key={namespace} namespaceId={namespace} />;
-              })}
+          <TableBody>
+            <TableRow>
+                <TableCell>
+                    <NamespaceRowContent namespaceId={namespace} />
+                </TableCell>
+            </TableRow>
+          </TableBody>
         </Table>
       </TableContainer>
     </div>
   );
 }
-
-interface NamespaceRowProps {
-    namespaceId: string;
-}
-
-export function NamespaceRow(props: NamespaceRowProps) {
-    const { namespaceId } = props;
-    const [open, setOpen] = useState(false);
-
-    return (
-        <TableBody data-testid={`namespace-row-body-${namespaceId}`}>
-            <TableRow sx={{ "& > *": { borderBottom: "unset" } }}>
-                <TableCell>
-                    <IconButton
-                        data-testid={`namespace-row-${namespaceId}`}
-                        aria-label="expand row"
-                        size="small"
-                        onClick={() => setOpen(!open)}
-                    >
-                        {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-                    </IconButton>
-                </TableCell>
-                <TableCell
-                    sx={{
-                        fontWeight: 500,
-                        fontSize: "1rem",
-                    }}
-                    component="th"
-                    scope="row"
-                >
-                    {namespaceId}
-                </TableCell>
-            </TableRow>
-            <TableRow>
-                <TableCell
-                    data-testid="table-cell"
-                    style={{ paddingBottom: 0, paddingTop: 0 }}
-                    colSpan={6}
-                >
-                    <Collapse in={open} timeout="auto" unmountOnExit>
-                        <NamespaceRowContent namespaceId={namespaceId} />
-                    </Collapse>
-                </TableCell>
-            </TableRow>
-        </TableBody>
-    );
-}
-

--- a/ui/src/components/pipeline/edgeinfo/EdgeInfo.tsx
+++ b/ui/src/components/pipeline/edgeinfo/EdgeInfo.tsx
@@ -106,7 +106,7 @@ export default function EdgeInfo(props: EdgeInfoProps) {
                     if (typeof singleEdge?.data?.bufferUsage !== "undefined") {
                       bufferUsage = (singleEdge?.data?.bufferUsage * 100).toFixed(2);
                     }
-                    return <TableRow>
+                    return <TableRow key={singleEdge.id}>
                       <TableCell>{singleEdge.data.bufferName.slice(singleEdge.data.bufferName.indexOf('-') + 1)}</TableCell>
                       <TableCell data-testid="isFull">{isFull}</TableCell>
                       <TableCell data-testid="ackPending">{singleEdge.data.ackPending}</TableCell>
@@ -155,6 +155,7 @@ export default function EdgeInfo(props: EdgeInfoProps) {
           {edges.map((singleEdge) => {
             if (singleEdge?.data?.conditions && (singleEdge?.source == edge?.data?.fromVertex && singleEdge?.target == edge?.data?.toVertex)) {
               return <ReactJson
+                  key={singleEdge.id}
                   name="conditions"
                   enableClipboard={handleCopy}
                   theme="apathy:inverted"


### PR DESCRIPTION
Closes #540 
Adding namespace search in the UI for namespace scope installation

- [ ] remove listing of namespaces from UI
- [ ] ability to list all pipelines in that namespace

Caches the previously searched namespace and renders its corresponding pipelines after a refresh

<img width="1724" alt="image" src="https://user-images.githubusercontent.com/49195734/220276695-cffc4533-f2dc-4e47-8e32-476ca4dc28b0.png">

<img width="1725" alt="image" src="https://user-images.githubusercontent.com/49195734/220276790-f36b7d2d-5673-4bf6-b648-1e01103e6e8d.png">

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/49195734/220276849-9ac7203d-a03d-4670-9256-f79e4e70a57c.png">
