### PR TITLE
fix: Idle watermark fix for read batch size > 0 and partial idle outgoing edges

### DIFF
--- a/pkg/forward/forward.go
+++ b/pkg/forward/forward.go
@@ -344,8 +344,8 @@ func (isdf *InterStepDataForward) forwardAChunk(ctx context.Context) {
 		// batch processing cycle, send an idle watermark
 		for bufferName := range isdf.publishWatermark {
 			if !activeWatermarkBuffers[bufferName] {
-				// TODO: in the case of map, we don't send the idle watermark with a time stamp for now
-				isdf.publishWatermark[bufferName].PublishIdleWatermark(nil)
+				// use the watermark of the current read batch for the idle watermark
+				isdf.publishWatermark[bufferName].PublishIdleWatermark(processorWM)
 			}
 		}
 	}

--- a/pkg/forward/forward.go
+++ b/pkg/forward/forward.go
@@ -302,7 +302,7 @@ func (isdf *InterStepDataForward) forwardAChunk(ctx context.Context) {
 		// batch processing cycle, send an idle watermark
 		for bufferName := range isdf.publishWatermark {
 			if !activeWatermarkBuffers[bufferName] {
-				isdf.publishWatermark[bufferName].PublishIdleWatermark()
+				isdf.publishWatermark[bufferName].PublishIdleWatermark(nil)
 			}
 		}
 	}

--- a/pkg/forward/forward.go
+++ b/pkg/forward/forward.go
@@ -302,6 +302,7 @@ func (isdf *InterStepDataForward) forwardAChunk(ctx context.Context) {
 		// batch processing cycle, send an idle watermark
 		for bufferName := range isdf.publishWatermark {
 			if !activeWatermarkBuffers[bufferName] {
+				// TODO: in the case of map, we don't send the idle watermark with a time stamp for now
 				isdf.publishWatermark[bufferName].PublishIdleWatermark(nil)
 			}
 		}

--- a/pkg/reduce/data_forward_test.go
+++ b/pkg/reduce/data_forward_test.go
@@ -77,7 +77,7 @@ func (e *EventTypeWMProgressor) PublishWatermark(watermark processor.Watermark, 
 	e.watermarks[offset.String()] = watermark
 }
 
-func (e *EventTypeWMProgressor) PublishIdleWatermark() {
+func (e *EventTypeWMProgressor) PublishIdleWatermark(*processor.Watermark) {
 	// TODO
 }
 

--- a/pkg/reduce/data_forward_test.go
+++ b/pkg/reduce/data_forward_test.go
@@ -77,7 +77,7 @@ func (e *EventTypeWMProgressor) PublishWatermark(watermark processor.Watermark, 
 	e.watermarks[offset.String()] = watermark
 }
 
-func (e *EventTypeWMProgressor) PublishIdleWatermark(*processor.Watermark) {
+func (e *EventTypeWMProgressor) PublishIdleWatermark(processor.Watermark) {
 	// TODO
 }
 

--- a/pkg/reduce/pnf/processandforward.go
+++ b/pkg/reduce/pnf/processandforward.go
@@ -265,7 +265,8 @@ func (p *ProcessAndForward) publishWM(wm processor.Watermark, writeOffsets map[s
 		// batch processing cycle, send an idle watermark
 		for bufferName := range p.publishWatermark {
 			if !activeWatermarkBuffers[bufferName] {
-				p.publishWatermark[bufferName].PublishIdleWatermark(&wm)
+				// use the watermark of the current read batch for the idle watermark
+				p.publishWatermark[bufferName].PublishIdleWatermark(wm)
 			}
 		}
 	}

--- a/pkg/reduce/pnf/processandforward.go
+++ b/pkg/reduce/pnf/processandforward.go
@@ -265,7 +265,7 @@ func (p *ProcessAndForward) publishWM(wm processor.Watermark, writeOffsets map[s
 		// batch processing cycle, send an idle watermark
 		for bufferName := range p.publishWatermark {
 			if !activeWatermarkBuffers[bufferName] {
-				p.publishWatermark[bufferName].PublishIdleWatermark()
+				p.publishWatermark[bufferName].PublishIdleWatermark(&wm)
 			}
 		}
 	}

--- a/pkg/reduce/pnf/processandforward_test.go
+++ b/pkg/reduce/pnf/processandforward_test.go
@@ -212,12 +212,12 @@ func TestProcessAndForward_Forward(t *testing.T) {
 			wmExpected: map[string]ot.Value{
 				"buffer1": {
 					Offset:    0,
-					Watermark: 60000,
+					Watermark: int64(60000),
 					Idle:      false,
 				},
 				"buffer2": {
 					Offset:    0,
-					Watermark: 0,
+					Watermark: int64(60000),
 					Idle:      true,
 				},
 			},
@@ -236,12 +236,12 @@ func TestProcessAndForward_Forward(t *testing.T) {
 			wmExpected: map[string]ot.Value{
 				"buffer1": {
 					Offset:    0,
-					Watermark: 60000,
+					Watermark: int64(60000),
 					Idle:      false,
 				},
 				"buffer2": {
 					Offset:    0,
-					Watermark: 60000,
+					Watermark: int64(60000),
 					Idle:      false,
 				},
 			},
@@ -260,12 +260,12 @@ func TestProcessAndForward_Forward(t *testing.T) {
 			wmExpected: map[string]ot.Value{
 				"buffer1": {
 					Offset:    0,
-					Watermark: 0,
+					Watermark: int64(60000),
 					Idle:      true,
 				},
 				"buffer2": {
 					Offset:    0,
-					Watermark: 0,
+					Watermark: int64(60000),
 					Idle:      true,
 				},
 			},

--- a/pkg/watermark/fetch/offset_timeline.go
+++ b/pkg/watermark/fetch/offset_timeline.go
@@ -182,7 +182,7 @@ func (t *OffsetTimeline) GetReferredWatermark(eventTime int64) OffsetWatermark {
 	}
 	// otherwise, find the OffsetWatermark which watermark is <= the eventTime
 	for e := t.watermarks.Front(); e != nil; e = e.Next() {
-		if eventTime <= e.Value.(OffsetWatermark).watermark {
+		if eventTime >= e.Value.(OffsetWatermark).watermark {
 			return e.Value.(OffsetWatermark)
 		}
 	}

--- a/pkg/watermark/fetch/offset_timeline.go
+++ b/pkg/watermark/fetch/offset_timeline.go
@@ -185,7 +185,6 @@ func (t *OffsetTimeline) GetReferredWatermark(idleWM int64) OffsetWatermark {
 			return e.Value.(OffsetWatermark)
 		}
 	}
-
 	return OffsetWatermark{
 		watermark: -1,
 		offset:    -1,

--- a/pkg/watermark/fetch/offset_timeline.go
+++ b/pkg/watermark/fetch/offset_timeline.go
@@ -171,7 +171,8 @@ func (t *OffsetTimeline) GetHeadOffsetWatermark() OffsetWatermark {
 	return t.watermarks.Front().Value.(OffsetWatermark)
 }
 
-// GetReferredWatermark returns the largest offset with the largest watermark.
+// GetReferredWatermark returns the watermark that will be used to replace
+// the idle watermark value
 func (t *OffsetTimeline) GetReferredWatermark(eventTime int64) OffsetWatermark {
 	t.lock.RLock()
 	defer t.lock.RUnlock()

--- a/pkg/watermark/fetch/offset_timeline_test.go
+++ b/pkg/watermark/fetch/offset_timeline_test.go
@@ -18,6 +18,7 @@ package fetch
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -280,4 +281,54 @@ func TestOffsetTimeline(t *testing.T) {
 	testTimeline.PutIdle(OffsetWatermark{watermark: 34, offset: 38}) // inserted
 	assert.Equal(t, "[34:38] -> [33:37] -> [32:36] -> [30:35] -> [29:35] -> [28:30] -> [23:27] -> [20:26] -> [15:25] -> [13:21]", testTimeline.Dump())
 
+}
+
+func TestOffsetTimeline_GetReferredWatermark(t *testing.T) {
+	var (
+		ctx            = context.Background()
+		testTimeline   = NewOffsetTimeline(ctx, 10)
+		testWatermarks = [10]OffsetWatermark{
+			{watermark: 10, offset: 9},
+			{watermark: 12, offset: 20},
+			{watermark: 13, offset: 21},
+			{watermark: 15, offset: 24},
+			{watermark: 15, offset: 25}, // will overwrite the previous one
+			{watermark: 20, offset: 26},
+			{watermark: 23, offset: 27},
+			{watermark: 28, offset: 30},
+			{watermark: 29, offset: 35},
+			{watermark: 32, offset: 36},
+		}
+		referredEventTimes = [10]int64{
+			12,
+			12,
+			12,
+			13,
+			16,
+			19,
+			20,
+			28,
+			30,
+			32,
+		}
+		expectedReferredWatermarks = [10]OffsetWatermark{
+			{watermark: 10, offset: 9},
+			{watermark: 12, offset: 20},
+			{watermark: 12, offset: 20},
+			{watermark: 13, offset: 21},
+			{watermark: 15, offset: 25},
+			{watermark: 15, offset: 25},
+			{watermark: 20, offset: 26},
+			{watermark: 28, offset: 30},
+			{watermark: 29, offset: 35},
+			{watermark: 32, offset: 36},
+		}
+	)
+
+	for i, watermark := range testWatermarks {
+		testTimeline.Put(watermark)
+		assert.Equal(t, watermark, testTimeline.GetReferredWatermark(0))
+		assert.Equal(t, expectedReferredWatermarks[i], testTimeline.GetReferredWatermark(referredEventTimes[i]), fmt.Sprintf("test %d", i))
+	}
+	assert.Equal(t, "[32:36] -> [29:35] -> [28:30] -> [23:27] -> [20:26] -> [15:25] -> [13:21] -> [12:20] -> [10:9] -> [-1:-1]", testTimeline.Dump())
 }

--- a/pkg/watermark/fetch/offset_timeline_test.go
+++ b/pkg/watermark/fetch/offset_timeline_test.go
@@ -327,7 +327,6 @@ func TestOffsetTimeline_GetReferredWatermark(t *testing.T) {
 
 	for i, watermark := range testWatermarks {
 		testTimeline.Put(watermark)
-		assert.Equal(t, watermark, testTimeline.GetReferredWatermark(0))
 		assert.Equal(t, expectedReferredWatermarks[i], testTimeline.GetReferredWatermark(referredEventTimes[i]), fmt.Sprintf("test %d", i))
 	}
 	assert.Equal(t, "[32:36] -> [29:35] -> [28:30] -> [23:27] -> [20:26] -> [15:25] -> [13:21] -> [12:20] -> [10:9] -> [-1:-1]", testTimeline.Dump())

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -260,6 +260,7 @@ func (v *ProcessorManager) startTimeLineWatcher() {
 							// if the referred watermark is empty, skip
 							if referredWatermarkOffset.watermark != -1 {
 								p.offsetTimeline.PutIdle(referredWatermarkOffset)
+								v.log.Debugw("TimelineWatcher- Updates", zap.String("bucket", v.otWatcher.GetKVName()), zap.Int64("referredWatermark", referredWatermarkOffset.watermark), zap.Int64("offset", referredWatermarkOffset.offset))
 								break
 							}
 						}
@@ -273,8 +274,8 @@ func (v *ProcessorManager) startTimeLineWatcher() {
 						watermark: otValue.Watermark,
 						offset:    otValue.Offset,
 					})
+					v.log.Debugw("TimelineWatcher- Updates", zap.String("bucket", v.otWatcher.GetKVName()), zap.Int64("watermark", otValue.Watermark), zap.Int64("offset", otValue.Offset))
 				}
-				v.log.Debugw("TimelineWatcher- Updates", zap.String("bucket", v.otWatcher.GetKVName()), zap.Int64("watermark", otValue.Watermark), zap.Int64("offset", otValue.Offset))
 			case store.KVDelete:
 				// we do not care about Delete events because the timeline bucket is meant to grow and the TTL will
 				// naturally trim the KV store.

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -266,7 +266,7 @@ func (v *ProcessorManager) startTimeLineWatcher() {
 					}
 					// if the break never happens, it's safe to do nothing ATM
 					// it could be the Vn-1's idle processor's speed is much slower than the others
-					// or the data is not flowing into this Vn's processor
+					// or no data is flowing into this Vn's processor
 				} else {
 					// NOTE: currently, for source edges, the otValue.Idle is always false
 					p.offsetTimeline.Put(OffsetWatermark{

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -257,7 +257,7 @@ func (v *ProcessorManager) startTimeLineWatcher() {
 							// any other Vn-1 processor's non-empty head offsetWatermark can replace the idle watermark
 							// if all tail offsetWatermarks are empty, then it means there's no data flowing into
 							// this Vn processor, so it's safe to do nothing
-							watermarkOffset := processor.offsetTimeline.GetHeadOffsetWatermark()
+							watermarkOffset := processor.offsetTimeline.GetReferredWatermark(otValue.Watermark)
 							if watermarkOffset.offset != -1 {
 								p.offsetTimeline.PutIdle(watermarkOffset)
 								break

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -256,10 +256,10 @@ func (v *ProcessorManager) startTimeLineWatcher() {
 						if processorName != value.Key() {
 							// in any other Vn-1 processor's offset timeline, we can replace the idle watermark
 							// with any watermark whose watermark is <= otValue.Watermark
-							watermarkOffset := processor.offsetTimeline.GetReferredWatermark(otValue.Watermark)
+							referredWatermarkOffset := processor.offsetTimeline.GetReferredWatermark(otValue.Watermark)
 							// if the referred watermark is empty, skip
-							if watermarkOffset.offset != -1 {
-								p.offsetTimeline.PutIdle(watermarkOffset)
+							if referredWatermarkOffset.watermark != -1 {
+								p.offsetTimeline.PutIdle(referredWatermarkOffset)
 								break
 							}
 						}

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -254,7 +254,7 @@ func (v *ProcessorManager) startTimeLineWatcher() {
 					for processorName, processor := range processors {
 						// skip the processor itself, only use other processors as reference
 						if processorName != value.Key() {
-							// any other Vn-1 processor's non-empty head offsetWatermark can replace the idle watermark
+							// any other Vn-1 processor's non-empty offsetWatermark can possibly replace the idle watermark
 							// if all tail offsetWatermarks are empty, then it means there's no data flowing into
 							// this Vn processor, so it's safe to do nothing
 							watermarkOffset := processor.offsetTimeline.GetReferredWatermark(otValue.Watermark)

--- a/pkg/watermark/fetch/processor_manager.go
+++ b/pkg/watermark/fetch/processor_manager.go
@@ -265,7 +265,8 @@ func (v *ProcessorManager) startTimeLineWatcher() {
 						}
 					}
 					// if the break never happens, it's safe to do nothing ATM
-					// because
+					// it could be the Vn-1's idle processor's speed is much slower than the others
+					// or the data is not flowing into this Vn's processor
 				} else {
 					// NOTE: currently, for source edges, the otValue.Idle is always false
 					p.offsetTimeline.Put(OffsetWatermark{

--- a/pkg/watermark/fetch/processor_manager_test.go
+++ b/pkg/watermark/fetch/processor_manager_test.go
@@ -312,7 +312,7 @@ func TestFetcherWithSameOTBucket(t *testing.T) {
 	}
 
 	// publish an idle watermark
-	otValueByte, err = otValueToBytes(0, 0, true)
+	otValueByte, err = otValueToBytes(0, epoch+600, true)
 	assert.NoError(t, err)
 	err = otStore.PutKV(ctx, "p1", otValueByte)
 	assert.NoError(t, err)

--- a/pkg/watermark/generic/noop.go
+++ b/pkg/watermark/generic/noop.go
@@ -47,7 +47,7 @@ func (n NoOpWMProgressor) PublishWatermark(_ processor.Watermark, _ isb.Offset) 
 }
 
 // PublishIdleWatermark does a no-op idle watermark publish.
-func (n NoOpWMProgressor) PublishIdleWatermark(*processor.Watermark) {
+func (n NoOpWMProgressor) PublishIdleWatermark(processor.Watermark) {
 }
 
 // GetLatestWatermark returns the default watermark as the latest watermark.

--- a/pkg/watermark/generic/noop.go
+++ b/pkg/watermark/generic/noop.go
@@ -47,7 +47,7 @@ func (n NoOpWMProgressor) PublishWatermark(_ processor.Watermark, _ isb.Offset) 
 }
 
 // PublishIdleWatermark does a no-op idle watermark publish.
-func (n NoOpWMProgressor) PublishIdleWatermark() {
+func (n NoOpWMProgressor) PublishIdleWatermark(*processor.Watermark) {
 }
 
 // GetLatestWatermark returns the default watermark as the latest watermark.

--- a/pkg/watermark/publish/publisher.go
+++ b/pkg/watermark/publish/publisher.go
@@ -95,8 +95,8 @@ func (p *publish) initialSetup() {
 
 // PublishWatermark publishes watermark and will retry until it can succeed. It will not publish if the new-watermark
 // is less than the current head watermark.
-func (p *publish) PublishWatermark(validWM processor.Watermark, offset isb.Offset) {
-	validWM, skipWM := p.validateWatermark(validWM)
+func (p *publish) PublishWatermark(wm processor.Watermark, offset isb.Offset) {
+	validWM, skipWM := p.validateWatermark(wm)
 	if skipWM {
 		return
 	}

--- a/pkg/watermark/publish/publisher.go
+++ b/pkg/watermark/publish/publisher.go
@@ -133,6 +133,8 @@ func (p *publish) PublishWatermark(wm processor.Watermark, offset isb.Offset) {
 	}
 }
 
+// validateWatermark checks if the new watermark is greater than the head watermark, return true if yes,
+// otherwise, return false
 func (p *publish) validateWatermark(wm processor.Watermark) (processor.Watermark, bool) {
 	if p.opts.isSource && p.opts.delay.Nanoseconds() > 0 && !time.Time(wm).IsZero() {
 		wm = processor.Watermark(time.Time(wm).Add(-p.opts.delay))

--- a/pkg/watermark/publish/publisher.go
+++ b/pkg/watermark/publish/publisher.go
@@ -37,7 +37,7 @@ type Publisher interface {
 	// PublishWatermark publishes the watermark.
 	PublishWatermark(processor.Watermark, isb.Offset)
 	// PublishIdleWatermark publishes the idle watermark.
-	PublishIdleWatermark()
+	PublishIdleWatermark(wm *processor.Watermark)
 	// GetLatestWatermark returns the latest published watermark.
 	GetLatestWatermark() processor.Watermark
 }
@@ -95,19 +95,9 @@ func (p *publish) initialSetup() {
 
 // PublishWatermark publishes watermark and will retry until it can succeed. It will not publish if the new-watermark
 // is less than the current head watermark.
-func (p *publish) PublishWatermark(wm processor.Watermark, offset isb.Offset) {
-	if p.opts.isSource && p.opts.delay.Nanoseconds() > 0 && !time.Time(wm).IsZero() {
-		wm = processor.Watermark(time.Time(wm).Add(-p.opts.delay))
-	}
-	// update p.headWatermark only if wm > p.headWatermark
-	if wm.After(time.Time(p.headWatermark)) {
-		p.log.Debugw("New watermark is updated for the head watermark", zap.String("head", p.headWatermark.String()), zap.String("new", wm.String()))
-		p.headWatermark = wm
-	} else if wm.Before(time.Time(p.headWatermark)) {
-		p.log.Warnw("Skip publishing the new watermark because it's older than the current watermark", zap.String("head", p.headWatermark.String()), zap.String("new", wm.String()))
-		return
-	} else {
-		p.log.Debugw("Skip publishing the new watermark because it's the same as the current watermark", zap.String("head", p.headWatermark.String()), zap.String("new", wm.String()))
+func (p *publish) PublishWatermark(validWM processor.Watermark, offset isb.Offset) {
+	validWM, skipWM := p.validateWatermark(validWM)
+	if skipWM {
 		return
 	}
 
@@ -123,7 +113,7 @@ func (p *publish) PublishWatermark(wm processor.Watermark, offset isb.Offset) {
 	}
 	var otValue = ot.Value{
 		Offset:    seq,
-		Watermark: wm.UnixMilli(),
+		Watermark: validWM.UnixMilli(),
 	}
 	value, err := otValue.EncodeToBytes()
 	if err != nil {
@@ -137,19 +127,44 @@ func (p *publish) PublishWatermark(wm processor.Watermark, offset isb.Offset) {
 			// TODO: better exponential backoff
 			time.Sleep(time.Millisecond * 250)
 		} else {
-			p.log.Debugw("New watermark published with offset", zap.Int64("head", p.headWatermark.UnixMilli()), zap.Int64("new", wm.UnixMilli()), zap.Int64("offset", seq))
+			p.log.Debugw("New watermark published with offset", zap.Int64("head", p.headWatermark.UnixMilli()), zap.Int64("new", validWM.UnixMilli()), zap.Int64("offset", seq))
 			break
 		}
 	}
 }
 
+func (p *publish) validateWatermark(wm processor.Watermark) (processor.Watermark, bool) {
+	if p.opts.isSource && p.opts.delay.Nanoseconds() > 0 && !time.Time(wm).IsZero() {
+		wm = processor.Watermark(time.Time(wm).Add(-p.opts.delay))
+	}
+	// update p.headWatermark only if wm > p.headWatermark
+	if wm.After(time.Time(p.headWatermark)) {
+		p.log.Debugw("New watermark is updated for the head watermark", zap.String("head", p.headWatermark.String()), zap.String("new", wm.String()))
+		p.headWatermark = wm
+	} else if wm.Before(time.Time(p.headWatermark)) {
+		p.log.Warnw("Skip publishing the new watermark because it's older than the current watermark", zap.String("head", p.headWatermark.String()), zap.String("new", wm.String()))
+		return processor.Watermark{}, true
+	} else {
+		p.log.Debugw("Skip publishing the new watermark because it's the same as the current watermark", zap.String("head", p.headWatermark.String()), zap.String("new", wm.String()))
+		return processor.Watermark{}, true
+	}
+	return wm, false
+}
+
 // PublishIdleWatermark publishes the idle watermark and will retry until it can succeed.
-func (p *publish) PublishIdleWatermark() {
+func (p *publish) PublishIdleWatermark(wm *processor.Watermark) {
 	var key = p.entity.GetName()
 	var otValue = ot.Value{
 		Offset:    0,
 		Watermark: 0,
 		Idle:      true,
+	}
+	if wm != nil {
+		validWM, skipWM := p.validateWatermark(*wm)
+		if skipWM {
+			return
+		}
+		otValue.Watermark = validWM.UnixMilli()
 	}
 	value, err := otValue.EncodeToBytes()
 	if err != nil {

--- a/pkg/watermark/publish/publisher_test.go
+++ b/pkg/watermark/publish/publisher_test.go
@@ -96,7 +96,7 @@ func TestPublisherWithSharedOTBucket(t *testing.T) {
 	head := p.GetLatestWatermark()
 	assert.Equal(t, processor.Watermark(time.UnixMilli(epoch-60000).In(location)).String(), head.String())
 
-	p.PublishIdleWatermark()
+	p.PublishIdleWatermark(nil)
 	keys, err = p.otStore.GetAllKeys(p.ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"publisherTestPod1"}, keys)

--- a/pkg/watermark/publish/publisher_test.go
+++ b/pkg/watermark/publish/publisher_test.go
@@ -96,7 +96,8 @@ func TestPublisherWithSharedOTBucket(t *testing.T) {
 	head := p.GetLatestWatermark()
 	assert.Equal(t, processor.Watermark(time.UnixMilli(epoch-60000).In(location)).String(), head.String())
 
-	p.PublishIdleWatermark(nil)
+	// simulate the next read batch where the watermark is now $epoch
+	p.PublishIdleWatermark(processor.Watermark(time.UnixMilli(epoch).In(location)))
 	keys, err = p.otStore.GetAllKeys(p.ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"publisherTestPod1"}, keys)


### PR DESCRIPTION
In the case when a pod doesn't publish to all the out edges, we send an idle watermark whose watermark is assigned as the read batch's watermark.

Note that this solution is when the read in batch size is > 0. Meaning the reduce vertex is receiving incoming messages.