### PR TITLE
chore: adding nil check for vertex metrics endpoint and rendering UI with partial data

### DIFF
--- a/pkg/daemon/server/service/pipeline_metrics_query.go
+++ b/pkg/daemon/server/service/pipeline_metrics_query.go
@@ -180,6 +180,10 @@ func (ps *pipelineMetadataQuery) GetVertexMetrics(ctx context.Context, req *daem
 		url := fmt.Sprintf("https://%s-%v.%s.%s.svc.cluster.local:%v/metrics", vertexName, i, headlessServiceName, ps.pipeline.Namespace, v1alpha1.VertexMetricsPort)
 		if res, err := ps.httpClient.Get(url); err != nil {
 			log.Debugf("Error reading the metrics endpoint, it might be because of vertex scaling down to 0: %f", err.Error())
+			metricsArr[i] = &daemon.VertexMetrics{
+				Pipeline: &ps.pipeline.Name,
+				Vertex:   req.Vertex,
+			}
 		} else {
 			// expfmt Parser from prometheus to parse the metrics
 			textParser := expfmt.TextParser{}
@@ -225,15 +229,7 @@ func (ps *pipelineMetadataQuery) GetVertexMetrics(ctx context.Context, req *daem
 		}
 	}
 
-	var metricsArrFilter []*daemon.VertexMetrics
-
-	// in case any vertex queried for metrics is not running, this check prevents daemon crashes
-	for _, v := range metricsArr {
-		if v != nil {
-			metricsArrFilter = append(metricsArrFilter, v)
-		}
-	}
-	resp.VertexMetrics = metricsArrFilter
+	resp.VertexMetrics = metricsArr
 	return resp, nil
 }
 

--- a/pkg/daemon/server/service/pipeline_metrics_query.go
+++ b/pkg/daemon/server/service/pipeline_metrics_query.go
@@ -225,14 +225,15 @@ func (ps *pipelineMetadataQuery) GetVertexMetrics(ctx context.Context, req *daem
 		}
 	}
 
+	var metricsArrFilter []*daemon.VertexMetrics
+
 	// in case any vertex queried for metrics is not running, this check prevents daemon crashes
 	for _, v := range metricsArr {
-		if v == nil {
-			return nil, fmt.Errorf("error while retrieving metrics for the %s vertex", req.GetVertex())
+		if v != nil {
+			metricsArrFilter = append(metricsArrFilter, v)
 		}
 	}
-
-	resp.VertexMetrics = metricsArr
+	resp.VertexMetrics = metricsArrFilter
 	return resp, nil
 }
 

--- a/pkg/daemon/server/service/pipeline_metrics_query.go
+++ b/pkg/daemon/server/service/pipeline_metrics_query.go
@@ -225,6 +225,13 @@ func (ps *pipelineMetadataQuery) GetVertexMetrics(ctx context.Context, req *daem
 		}
 	}
 
+	// in case any vertex queried for metrics is not running, this check prevents daemon crashes
+	for _, v := range metricsArr {
+		if v == nil {
+			return nil, fmt.Errorf("error while retrieving metrics for the %s vertex", req.GetVertex())
+		}
+	}
+
 	resp.VertexMetrics = metricsArr
 	return resp, nil
 }

--- a/ui/src/components/pipeline/Pipeline.tsx
+++ b/ui/src/components/pipeline/Pipeline.tsx
@@ -88,31 +88,28 @@ export function Pipeline() {
               const vertexMetrics = {ratePerMin: "0.00", ratePerFiveMin: "0.00", ratePerFifteenMin: "0.00", podMetrics: null, error: false} as VertexMetrics;
               let ratePerMin = 0.0, ratePerFiveMin = 0.0, ratePerFifteenMin = 0.0;
               // keeping processing rates as summation of pod values
-              if (json) {
-                json.map((pod) => {
-                  if ("processingRates" in pod) {
-                    if ("1m" in pod["processingRates"]) {
-                      ratePerMin += pod["processingRates"]["1m"];
-                    }
-                    if ("5m" in pod["processingRates"]) {
-                      ratePerFiveMin += pod["processingRates"]["5m"];
-                    }
-                    if ("15m" in pod["processingRates"]) {
-                      ratePerFifteenMin += pod["processingRates"]["15m"];
-                    }
+              json.map((pod) => {
+                if ("processingRates" in pod) {
+                  if ("1m" in pod["processingRates"]) {
+                    ratePerMin += pod["processingRates"]["1m"];
                   }
-                })
-                vertexMetrics.ratePerMin = ratePerMin.toFixed(2);
-                vertexMetrics.ratePerFiveMin = ratePerFiveMin.toFixed(2);
-                vertexMetrics.ratePerFifteenMin = ratePerFifteenMin.toFixed(2);
+                  if ("5m" in pod["processingRates"]) {
+                    ratePerFiveMin += pod["processingRates"]["5m"];
+                  }
+                  if ("15m" in pod["processingRates"]) {
+                    ratePerFifteenMin += pod["processingRates"]["15m"];
+                  }
+                } else {
+                  if (vertexPods && vertexPods.get(vertex.name) !== 0) {
+                    vertexMetrics.error = true;
+                  }
+                }
+              })
+              vertexMetrics.ratePerMin = ratePerMin.toFixed(2);
+              vertexMetrics.ratePerFiveMin = ratePerFiveMin.toFixed(2);
+              vertexMetrics.ratePerFifteenMin = ratePerFifteenMin.toFixed(2);
+              if (vertexPods && vertexPods.get(vertex.name) !== 0) {
                 vertexMetrics.podMetrics = json;
-                if (vertex?.udf?.groupBy && vertexPods && vertexPods.get(vertex.name) > json.length) {
-                  vertexMetrics.error = true;
-                }
-              } else {
-                if (vertex?.udf?.groupBy && vertexPods && vertexPods.get(vertex.name) !== 0) {
-                  vertexMetrics.error = true;
-                }
               }
               vertexToMetricsMap.set(vertex.name, vertexMetrics);
             });

--- a/ui/src/components/pipeline/Pipeline.tsx
+++ b/ui/src/components/pipeline/Pipeline.tsx
@@ -85,7 +85,6 @@ export function Pipeline() {
           )
             .then((response) => response.json())
             .then((json) => {
-              console.log(vertex.name, " - ", json);
               const vertexMetrics = {ratePerMin: "0.00", ratePerFiveMin: "0.00", ratePerFifteenMin: "0.00", podMetrics: null, error: false} as VertexMetrics;
               let ratePerMin = 0.0, ratePerFiveMin = 0.0, ratePerFifteenMin = 0.0;
               // keeping processing rates as summation of pod values
@@ -107,11 +106,11 @@ export function Pipeline() {
                 vertexMetrics.ratePerFiveMin = ratePerFiveMin.toFixed(2);
                 vertexMetrics.ratePerFifteenMin = ratePerFifteenMin.toFixed(2);
                 vertexMetrics.podMetrics = json;
-                if (vertexPods && vertexPods.get(vertex.name) > json.length) {
+                if (vertex?.udf?.groupBy && vertexPods && vertexPods.get(vertex.name) > json.length) {
                   vertexMetrics.error = true;
                 }
               } else {
-                if (vertexPods && vertexPods.get(vertex.name) !== 0) {
+                if (vertex?.udf?.groupBy && vertexPods && vertexPods.get(vertex.name) !== 0) {
                   vertexMetrics.error = true;
                 }
               }

--- a/ui/src/components/pipeline/edgeinfo/EdgeInfo.tsx
+++ b/ui/src/components/pipeline/edgeinfo/EdgeInfo.tsx
@@ -106,7 +106,7 @@ export default function EdgeInfo(props: EdgeInfoProps) {
                     if (typeof singleEdge?.data?.bufferUsage !== "undefined") {
                       bufferUsage = (singleEdge?.data?.bufferUsage * 100).toFixed(2);
                     }
-                    return <TableRow key={singleEdge.id}>
+                    return <TableRow>
                       <TableCell>{singleEdge.data.bufferName.slice(singleEdge.data.bufferName.indexOf('-') + 1)}</TableCell>
                       <TableCell data-testid="isFull">{isFull}</TableCell>
                       <TableCell data-testid="ackPending">{singleEdge.data.ackPending}</TableCell>
@@ -155,7 +155,6 @@ export default function EdgeInfo(props: EdgeInfoProps) {
           {edges.map((singleEdge) => {
             if (singleEdge?.data?.conditions && (singleEdge?.source == edge?.data?.fromVertex && singleEdge?.target == edge?.data?.toVertex)) {
               return <ReactJson
-                  key={singleEdge.id}
                   name="conditions"
                   enableClipboard={handleCopy}
                   theme="apathy:inverted"

--- a/ui/src/components/pipeline/graph/Graph.tsx
+++ b/ui/src/components/pipeline/graph/Graph.tsx
@@ -127,12 +127,14 @@ export default function Graph(props: GraphProps) {
 
   // This has been added to make sure that edge container refreshes on edges being refreshed
   useEffect(() => {
+    let flag = false;
     edges.forEach((dataEdge) => {
       const edge = {} as Edge;
-      if (dataEdge.id === edgeId) {
+      if (dataEdge.id === edgeId && !flag) {
         edge.data = dataEdge.data;
         edge.label = dataEdge.label;
         edge.id = dataEdge.id;
+        flag = true;
         setEdge(edge);
       }
     });
@@ -144,11 +146,13 @@ export default function Graph(props: GraphProps) {
   const [node, setNode] = useState<Node>();
 
   const handleNodeClick = (event: MouseEvent, node: Node) => {
-    setNodeOpen(true);
-    setNode(node);
-    setNodeId(node.id);
-    setShowSpec(false);
-    setEdgeOpen(false);
+    if (node?.data?.vertexMetrics?.error === false) {
+      setNodeOpen(true);
+      setNode(node);
+      setNodeId(node.id);
+      setShowSpec(false);
+      setEdgeOpen(false);
+    }
   };
 
   // This has been added to make sure that node container refreshes on nodes being refreshed

--- a/ui/src/components/pipeline/graph/Graph.tsx
+++ b/ui/src/components/pipeline/graph/Graph.tsx
@@ -146,13 +146,11 @@ export default function Graph(props: GraphProps) {
   const [node, setNode] = useState<Node>();
 
   const handleNodeClick = (event: MouseEvent, node: Node) => {
-    if (node?.data?.vertexMetrics?.error === false) {
-      setNodeOpen(true);
-      setNode(node);
-      setNodeId(node.id);
-      setShowSpec(false);
-      setEdgeOpen(false);
-    }
+    setNodeOpen(true);
+    setNode(node);
+    setNodeId(node.id);
+    setShowSpec(false);
+    setEdgeOpen(false);
   };
 
   // This has been added to make sure that node container refreshes on nodes being refreshed

--- a/ui/src/components/pipeline/graph/SinkNode.tsx
+++ b/ui/src/components/pipeline/graph/SinkNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import {memo, useState} from "react";
 import { Handle, NodeProps, Position } from "reactflow";
 import { Tooltip } from "@mui/material";
 import "./Node.css";
@@ -9,43 +9,70 @@ const SinkNode = ({
   isConnectable,
   targetPosition = Position.Top,
 }: NodeProps) => {
+
+  const [ bgColor, setBgColor] = useState("#82A9C9");
+  const [ isOpen, setIsOpen ] = useState(false);
+
+  const handleNodeEnter = () => {
+    if (data?.vertexMetrics?.error) {
+      setBgColor("gray");
+      setIsOpen(true);
+    }
+  }
+
+  const handleNodeLeave = () => {
+    if (data?.vertexMetrics?.error) {
+      setBgColor("#82A9C9");
+      setIsOpen(false);
+    }
+  }
+
   return (
     <div>
-      <div
-        className={"react-flow__node-output"}
-        style={{
-          background: "#82A9C9",
-          color: "#333",
-          border: "1px solid #5e7a91",
-          boxShadow: "1",
-          cursor: "pointer",
-          fontFamily: "IBM Plex Sans",
-          fontWeight: 400,
-          fontSize: "0.50rem",
-        }}
+      <Tooltip
+        title={<div className={"node-tooltip"}> 1 or more pods are not running </div>}
+        placement={"top"}
+        open={isOpen}
+        arrow
       >
-        <Tooltip
-          title={
-            <div className={"node-tooltip"}>
-              <div>Processing Rates</div>
-              <div>1 min: {data?.vertexMetrics?.ratePerMin}/sec</div>
-              <div>5 min: {data?.vertexMetrics?.ratePerFiveMin}/sec</div>
-              <div>15 min: {data?.vertexMetrics?.ratePerFifteenMin}/sec</div>
-            </div>
-          }
-          arrow
+        <div
+          className={"react-flow__node-output"}
+          style={{
+            background: `${bgColor}`,
+            color: "#333",
+            border: "1px solid #5e7a91",
+            boxShadow: "1",
+            cursor: "pointer",
+            fontFamily: "IBM Plex Sans",
+            fontWeight: 400,
+            fontSize: "0.50rem",
+          }}
+          onMouseEnter={handleNodeEnter}
+          onMouseLeave={handleNodeLeave}
         >
-          <div className={"node-rate"}>
-            {data?.vertexMetrics?.ratePerMin}/sec
-          </div>
-        </Tooltip>
-        <Handle
-          type="target"
-          position={targetPosition}
-          isConnectable={isConnectable}
-        />
-        {GetNodeInfoValueComponent(data)}
-      </div>
+          <Tooltip
+            title={
+              <div className={"node-tooltip"}>
+                <div>Processing Rates</div>
+                <div>1 min: {data?.vertexMetrics?.ratePerMin}/sec</div>
+                <div>5 min: {data?.vertexMetrics?.ratePerFiveMin}/sec</div>
+                <div>15 min: {data?.vertexMetrics?.ratePerFifteenMin}/sec</div>
+              </div>
+            }
+            arrow
+          >
+            <div className={"node-rate"}>
+              {data?.vertexMetrics?.ratePerMin}/sec
+            </div>
+          </Tooltip>
+          <Handle
+            type="target"
+            position={targetPosition}
+            isConnectable={isConnectable}
+          />
+          {GetNodeInfoValueComponent(data)}
+        </div>
+      </Tooltip>
     </div>
   );
 };

--- a/ui/src/components/pipeline/graph/SourceNode.tsx
+++ b/ui/src/components/pipeline/graph/SourceNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import {memo, useState} from "react";
 import { Handle, NodeProps, Position } from "reactflow";
 import { Tooltip } from "@mui/material";
 import "./Node.css";
@@ -9,43 +9,70 @@ const SourceNode = ({
   isConnectable,
   sourcePosition = Position.Bottom,
 }: NodeProps) => {
+
+  const [ bgColor, setBgColor] = useState("#34BFFF");
+  const [ isOpen, setIsOpen ] = useState(false);
+
+  const handleNodeEnter = () => {
+    if (data?.vertexMetrics?.error) {
+      setBgColor("gray");
+      setIsOpen(true);
+    }
+  }
+
+  const handleNodeLeave = () => {
+    if (data?.vertexMetrics?.error) {
+      setBgColor("#34BFFF");
+      setIsOpen(false);
+    }
+  }
+
   return (
     <div>
-      <div
-        className={"react-flow__node-input"}
-        style={{
-          background: "#34BFFF",
-          boxShadow: "1",
-          color: "#333",
-          border: "1px solid #2382ad",
-          cursor: "pointer",
-          fontFamily: "IBM Plex Sans",
-          fontWeight: 400,
-          fontSize: "0.50rem",
-        }}
+      <Tooltip
+        title={<div className={"node-tooltip"}> 1 or more pods are not running </div>}
+        placement={"top"}
+        open={isOpen}
+        arrow
       >
-        <Tooltip
-          title={
-            <div className={"node-tooltip"}>
-              <div>Processing Rates</div>
-              <div>1 min: {data?.vertexMetrics?.ratePerMin}/sec</div>
-              <div>5 min: {data?.vertexMetrics?.ratePerFiveMin}/sec</div>
-              <div>15 min: {data?.vertexMetrics?.ratePerFifteenMin}/sec</div>
-            </div>
-          }
-          arrow
+        <div
+          className={"react-flow__node-input"}
+          style={{
+            background: `${bgColor}`,
+            boxShadow: "1",
+            color: "#333",
+            border: "1px solid #2382ad",
+            cursor: "pointer",
+            fontFamily: "IBM Plex Sans",
+            fontWeight: 400,
+            fontSize: "0.50rem",
+          }}
+          onMouseEnter={handleNodeEnter}
+          onMouseLeave={handleNodeLeave}
         >
-          <div className={"node-rate"}>
-            {data?.vertexMetrics?.ratePerMin}/sec
-          </div>
-        </Tooltip>
-        {GetNodeInfoValueComponent(data)}
-        <Handle
-          type="source"
-          position={sourcePosition}
-          isConnectable={isConnectable}
-        />
-      </div>
+          <Tooltip
+            title={
+              <div className={"node-tooltip"}>
+                <div>Processing Rates</div>
+                <div>1 min: {data?.vertexMetrics?.ratePerMin}/sec</div>
+                <div>5 min: {data?.vertexMetrics?.ratePerFiveMin}/sec</div>
+                <div>15 min: {data?.vertexMetrics?.ratePerFifteenMin}/sec</div>
+              </div>
+            }
+            arrow
+          >
+            <div className={"node-rate"}>
+              {data?.vertexMetrics?.ratePerMin}/sec
+            </div>
+          </Tooltip>
+          {GetNodeInfoValueComponent(data)}
+          <Handle
+            type="source"
+            position={sourcePosition}
+            isConnectable={isConnectable}
+          />
+        </div>
+      </Tooltip>
     </div>
   );
 };

--- a/ui/src/components/pipeline/graph/UDFNode.tsx
+++ b/ui/src/components/pipeline/graph/UDFNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import {memo, useState} from "react";
 import { Handle, NodeProps, Position } from "reactflow";
 import { Tooltip } from "@mui/material";
 import "./Node.css";
@@ -10,48 +10,75 @@ const UDFNode = ({
   targetPosition = Position.Top,
   sourcePosition = Position.Bottom,
 }: NodeProps) => {
+
+  const [ bgColor, setBgColor ] = useState("#82DBE4");
+  const [ isOpen, setIsOpen ] = useState(false);
+
+  const handleNodeEnter = () => {
+    if (data?.vertexMetrics?.error) {
+        setBgColor("gray");
+        setIsOpen(true);
+    }
+  }
+
+  const handleNodeLeave = () => {
+    if (data?.vertexMetrics?.error) {
+        setBgColor("#82DBE4");
+        setIsOpen(false);
+    }
+  }
+
   return (
     <div>
-      <div
-        className={"react-flow__node-default"}
-        style={{
-          background: "#82DBE4",
-          boxShadow: "1",
-          color: "#333",
-          border: "1px solid #59959c",
-          cursor: "pointer",
-          fontFamily: "IBM Plex Sans",
-          fontWeight: 400,
-          fontSize: "0.50rem",
-        }}
+      <Tooltip
+        title={<div className={"node-tooltip"}> 1 or more pods are not running </div>}
+        placement={"top"}
+        open={isOpen}
+        arrow
       >
-        <Tooltip
-          title={
-            <div className={"node-tooltip"}>
-              <div>Processing Rates</div>
-              <div>1 min: {data?.vertexMetrics?.ratePerMin}/sec</div>
-              <div>5 min: {data?.vertexMetrics?.ratePerFiveMin}/sec</div>
-              <div>15 min: {data?.vertexMetrics?.ratePerFifteenMin}/sec</div>
-            </div>
-          }
-          arrow
+        <div
+          className={"react-flow__node-default"}
+          style={{
+            background: `${bgColor}`,
+            boxShadow: "1",
+            color: "#333",
+            border: "1px solid #59959c",
+            cursor: "pointer",
+            fontFamily: "IBM Plex Sans",
+            fontWeight: 400,
+            fontSize: "0.50rem",
+          }}
+          onMouseEnter={handleNodeEnter}
+          onMouseLeave={handleNodeLeave}
         >
-          <div className={"node-rate"}>
-            {data?.vertexMetrics?.ratePerMin}/sec
-          </div>
-        </Tooltip>
-        <Handle
-          type="target"
-          position={targetPosition}
-          isConnectable={isConnectable}
-        />
-        {GetNodeInfoValueComponent(data)}
-        <Handle
-          type="source"
-          position={sourcePosition}
-          isConnectable={isConnectable}
-        />
-      </div>
+          <Tooltip
+            title={
+              <div className={"node-tooltip"}>
+                <div>Processing Rates</div>
+                <div>1 min: {data?.vertexMetrics?.ratePerMin}/sec</div>
+                <div>5 min: {data?.vertexMetrics?.ratePerFiveMin}/sec</div>
+                <div>15 min: {data?.vertexMetrics?.ratePerFifteenMin}/sec</div>
+              </div>
+            }
+            arrow
+          >
+            <div className={"node-rate"}>
+              {data?.vertexMetrics?.ratePerMin}/sec
+            </div>
+          </Tooltip>
+          <Handle
+            type="target"
+            position={targetPosition}
+            isConnectable={isConnectable}
+          />
+          {GetNodeInfoValueComponent(data)}
+          <Handle
+            type="source"
+            position={sourcePosition}
+            isConnectable={isConnectable}
+          />
+        </div>
+      </Tooltip>
     </div>
   );
 };

--- a/ui/src/components/pipeline/nodeinfo/NodeInfo.tsx
+++ b/ui/src/components/pipeline/nodeinfo/NodeInfo.tsx
@@ -116,7 +116,7 @@ export default function NodeInfo(props: NodeInfoProps) {
             )}
           </TabPanel>
           <TabPanel value={value} index={2}>
-            {node?.data?.vertexMetrics && (
+            {node?.data?.vertexMetrics?.podMetrics && (
               <TableContainer
                   component={Paper}
                   sx={{ borderBottom: 1, borderColor: "divider" }}
@@ -131,8 +131,7 @@ export default function NodeInfo(props: NodeInfoProps) {
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {node?.data?.vertexMetrics?.podMetrics &&
-                        node.data.vertexMetrics.podMetrics.map((podMetric, idx) => {
+                    {node.data.vertexMetrics.podMetrics.map((podMetric, idx) => {
                       return <TableRow>
                         <TableCell>Pod - {idx}</TableCell>
                         <TableCell>{podMetric["processingRates"]["1m"].toFixed(2)}</TableCell>
@@ -143,6 +142,9 @@ export default function NodeInfo(props: NodeInfoProps) {
                   </TableBody>
                 </Table>
               </TableContainer>
+            )}
+            {!node?.data?.vertexMetrics?.podMetrics && (
+              <Box  key = {"no pods"}>{`No pods found`}</Box>
             )}
           </TabPanel>
         </>

--- a/ui/src/components/pipeline/nodeinfo/NodeInfo.tsx
+++ b/ui/src/components/pipeline/nodeinfo/NodeInfo.tsx
@@ -124,7 +124,7 @@ export default function NodeInfo(props: NodeInfoProps) {
                 <Table aria-label="pod-backpressure">
                   <TableHead>
                     <TableRow>
-                      <TableCell>Pod</TableCell>
+                      <TableCell>Partition</TableCell>
                       <TableCell >1m</TableCell>
                       <TableCell >5m</TableCell>
                       <TableCell >15m</TableCell>
@@ -133,7 +133,7 @@ export default function NodeInfo(props: NodeInfoProps) {
                   <TableBody>
                     {node.data.vertexMetrics.podMetrics.map((podMetric, idx) => {
                       return <TableRow>
-                        <TableCell>Pod - {idx}</TableCell>
+                        <TableCell>Partition - {idx}</TableCell>
                         <TableCell>{podMetric["processingRates"]["1m"].toFixed(2)}</TableCell>
                         <TableCell>{podMetric["processingRates"]["5m"].toFixed(2)}</TableCell>
                         <TableCell>{podMetric["processingRates"]["15m"].toFixed(2)}</TableCell>

--- a/ui/src/components/pipeline/nodeinfo/NodeInfo.tsx
+++ b/ui/src/components/pipeline/nodeinfo/NodeInfo.tsx
@@ -133,10 +133,19 @@ export default function NodeInfo(props: NodeInfoProps) {
                   <TableBody>
                     {node.data.vertexMetrics.podMetrics.map((podMetric, idx) => {
                       return <TableRow>
-                        <TableCell>Partition - {idx}</TableCell>
-                        <TableCell>{podMetric["processingRates"]["1m"].toFixed(2)}</TableCell>
-                        <TableCell>{podMetric["processingRates"]["5m"].toFixed(2)}</TableCell>
-                        <TableCell>{podMetric["processingRates"]["15m"].toFixed(2)}</TableCell>
+                        <TableCell>{idx}</TableCell>
+                        <TableCell>
+                          {("processingRates" in podMetric) && podMetric["processingRates"]["1m"].toFixed(2)}
+                          {!("processingRates" in podMetric) && -1}
+                        </TableCell>
+                        <TableCell>
+                          {("processingRates" in podMetric) && podMetric["processingRates"]["5m"].toFixed(2)}
+                          {!("processingRates" in podMetric) && -1}
+                        </TableCell>
+                        <TableCell>
+                          {("processingRates" in podMetric) && podMetric["processingRates"]["15m"].toFixed(2)}
+                          {!("processingRates" in podMetric) && -1}
+                        </TableCell>
                       </TableRow>
                     })}
                   </TableBody>

--- a/ui/src/components/pods/Pods.tsx
+++ b/ui/src/components/pods/Pods.tsx
@@ -165,6 +165,17 @@ export function Pods(props: PodsProps) {
       errors.push(<Box  key = {podsDetailError}>{`Pods metric map undefined`}</Box>);
     }
     return <Box>{errors}</Box>;
+  } else {
+    let found = false;
+    pods.forEach((pod) => {
+      if (podsDetailMap.has(pod.name)) {
+        found = true;
+      }
+    })
+
+    if (!found) {
+      return <Box  key = {"load-pods"}>{`Pods are not up yet...`}</Box>;
+    }
   }
 
   return (

--- a/ui/src/utils/models/pipeline.ts
+++ b/ui/src/utils/models/pipeline.ts
@@ -5,6 +5,7 @@ export interface VertexMetrics {
   ratePerFiveMin: string;
   ratePerFifteenMin: string;
   podMetrics: any[];
+  error: boolean;
 }
 
 export interface EdgeWatermark {


### PR DESCRIPTION
Fixes metrics api to prevent daemon pod crashes
Fixes UI to render for partial data.

Vertex with some pods not running grays out and shows message on hover, also the processing rates becomes -1.
<img width="1722" alt="image" src="https://user-images.githubusercontent.com/49195734/224013761-b1322f49-383f-40de-92e4-55ad1f04e598.png">


