### PR TITLE
chore: fix TestBuiltinEventTimeExtractor e2e test

### DIFF
--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -217,6 +217,7 @@ func (s *FunctionalSuite) TestBuiltinEventTimeExtractor() {
 	wm, err := client.GetPipelineWatermarks(ctx, pipelineName)
 	assert.NoError(s.T(), err)
 	edgeWM := wm[0].Watermarks[0]
+	fmt.Printf("delete-this: edgeWM=%+v\n", edgeWM)
 	// Watermark propagation can delay, we consider the test as passed as long as the retrieved watermark matches one of the assigned event times.
 	assert.True(s.T(), edgeWM == time.Date(2021, 4, 18, 21, 54, 42, 123000000, time.UTC).UnixMilli() || edgeWM == time.Date(2021, 3, 18, 21, 54, 42, 123000000, time.UTC).UnixMilli() || edgeWM == time.Date(2021, 2, 18, 21, 54, 42, 123000000, time.UTC).UnixMilli())
 }

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -217,9 +217,8 @@ func (s *FunctionalSuite) TestBuiltinEventTimeExtractor() {
 	wm, err := client.GetPipelineWatermarks(ctx, pipelineName)
 	assert.NoError(s.T(), err)
 	edgeWM := wm[0].Watermarks[0]
-	fmt.Printf("delete-this: edgeWM=%+v\n", edgeWM)
 	// Watermark propagation can delay, we consider the test as passed as long as the retrieved watermark matches one of the assigned event times.
-	assert.True(s.T(), edgeWM == time.Date(2021, 4, 18, 21, 54, 42, 123000000, time.UTC).UnixMilli() || edgeWM == time.Date(2021, 3, 18, 21, 54, 42, 123000000, time.UTC).UnixMilli() || edgeWM == time.Date(2021, 2, 18, 21, 54, 42, 123000000, time.UTC).UnixMilli())
+	assert.True(s.T(), edgeWM == time.Date(2021, 5, 18, 21, 54, 42, 123000000, time.UTC).UnixMilli() || edgeWM == time.Date(2021, 4, 18, 21, 54, 42, 123000000, time.UTC).UnixMilli() || edgeWM == time.Date(2021, 3, 18, 21, 54, 42, 123000000, time.UTC).UnixMilli() || edgeWM == time.Date(2021, 2, 18, 21, 54, 42, 123000000, time.UTC).UnixMilli())
 }
 
 func (s *FunctionalSuite) TestConditionalForwarding() {


### PR DESCRIPTION
With idle watermark in place, the watermark propagation becomes faster than before, that it seems the edge watermark can be the event time of the latest message. Since the purpose of this specific test case is to verify the event time is extracted from the message payload, I am updating the test to pass if the watermark is the event time extracted from the latest message.

Closes #632 

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
