### PR TITLE
fix: vertex overlapping watermark

### DIFF
--- a/ui/src/components/pipeline/graph/CustomEdge.tsx
+++ b/ui/src/components/pipeline/graph/CustomEdge.tsx
@@ -13,7 +13,7 @@ const CustomEdge: FC<EdgeProps> = ({
                                        targetPosition,
                                        data,
                                    }) => {
-    const [edgePath, labelX, labelY] = getSmoothStepPath({
+    const obj = getSmoothStepPath({
         sourceX,
         sourceY,
         sourcePosition,
@@ -22,23 +22,31 @@ const CustomEdge: FC<EdgeProps> = ({
         targetPosition,
     });
 
+  const [edgePath, labelX, ] = obj
+  let [, , labelY ] = obj
+
     // Color the edge on isFull
     let edgeStyle;
     if (data.isFull) {
         edgeStyle = {
             stroke: "red",
-            strokeWidth: "4px",
+            strokeWidth: "2px",
             fontWeight: 700,
         };
     }
     let wmStyle;
     let pendingStyle;
     if (sourceY === targetY) {
-        wmStyle = { marginTop: "-12px" }
+        wmStyle = { marginTop: "-13px" }
         pendingStyle = { marginTop: "1px" }
     } else {
         wmStyle = { right: "1px" }
         pendingStyle = { left: "1px" }
+        if (sourceY < targetY) {
+          labelY = targetY - 13
+        } else {
+          labelY = targetY + 1
+        }
     }
 
     return (

--- a/ui/src/components/pipeline/graph/Graph.tsx
+++ b/ui/src/components/pipeline/graph/Graph.tsx
@@ -47,7 +47,7 @@ const getLayoutedElements = (
   const dagreGraph = new dagre.graphlib.Graph();
   dagreGraph.setDefaultEdgeLabel(() => ({}));
   const isHorizontal = direction === "LR";
-  dagreGraph.setGraph({ rankdir: direction });
+  dagreGraph.setGraph({ rankdir: direction, ranksep: 80 });
 
   nodes.forEach((node) => {
     dagreGraph.setNode(node.id, { width: nodeWidth, height: nodeHeight });


### PR DESCRIPTION
For pipeline where vertex branched the watermark for the edge was overlapped by the previous vertex
adding a fix for the same

Previous
![image](https://user-images.githubusercontent.com/49195734/229486125-f2f2f60a-da5a-43de-b919-8a1f85e4a2a4.png)

Current
<img width="1350" alt="image" src="https://user-images.githubusercontent.com/49195734/229488113-14ba37d9-b0df-41ff-9ba4-8db4fb3d3831.png">
