### PR TITLE
fix: add wal dir x permission

### DIFF
--- a/examples/6-reduce-fixed-window.yaml
+++ b/examples/6-reduce-fixed-window.yaml
@@ -10,41 +10,15 @@ spec:
     - name: atoi
       scale:
         min: 1
-      securityContext:
-        fsGroup: 1000
-      containerTemplate:
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 1000
       udf:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/function/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd
-          securityContext:
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
     - name: compute-sum
-      securityContext:
-#        fsGroup: 1000
-      containerTemplate:
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 1000
       udf:
         container:
           # compute the sum
           image: quay.io/numaio/numaflow-go/reduce-sum
-          securityContext:
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
         groupBy:
           window:
             fixed:
@@ -52,7 +26,7 @@ spec:
           keyed: true
           storage:
             persistentVolumeClaim:
-              volumeSize: 1Gi
+              volumeSize: 10Gi
               accessMode: ReadWriteOnce
     - name: sink
       scale:
@@ -64,5 +38,6 @@ spec:
       to: atoi
     - from: atoi
       to: compute-sum
+      parallelism: 2
     - from: compute-sum
       to: sink

--- a/examples/6-reduce-fixed-window.yaml
+++ b/examples/6-reduce-fixed-window.yaml
@@ -10,15 +10,41 @@ spec:
     - name: atoi
       scale:
         min: 1
+      securityContext:
+        fsGroup: 1000
+      containerTemplate:
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
       udf:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/function/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
     - name: compute-sum
+      securityContext:
+#        fsGroup: 1000
+      containerTemplate:
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
       udf:
         container:
           # compute the sum
           image: quay.io/numaio/numaflow-go/reduce-sum
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
         groupBy:
           window:
             fixed:
@@ -26,7 +52,7 @@ spec:
           keyed: true
           storage:
             persistentVolumeClaim:
-              volumeSize: 10Gi
+              volumeSize: 1Gi
               accessMode: ReadWriteOnce
     - name: sink
       scale:
@@ -38,6 +64,5 @@ spec:
       to: atoi
     - from: atoi
       to: compute-sum
-      parallelism: 2
     - from: compute-sum
       to: sink

--- a/pkg/reduce/pbq/store/wal/stores.go
+++ b/pkg/reduce/pbq/store/wal/stores.go
@@ -61,7 +61,7 @@ func (ws *walStores) CreateStore(_ context.Context, partitionID partition.ID) (s
 	// Create wal dir if not exist
 	var err error
 	if _, err = os.Stat(ws.storePath); os.IsNotExist(err) {
-		err = os.Mkdir(ws.storePath, 0644)
+		err = os.Mkdir(ws.storePath, 0744)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/reduce/pbq/store/wal/stores.go
+++ b/pkg/reduce/pbq/store/wal/stores.go
@@ -61,7 +61,7 @@ func (ws *walStores) CreateStore(_ context.Context, partitionID partition.ID) (s
 	// Create wal dir if not exist
 	var err error
 	if _, err = os.Stat(ws.storePath); os.IsNotExist(err) {
-		err = os.Mkdir(ws.storePath, 0744)
+		err = os.Mkdir(ws.storePath, 0755)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes: #688

`/var/numaflow/pbq/wal` was created with `0644`, there's no issue with it when the vertex pod/containers run as root. If they run as non-root, since it has no `x` permission, there's no way to `cd` to the dir and create wal files.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
