### PR TITLE
feat: gRPC error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -194,3 +194,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
+
+replace github.com/numaproj/numaflow-go => /Users/jyu6/work/jyu6/numaflow-go

--- a/pkg/sources/transformer/grpc_transformer.go
+++ b/pkg/sources/transformer/grpc_transformer.go
@@ -93,13 +93,28 @@ func (u *gRPCBasedTransformer) ApplyMap(ctx context.Context, readMessage *isb.Re
 
 	datumList, err := u.client.MapTFn(ctx, d)
 	if err != nil {
-		return nil, function.ApplyUDFErr{
-			UserUDFErr: false,
-			Message:    fmt.Sprintf("gRPC client.MapTFn failed, %s", err),
-			InternalErr: function.InternalErr{
-				Flag:        true,
-				MainCarDown: false,
-			},
+		udfErr, _ := client.FromError(err)
+		switch udfErr.ErrorKind() {
+		case client.Retryable:
+		// TODO
+		case client.NonRetryable:
+			return nil, function.ApplyUDFErr{
+				UserUDFErr: false,
+				Message:    fmt.Sprintf("gRPC client.MapFn failed, %s", err),
+				InternalErr: function.InternalErr{
+					Flag:        true,
+					MainCarDown: false,
+				},
+			}
+		default:
+			return nil, function.ApplyUDFErr{
+				UserUDFErr: false,
+				Message:    fmt.Sprintf("gRPC client.MapFn failed, %s", err),
+				InternalErr: function.InternalErr{
+					Flag:        true,
+					MainCarDown: false,
+				},
+			}
 		}
 	}
 


### PR DESCRIPTION
Draft PR

Integrate with https://github.com/numaproj/numaflow-go/pull/56 to handle gRPC errors
- For Map and MapT, retry on retryable errors
- For Reduce, exit the program and restart the numa container
Pending: 
- Please check the retry configuration for Map and MapT
- Also @ashwinidulams once mentioned planning on a new design for the type `ApplyUDFErr`, we can discuss further