### PR TITLE
chore: use metrics to calculate rate for reducer partitions

### DIFF
--- a/pkg/daemon/server/daemon_server.go
+++ b/pkg/daemon/server/daemon_server.go
@@ -135,7 +135,7 @@ func (ds *daemonServer) Run(ctx context.Context) error {
 func (ds *daemonServer) newGRPCServer(
 	isbSvcClient isbsvc.ISBService,
 	wmFetchers map[string][]fetch.Fetcher,
-	rater *server.Rater) (*grpc.Server, error) {
+	rater server.Ratable) (*grpc.Server, error) {
 	// "Prometheus histograms are a great way to measure latency distributions of your RPCs.
 	// However, since it is a bad practice to have metrics of high cardinality the latency monitoring metrics are disabled by default.
 	// To enable them please call the following in your server initialization code:"
@@ -149,7 +149,7 @@ func (ds *daemonServer) newGRPCServer(
 	}
 	grpcServer := grpc.NewServer(sOpts...)
 	grpc_prometheus.Register(grpcServer)
-	pipelineMetadataQuery, err := service.NewPipelineMetadataQuery(isbSvcClient, ds.pipeline, wmFetchers, rater, true)
+	pipelineMetadataQuery, err := service.NewPipelineMetadataQuery(isbSvcClient, ds.pipeline, wmFetchers, rater)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/daemon/server/service/pipeline_metrics_query.go
+++ b/pkg/daemon/server/service/pipeline_metrics_query.go
@@ -253,12 +253,12 @@ func (ps *pipelineMetadataQuery) GetVertexMetrics(ctx context.Context, req *daem
 					Pendings: pendings,
 				}
 				if podNum == 1 {
-					// non-reduce vertex, or reduce vertex with single partition
-					// the processing rate of this pod is exactly same as the vertex level rate
+					// the vertex is either non-reduce, or single-partition reducer.
+					// in this case the processing rate of this pod is exactly same as the vertex level rate.
 					vm.ProcessingRates = vertexLevelRates
 				} else {
-					// reduce vertex with multiple partitions
-					// the processing rate of this pod is the rate of this partition
+					// the vertex is a multi-partition reducer.
+					// the processing rate of this pod is the rate of the corresponding partition.
 					vm.ProcessingRates = ps.rater.GetPodRates(req.GetVertex(), int(i))
 				}
 				metricsArr[i] = vm

--- a/pkg/daemon/server/service/pipeline_metrics_query.go
+++ b/pkg/daemon/server/service/pipeline_metrics_query.go
@@ -219,7 +219,7 @@ func (ps *pipelineMetadataQuery) GetVertexMetrics(ctx context.Context, req *daem
 				vm.ProcessingRates = ps.rater.GetPodRates(req.GetVertex(), int(i))
 			} else {
 				// if the vertex is not a reduce udf, then the processing rate is the sum of all pods in this vertex.
-				// TODO - change this to display the processing rate of each partition when we finish multi-partition support for non-reduce vertices.
+				// TODO (multi-partition) - change this to display the processing rate of each partition when we finish multi-partition support for non-reduce vertices.
 				vm.ProcessingRates = vertexLevelRates
 			}
 

--- a/pkg/daemon/server/service/rater/rater.go
+++ b/pkg/daemon/server/service/rater/rater.go
@@ -33,6 +33,12 @@ import (
 	sharedqueue "github.com/numaproj/numaflow/pkg/shared/queue"
 )
 
+type Ratable interface {
+	Start(ctx context.Context) error
+	GetRates(vertexName string) map[string]float64
+	GetPodRates(vertexName string, podIndex int) map[string]float64
+}
+
 // CountWindow is the time window for which we maintain the timestamped counts, currently 10 seconds
 // e.g. if the current time is 12:00:07, the retrieved count will be tracked in the 12:00:00-12:00:10 time window using 12:00:10 as the timestamp
 const CountWindow = time.Second * 10

--- a/pkg/daemon/server/service/rater/rater_test.go
+++ b/pkg/daemon/server/service/rater/rater_test.go
@@ -120,7 +120,7 @@ func TestRater_Start(t *testing.T) {
 	}()
 	go func() {
 		for {
-			if r.GetRates("v")["1m"] <= 0 {
+			if r.GetRates("v")["1m"] <= 0 || r.GetPodRates("v", 0)["1m"] <= 0 || r.GetPodRates("v", 1)["1m"] <= 0 {
 				time.Sleep(time.Second)
 			} else {
 				succeedChan <- struct{}{}

--- a/pkg/daemon/server/service/rater/timestamped_counts.go
+++ b/pkg/daemon/server/service/rater/timestamped_counts.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"fmt"
 	"sync"
 )
 
@@ -61,4 +62,13 @@ func (tc *TimestampedCounts) Snapshot() map[string]float64 {
 		counts[k] = v
 	}
 	return counts
+}
+
+// ToString returns a string representation of the TimestampedCounts
+// it's used for debugging purpose
+func (tc *TimestampedCounts) ToString() string {
+	tc.lock.RLock()
+	defer tc.lock.RUnlock()
+	res := fmt.Sprintf("{timestamp: %d, podCount: %v}", tc.timestamp, tc.podCounts)
+	return res
 }

--- a/pkg/daemon/server/service/rater/timestamped_counts.go
+++ b/pkg/daemon/server/service/rater/timestamped_counts.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"fmt"
 	"sync"
 )
 
@@ -62,13 +61,4 @@ func (tc *TimestampedCounts) Snapshot() map[string]float64 {
 		counts[k] = v
 	}
 	return counts
-}
-
-// ToString returns a string representation of the TimestampedCounts
-// it's used for debugging purpose
-func (tc *TimestampedCounts) ToString() string {
-	tc.lock.RLock()
-	defer tc.lock.RUnlock()
-	res := fmt.Sprintf("{timestamp: %d, podCount: %v}", tc.timestamp, tc.podCounts)
-	return res
 }


### PR DESCRIPTION
Fixes #746 

Showing the processing rate for each of the partitions is important as it helps us identify hot key issue. This change enables the rater to calculate rate for a single pod, such that we can retrieve per-partition rates and display them on UI.

### How was this change tested
**Before this change**

![before](https://github.com/numaproj/numaflow/assets/13165977/e421d819-6e53-440b-beab-c9996f1bae06)

**After**

![after](https://github.com/numaproj/numaflow/assets/13165977/436825c3-42b3-4c01-ab6c-da3a5047f667)

