### PR TITLE
chore: fix processor manager test goroutine leak

### DIFF
--- a/pkg/watermark/processor/processor_manager_test.go
+++ b/pkg/watermark/processor/processor_manager_test.go
@@ -19,11 +19,11 @@ package processor
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 
 	"github.com/numaproj/numaflow/pkg/watermark/store"
 	"github.com/numaproj/numaflow/pkg/watermark/store/inmem"
@@ -41,6 +41,10 @@ func otValueToBytes(offset int64, watermark int64, idle bool, partition int32) (
 	return otValueByte, err
 }
 
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
 func TestProcessorManager(t *testing.T) {
 	var (
 		err          error
@@ -48,16 +52,15 @@ func TestProcessorManager(t *testing.T) {
 		keyspace     = "fetcherTest"
 		hbBucketName = keyspace + "_PROCESSORS"
 		otBucketName = keyspace + "_OT"
-		wg           sync.WaitGroup
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
 	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, hbBucketName)
 	assert.NoError(t, err)
-	defer hbStore.Close()
 	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, otBucketName)
 	assert.NoError(t, err)
+	defer hbStore.Close()
 	defer otStore.Close()
+	defer cancel()
 
 	hbWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_PROCESSORS", hbWatcherCh)
 	assert.NoError(t, err)
@@ -65,10 +68,8 @@ func TestProcessorManager(t *testing.T) {
 	assert.NoError(t, err)
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
 	var processorManager = NewProcessorManager(ctx, storeWatcher)
-	// start p1 heartbeat for 3 loops
-	wg.Add(1)
+	// start p1 heartbeat for 3 loops then delete p1
 	go func() {
-		defer wg.Done()
 		var err error
 		for i := 0; i < 3; i++ {
 			err = hbStore.PutKV(ctx, "p1", []byte(fmt.Sprintf("%d", time.Now().Unix())))
@@ -79,15 +80,16 @@ func TestProcessorManager(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	// start p2 heartbeat for 20 loops (20 seconds)
-	wg.Add(1)
+	// start p2 heartbeat
 	go func() {
-		defer wg.Done()
-		var err error
-		for i := 0; i < 20; i++ {
-			err = hbStore.PutKV(ctx, "p2", []byte(fmt.Sprintf("%d", time.Now().Unix())))
-			assert.NoError(t, err)
-			time.Sleep(1 * time.Second)
+		for {
+			select {
+			case <-time.After(1 * time.Second):
+				err := hbStore.PutKV(ctx, "p2", []byte(fmt.Sprintf("%d", time.Now().Unix())))
+				assert.NoError(t, err)
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 
@@ -128,7 +130,6 @@ func TestProcessorManager(t *testing.T) {
 	processorManager.DeleteProcessor("p1")
 	processorManager.DeleteProcessor("p2")
 	assert.Equal(t, 0, len(processorManager.GetAllProcessors()))
-	cancel()
 }
 
 func TestProcessorManagerWatchForMap(t *testing.T) {
@@ -140,16 +141,15 @@ func TestProcessorManagerWatchForMap(t *testing.T) {
 		otBucketName       = keyspace + "_OT"
 		epoch        int64 = 60000
 		testOffset   int64 = 100
-		wg           sync.WaitGroup
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
 	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, hbBucketName)
 	assert.NoError(t, err)
-	defer hbStore.Close()
 	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, otBucketName)
 	assert.NoError(t, err)
+	defer hbStore.Close()
 	defer otStore.Close()
+	defer cancel()
 
 	hbWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_PROCESSORS", hbWatcherCh)
 	assert.NoError(t, err)
@@ -158,35 +158,27 @@ func TestProcessorManagerWatchForMap(t *testing.T) {
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
 	var processorManager = NewProcessorManager(ctx, storeWatcher)
 	// start p1 heartbeat for 3 loops
-	wg.Add(1)
 	go func(ctx context.Context) {
-		defer wg.Done()
-		var err error
 		for {
 			select {
+			case <-time.After(1 * time.Second):
+				err := hbStore.PutKV(ctx, "p1", []byte(fmt.Sprintf("%d", time.Now().Unix())))
+				assert.NoError(t, err)
 			case <-ctx.Done():
 				return
-			default:
-				err = hbStore.PutKV(ctx, "p1", []byte(fmt.Sprintf("%d", time.Now().Unix())))
-				assert.NoError(t, err)
-				time.Sleep(1 * time.Second)
 			}
 		}
 	}(ctx)
 
-	// start p2 heartbeat for 20 loops (20 seconds)
-	wg.Add(1)
+	// start p2 heartbeat
 	go func(ctx context.Context) {
-		defer wg.Done()
-		var err error
 		for {
 			select {
+			case <-time.After(1 * time.Second):
+				err := hbStore.PutKV(ctx, "p2", []byte(fmt.Sprintf("%d", time.Now().Unix())))
+				assert.NoError(t, err)
 			case <-ctx.Done():
 				return
-			default:
-				err = hbStore.PutKV(ctx, "p2", []byte(fmt.Sprintf("%d", time.Now().Unix())))
-				assert.NoError(t, err)
-				time.Sleep(1 * time.Second)
 			}
 		}
 	}(ctx)
@@ -237,7 +229,6 @@ func TestProcessorManagerWatchForMap(t *testing.T) {
 	}, processorManager.GetProcessor("p2").GetOffsetTimeline().GetHeadWMB())
 	processorManager.DeleteProcessor("p1")
 	processorManager.DeleteProcessor("p2")
-	cancel()
 }
 
 func TestProcessorManagerWatchForReduce(t *testing.T) {
@@ -249,16 +240,15 @@ func TestProcessorManagerWatchForReduce(t *testing.T) {
 		otBucketName       = keyspace + "_OT"
 		epoch        int64 = 60000
 		testOffset   int64 = 100
-		wg           sync.WaitGroup
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
 	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, hbBucketName)
 	assert.NoError(t, err)
-	defer hbStore.Close()
 	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, otBucketName)
 	assert.NoError(t, err)
+	defer hbStore.Close()
 	defer otStore.Close()
+	defer cancel()
 
 	hbWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_PROCESSORS", hbWatcherCh)
 	assert.NoError(t, err)
@@ -267,35 +257,28 @@ func TestProcessorManagerWatchForReduce(t *testing.T) {
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
 	var processorManager = NewProcessorManager(ctx, storeWatcher, WithIsReduce(true), WithVertexReplica(2))
 	// start p1 heartbeat for 3 loops
-	wg.Add(1)
 	go func(ctx context.Context) {
-		defer wg.Done()
-		var err error
 		for {
 			select {
+			case <-time.After(1 * time.Second):
+				err := hbStore.PutKV(ctx, "p1", []byte(fmt.Sprintf("%d", time.Now().Unix())))
+				assert.NoError(t, err)
 			case <-ctx.Done():
 				return
-			default:
-				err = hbStore.PutKV(ctx, "p1", []byte(fmt.Sprintf("%d", time.Now().Unix())))
-				assert.NoError(t, err)
-				time.Sleep(1 * time.Second)
 			}
 		}
 	}(ctx)
 
-	// start p2 heartbeat for 20 loops (20 seconds)
-	wg.Add(1)
+	// start p2 heartbeat
 	go func(ctx context.Context) {
-		defer wg.Done()
 		var err error
 		for {
 			select {
-			case <-ctx.Done():
-				return
-			default:
+			case <-time.After(1 * time.Second):
 				err = hbStore.PutKV(ctx, "p2", []byte(fmt.Sprintf("%d", time.Now().Unix())))
 				assert.NoError(t, err)
-				time.Sleep(1 * time.Second)
+			case <-ctx.Done():
+				return
 			}
 		}
 	}(ctx)
@@ -358,5 +341,4 @@ func TestProcessorManagerWatchForReduce(t *testing.T) {
 	}, processorManager.GetProcessor("p2").GetOffsetTimeline().GetHeadWMB())
 	processorManager.DeleteProcessor("p1")
 	processorManager.DeleteProcessor("p2")
-	cancel()
 }


### PR DESCRIPTION
Processor manager unit test is flaky. [sample run](https://github.com/KeranYang/numaflow/actions/runs/5156561831/jobs/9287719331)

The error message is as follow:

```
=== RUN   TestProcessorManagerWatchForMap
panic: send on closed channel

goroutine 9 [running]:
github.com/numaproj/numaflow/pkg/watermark/store/inmem.(*inMemStore).PutKV(0xc00011f4a0, {0xc0001ea016?, 0xa?}, {0x1425c15, 0x2}, {0xc0001ea020, 0xa, 0x0?})
	/home/runner/work/numaflow/numaflow/pkg/watermark/store/inmem/kv_store.go:134 +0x230
github.com/numaproj/numaflow/pkg/watermark/processor.TestProcessorManager.func2()
	/home/runner/work/numaflow/numaflow/pkg/watermark/processor/processor_manager_test.go:88 +0x174
created by github.com/numaproj/numaflow/pkg/watermark/processor.TestProcessorManager
	/home/runner/work/numaflow/numaflow/pkg/watermark/processor/processor_manager_test.go:84 +0x7a6
FAIL	github.com/numaproj/numaflow/pkg/watermark/processor	3.054s
```

Channel gets closed while one of the goroutines is still sending messages. This PR replaces the `time.Sleep` call with a `select` that waits either for the sleep duration to elapse or for the context to be cancelled, whichever comes first. If the context is cancelled and channel gets closed, the goroutine immediately returns and avoids the potential leak.
