### PR TITLE
fix: duplicate ui served from gin Router

### DIFF
--- a/server/cmd/start.go
+++ b/server/cmd/start.go
@@ -42,9 +42,11 @@ func Start(insecure bool, port int, namespaced bool, managedNamespace string, ba
 	router.Use(gin.LoggerWithConfig(gin.LoggerConfig{SkipPaths: []string{"/livez"}}))
 	router.RedirectTrailingSlash = true
 	router.Use(static.Serve(baseHref, static.LocalFile("./ui/build", true)))
-	router.NoRoute(func(c *gin.Context) {
-		c.File("./ui/build/index.html")
-	})
+	if baseHref != "/" {
+		router.NoRoute(func(c *gin.Context) {
+			c.File("./ui/build/index.html")
+		})
+	}
 	routes.Routes(router, routes.SystemInfo{ManagedNamespace: managedNamespace, Namespaced: namespaced})
 	router.Use(UrlRewrite(router))
 	server := http.Server{

--- a/ui/src/components/common/Breadcrumbs/index.tsx
+++ b/ui/src/components/common/Breadcrumbs/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { useLocation, Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import MUIBreadcrumbs from "@mui/material/Breadcrumbs";
 import Typography from "@mui/material/Typography";
 
@@ -22,6 +22,8 @@ export function Breadcrumbs() {
       );
     }
     const pathParts = pathname.split("/");
+    // safety check for trailing slash
+    if (pathname.charAt(pathname.length - 1) === "/") pathParts.pop();
     switch (pathParts.length) {
       case 5: // pipeline view
         return [

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -21,7 +21,6 @@ const theme = createTheme({
       main: "#0077C5",
     },
   },
-
 });
 
 root.render(


### PR DESCRIPTION
Currently, on refresh we return index.html (default HTML file in your browser when visiting any directory on a web server) content twice when we don't set the baseHref like in this response. This caused all the calls in the UI to be run twice (meaning duplicate logs and API calls). This PR fixes the routing.
![image](https://github.com/numaproj/numaflow/assets/49195734/c4cd597c-1fb8-4ce3-bb21-6ca3b39ce2c0)


Also added a safety check to the Breadcrumbs component, to provide correct navigation for trailing slashes.
(`Unknown -> Namespaces > default (simple-pipeline)`)
<img width="1403" alt="image" src="https://github.com/numaproj/numaflow/assets/49195734/89c8fc4e-5975-4b77-90cb-95f487a2c230">