### PR TITLE
chore: this is no longer an error messages now that there are multiple goroutines publishing to Offset Timeline

### DIFF
--- a/pkg/watermark/timeline/offset_timeline.go
+++ b/pkg/watermark/timeline/offset_timeline.go
@@ -85,6 +85,12 @@ func (t *OffsetTimeline) Put(node wmb.WMB) {
 				}
 				return
 			} else {
+				// This can happen if the publisher of the watermark is a Map Vertex reading from >1 partition. In that case, there is one goroutine per
+				// partition and the following example can happen some of the time for two goroutines G1 and G2 both publishing to the same OffsetTimeline:
+				// 1. G1 determines watermark x and publishes to offsets 100-101
+				// 2. G2 determines watermark x and publishes to offsets 102-103
+				// 3. G2 publishes watermark x for offset 103
+				// 4. G1 publishes watermark x for offset 101
 				t.log.Debugw("Watermark the same but Input offset smaller than the existing offset - skipping", zap.Int64("watermark", node.Watermark),
 					zap.Int64("existingOffset", elementNode.Offset), zap.Int64("inputOffset", node.Offset))
 				return

--- a/pkg/watermark/timeline/offset_timeline.go
+++ b/pkg/watermark/timeline/offset_timeline.go
@@ -85,7 +85,7 @@ func (t *OffsetTimeline) Put(node wmb.WMB) {
 				}
 				return
 			} else {
-				t.log.Errorw("The new input offset should never be smaller than the existing offset", zap.Int64("watermark", node.Watermark),
+				t.log.Debugw("Watermark the same but Input offset smaller than the existing offset - skipping", zap.Int64("watermark", node.Watermark),
 					zap.Int64("existingOffset", elementNode.Offset), zap.Int64("inputOffset", node.Offset))
 				return
 			}


### PR DESCRIPTION
It used to be the case that a given OffsetTimeline could be expected to reliably be published to the K/V store in increasing order of offset. This is no longer the case now that multiple goroutines (each reading from a different partition in a Map vertex) can publish to that OffsetTimeline. For example, take two goroutines G1 and G2 both publishing to the same OffsetTimeline:  

- G1 determines watermark x and publishes to offsets 100-101
- G2 determines watermark y and publishes to offsets 102-103
- G2 publishes watermark y for offset 103
- G1 publishes watermark x for offset 101

This PR addresses the case where watermark x = y. The receiver of the OffsetTimeline in this case will see offset 103 prior to offset 101. This should not be considered an error.

Note this error is seen in the log occasionally if [this](https://github.com/numaproj/numaflow/blob/main/test/reduce-e2e/testdata/simple-keyed-reduce-pipeline.yaml) e2e test pipeline is modified to set 2 partitions for `atoi` vertex (i.e. 2 goroutines publishing).

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
