### PR TITLE
fix: minor ui bugs

### DIFF
--- a/ui/src/components/pages/Namespace/partials/NamespaceRowContent/index.tsx
+++ b/ui/src/components/pages/Namespace/partials/NamespaceRowContent/index.tsx
@@ -30,22 +30,22 @@ export function NamespaceRowContent(props: NamespaceRowContentProps) {
           fontSize: "1rem",
         }}
       >
+        <Box
+          sx={{
+            fontWeight: 400,
+            fontSize: "0.8rem",
+            color: "#0000008a",
+            width: "fit-content",
+            mx: "1rem",
+          }}
+        >
+          Pipelines
+        </Box>
         <List>
           {pipelines &&
             pipelines.map((pipelineId, idx) => {
               return (
                 <div key={`ns-row-list-${idx}`}>
-                  <Box
-                    sx={{
-                      fontWeight: 400,
-                      fontSize: "0.8rem",
-                      color: "#0000008a",
-                      width: "fit-content",
-                      mx: "1rem",
-                    }}
-                  >
-                    Pipelines
-                  </Box>
                   <ListItem key={pipelineId}>
                     <Link
                       to={`/namespaces/${namespaceId}/pipelines/${pipelineId}`}

--- a/ui/src/utils/fetcherHooks/pipelineViewFetch.ts
+++ b/ui/src/utils/fetcherHooks/pipelineViewFetch.ts
@@ -142,11 +142,13 @@ export const usePipelineViewFetch = (
           if (podsErr.length > 0) setPodsErr(podsErr);
         })
         .then(() => {
-          setVertexPods(vertexToPodsMap);
+          if (!isEqual(vertexPods, vertexToPodsMap)) {
+            setVertexPods(vertexToPodsMap);
+          }
         })
         .catch(console.error);
     }
-  }, [spec]);
+  }, [spec, requestKey]);
 
   const getVertexMetrics = useCallback(() => {
     const vertexToMetricsMap = new Map();


### PR DESCRIPTION
- Querying for pods of a vertex with a 30sec periodic refresh, removes the need to refresh the webpage to see updated pod counts
![image](https://github.com/numaproj/numaflow/assets/49195734/4e07958d-dc94-4375-9da4-1ba42f16903d)
- Removed multiple pipeline labels seen when searching for a namespace

![image](https://github.com/numaproj/numaflow/assets/49195734/6c347046-c08e-42f4-b5d5-6754a17ffec4)
![image](https://github.com/numaproj/numaflow/assets/49195734/2c72b2c0-e9af-46f2-8cdf-e66b74e26e8e)
