### PR TITLE
fix: avoid potential deadlocks when operating UniqueStringList

### DIFF
--- a/pkg/daemon/server/service/rater/uniq_str_list.go
+++ b/pkg/daemon/server/service/rater/uniq_str_list.go
@@ -59,7 +59,7 @@ func (l *UniqueStringList) MoveToBack(value string) {
 func (l *UniqueStringList) Front() string {
 	l.lock.RLock()
 	defer l.lock.RUnlock()
-	if l.Length() == 0 {
+	if l.l.Len() == 0 {
 		return ""
 	}
 	return l.l.Front().Value.(string)


### PR DESCRIPTION
Fixes #863 

See https://github.com/numaproj/numaflow/issues/863#issuecomment-1658656984 for more details about the root cause.