### PR TITLE
fix: retry logic for fetching last updated kv time

### DIFF
--- a/pkg/shared/kvs/jetstream/kv_watch.go
+++ b/pkg/shared/kvs/jetstream/kv_watch.go
@@ -207,7 +207,13 @@ func (jsw *jetStreamWatch) newWatcher(ctx context.Context) nats.KeyWatcher {
 
 // lastUpdateKVTime returns the last update time of the kv store
 func (jsw *jetStreamWatch) lastUpdateKVTime() time.Time {
-	keys, err := jsw.kvStore.Keys()
+	var (
+		keys       []string
+		err        error
+		lastUpdate time.Time
+		value      nats.KeyValueEntry
+	)
+
 retryLoop:
 	for {
 		select {
@@ -230,9 +236,8 @@ retryLoop:
 
 	}
 
-	var lastUpdate = time.Time{}
 	for _, key := range keys {
-		value, err := jsw.kvStore.Get(key)
+		value, err = jsw.kvStore.Get(key)
 		for err != nil {
 			select {
 			case <-jsw.ctx.Done():

--- a/pkg/shared/kvs/jetstream/kv_watch.go
+++ b/pkg/shared/kvs/jetstream/kv_watch.go
@@ -205,7 +205,7 @@ func (jsw *jetStreamWatch) newWatcher(ctx context.Context) nats.KeyWatcher {
 	return kvWatcher
 }
 
-// lastUpdateKVTime returns the last update time of the kv store
+// lastUpdateKVTime returns the last update time of the kv store. if the key is missing, it will return time.Zero.
 func (jsw *jetStreamWatch) lastUpdateKVTime() time.Time {
 	var (
 		keys       []string

--- a/pkg/sources/forward/data_forward_test.go
+++ b/pkg/sources/forward/data_forward_test.go
@@ -225,6 +225,12 @@ func TestNewDataForward(t *testing.T) {
 			fetchWatermark := &testForwardFetcher{}
 			publishWatermark, otStores := buildPublisherMapAndOTStore(toSteps)
 
+			defer func() {
+				for _, p := range publishWatermark {
+					_ = p.Close()
+				}
+			}()
+
 			f, err := NewDataForward(vertex, fromStep, toSteps, &myForwardToAllTest{}, &myForwardToAllTest{}, fetchWatermark, publishWatermark, TestSourceWatermarkPublisher{}, WithReadBatchSize(batchSize))
 
 			assert.NoError(t, err)
@@ -371,6 +377,13 @@ func TestNewDataForward(t *testing.T) {
 
 			fetchWatermark := &testForwardFetcher{}
 			publishWatermark, otStores := buildPublisherMapAndOTStore(toSteps)
+
+			defer func() {
+				for _, p := range publishWatermark {
+					_ = p.Close()
+				}
+			}()
+
 			f, err := NewDataForward(vertex, fromStep, toSteps, myForwardDropTest{}, myForwardDropTest{}, fetchWatermark, publishWatermark, TestSourceWatermarkPublisher{}, WithReadBatchSize(batchSize))
 
 			assert.NoError(t, err)
@@ -529,6 +542,13 @@ func TestNewDataForward(t *testing.T) {
 
 			fetchWatermark := &testForwardFetcher{}
 			publishWatermark, otStores := buildPublisherMapAndOTStore(toSteps)
+
+			defer func() {
+				for _, p := range publishWatermark {
+					_ = p.Close()
+				}
+			}()
+
 			f, err := NewDataForward(vertex, fromStep, toSteps, &mySourceForwardTestRoundRobin{}, myForwardTest{}, fetchWatermark, publishWatermark, TestSourceWatermarkPublisher{}, WithReadBatchSize(batchSize))
 
 			assert.NoError(t, err)


### PR DESCRIPTION
if there are no keys in the store we should not retry while trying to calculate the last updated kv time.

Signed-off-by: Yashash H L <yashashhl25@gmail.com>