### PR TITLE
refactor: build wmstore and wmstorewatcher directly, and remove some unnecessary fields 

### DIFF
--- a/cmd/commands/daemon_server.go
+++ b/cmd/commands/daemon_server.go
@@ -39,13 +39,11 @@ func NewDaemonServerCommand() *cobra.Command {
 		Use:   "daemon-server",
 		Short: "Start the daemon server",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := logging.NewLogger().Named("daemon-server")
-
 			pl, err := decodePipeline()
 			if err != nil {
 				return fmt.Errorf("failed to decode the pipeline spec: %v", err)
 			}
-
+			logger := logging.NewLogger().Named("daemon-server").With("pipeline", pl.Name)
 			ctx := logging.WithLogger(signals.SetupSignalHandler(), logger)
 			server := server.NewDaemonServer(pl, v1alpha1.ISBSvcType(isbSvcType))
 			return server.Run(ctx)

--- a/cmd/commands/isbsvc_create.go
+++ b/cmd/commands/isbsvc_create.go
@@ -45,11 +45,11 @@ func NewISBSvcCreateCommand() *cobra.Command {
 		Use:   "isbsvc-create",
 		Short: "Create buffers, buckets and side inputs store",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := logging.NewLogger().Named("isbsvc-create")
 			pipelineName, defined := os.LookupEnv(v1alpha1.EnvPipelineName)
 			if !defined {
 				return fmt.Errorf("required environment variable '%s' not defined", v1alpha1.EnvPipelineName)
 			}
+			logger := logging.NewLogger().Named("isbsvc-create").With("pipeline", pipelineName)
 			isbSvcConfig := &v1alpha1.BufferServiceConfig{}
 			encodedBufferServiceConfig := os.Getenv(v1alpha1.EnvISBSvcConfig)
 			if len(encodedBufferServiceConfig) > 0 {

--- a/cmd/commands/isbsvc_delete.go
+++ b/cmd/commands/isbsvc_delete.go
@@ -42,11 +42,11 @@ func NewISBSvcDeleteCommand() *cobra.Command {
 		Use:   "isbsvc-delete",
 		Short: "Delete ISB Service buffers, buckets and side inputs store",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := logging.NewLogger().Named("isbsvc-delete")
 			pipelineName, defined := os.LookupEnv(v1alpha1.EnvPipelineName)
 			if !defined {
 				return fmt.Errorf("required environment variable '%s' not defined", v1alpha1.EnvPipelineName)
 			}
+			logger := logging.NewLogger().Named("isbsvc-delete").With("pipeline", pipelineName)
 			var isbsClient isbsvc.ISBService
 			var err error
 			ctx := logging.WithLogger(context.Background(), logger)

--- a/cmd/commands/isbsvc_validate.go
+++ b/cmd/commands/isbsvc_validate.go
@@ -45,11 +45,11 @@ func NewISBSvcValidateCommand() *cobra.Command {
 		Use:   "isbsvc-validate",
 		Short: "Validate ISB Service buffers, buckets and side inputs store",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := logging.NewLogger().Named("isbsvc-validate")
 			pipelineName, existing := os.LookupEnv(v1alpha1.EnvPipelineName)
 			if !existing {
 				return fmt.Errorf("environment variable %q not existing", v1alpha1.EnvPipelineName)
 			}
+			logger := logging.NewLogger().Named("isbsvc-validate").With("pipeline", pipelineName)
 			var isbsClient isbsvc.ISBService
 			var err error
 			ctx := logging.WithLogger(context.Background(), logger)

--- a/cmd/commands/processor.go
+++ b/cmd/commands/processor.go
@@ -68,7 +68,7 @@ func NewProcessorCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("invalid replica %q", replicaStr)
 			}
-			log = log.With("vertex", vertex.Name)
+			log = log.With("pipeline", vertex.Spec.PipelineName).With("vertex", vertex.Spec.Name)
 			vertexInstance := &dfv1.VertexInstance{
 				Vertex:   vertex,
 				Hostname: hostname,

--- a/cmd/commands/side_inputs_init.go
+++ b/cmd/commands/side_inputs_init.go
@@ -37,7 +37,6 @@ func NewSideInputsInitCommand() *cobra.Command {
 		Use:   "side-inputs-init",
 		Short: "Start the Side Inputs init service",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := logging.NewLogger().Named("side-inputs-init")
 
 			pipelineName, defined := os.LookupEnv(dfv1.EnvPipelineName)
 			if !defined {
@@ -47,7 +46,7 @@ func NewSideInputsInitCommand() *cobra.Command {
 			if len(sideInputs) == 0 {
 				return fmt.Errorf("no side inputs are defined for this vertex")
 			}
-
+			logger := logging.NewLogger().Named("side-inputs-init").With("pipeline", pipelineName)
 			ctx := logging.WithLogger(context.Background(), logger)
 			sideInputsInitializer := initializer.NewSideInputsInitializer(dfv1.ISBSvcType(isbSvcType), pipelineName, sideInputsStore, sideInputs)
 			return sideInputsInitializer.Run(ctx)

--- a/cmd/commands/side_inputs_manager.go
+++ b/cmd/commands/side_inputs_manager.go
@@ -39,8 +39,6 @@ func NewSideInputsManagerCommand() *cobra.Command {
 		Use:   "side-inputs-manager",
 		Short: "Start a Side Inputs Manager",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := logging.NewLogger().Named("side-inputs-manager")
-
 			encodedSiceInputSpec, defined := os.LookupEnv(dfv1.EnvSideInputObject)
 			if !defined {
 				return fmt.Errorf("environment %q is not defined", dfv1.EnvSideInputObject)
@@ -58,6 +56,8 @@ func NewSideInputsManagerCommand() *cobra.Command {
 			if !defined {
 				return fmt.Errorf("environment %q is not defined", dfv1.EnvPipelineName)
 			}
+
+			logger := logging.NewLogger().Named("side-inputs-manager").With("pipeline", pipelineName)
 
 			ctx := logging.WithLogger(signals.SetupSignalHandler(), logger)
 			sideInputManager := manager.NewSideInputsManager(dfv1.ISBSvcType(isbSvcType), pipelineName, sideInputsStore, sideInput)

--- a/cmd/commands/side_inputs_watcher.go
+++ b/cmd/commands/side_inputs_watcher.go
@@ -38,8 +38,6 @@ func NewSideInputsWatcherCommand() *cobra.Command {
 		Use:   "side-inputs-watcher",
 		Short: "Start the Side Inputs Watcher",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := logging.NewLogger().Named("side-inputs-watcher")
-
 			pipelineName, defined := os.LookupEnv(dfv1.EnvPipelineName)
 			if !defined {
 				return fmt.Errorf("environment %q is not defined", dfv1.EnvPipelineName)
@@ -49,6 +47,7 @@ func NewSideInputsWatcherCommand() *cobra.Command {
 				return fmt.Errorf("no side inputs are defined for this vertex")
 			}
 
+			logger := logging.NewLogger().Named("side-inputs-watcher").With("pipeline", pipelineName)
 			ctx := logging.WithLogger(signals.SetupSignalHandler(), logger)
 			sideInputsWatcher := synchronizer.NewSideInputsSynchronizer(dfv1.ISBSvcType(isbSvcType), pipelineName, sideInputsStore, sideInputs)
 			return sideInputsWatcher.Start(ctx)

--- a/pkg/forward/forward_test.go
+++ b/pkg/forward/forward_test.go
@@ -1601,7 +1601,7 @@ func buildPublisherMapAndOTStore(toBuffers map[string][]isb.BufferWriter) (map[s
 	publishers := make(map[string]publish.Publisher)
 	otStores := make(map[string]kvs.KVStorer)
 	for key, partitionedBuffers := range toBuffers {
-		store, _, _, _ := wmstore.BuildInmemWatermarkStore(ctx, testPipelineName, fmt.Sprintf(publisherKeyspace, key))
+		store, _, _, _ := wmstore.BuildInmemWatermarkStore(ctx, fmt.Sprintf(publisherKeyspace, key))
 		otStores[key] = store.OffsetTimelineStore()
 		p := publish.NewPublish(ctx, processorEntity, store, int32(len(partitionedBuffers)), publish.WithAutoRefreshHeartbeatDisabled(), publish.WithPodHeartbeatRate(1))
 		publishers[key] = p

--- a/pkg/isbsvc/jetstream_service.go
+++ b/pkg/isbsvc/jetstream_service.go
@@ -327,12 +327,12 @@ func (jss *jetStreamSvc) CreateProcessorManagers(ctx context.Context, bucketName
 	// if it's not a reduce vertex, we don't need multiple watermark fetchers. We use common fetcher among all partitions.
 	for i := 0; i < fetchers; i++ {
 		hbKVName := JetStreamProcessorKVName(bucketName)
-		hbWatch, err := jetstream.NewKVJetStreamKVWatch(ctx, jss.pipelineName, hbKVName, jss.jsClient)
+		hbWatch, err := jetstream.NewKVJetStreamKVWatch(ctx, hbKVName, jss.jsClient)
 		if err != nil {
 			return nil, err
 		}
 		otKVName := JetStreamOTKVName(bucketName)
-		otWatch, err := jetstream.NewKVJetStreamKVWatch(ctx, jss.pipelineName, otKVName, jss.jsClient)
+		otWatch, err := jetstream.NewKVJetStreamKVWatch(ctx, otKVName, jss.jsClient)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/isbsvc/jetstream_service.go
+++ b/pkg/isbsvc/jetstream_service.go
@@ -317,6 +317,8 @@ func (jss *jetStreamSvc) GetBufferInfo(ctx context.Context, buffer string) (*Buf
 
 // CreateProcessorManagers is used to create processor manager for the given bucket.
 func (jss *jetStreamSvc) CreateProcessorManagers(ctx context.Context, bucketName string, fromBufferPartitionCount int, isReduce bool) ([]*processor.ProcessorManager, error) {
+	log := logging.FromContext(ctx).With("bucket", bucketName)
+	ctx = logging.WithLogger(ctx, log)
 	var processorManagers []*processor.ProcessorManager
 	fetchers := 1
 	if isReduce {
@@ -337,9 +339,9 @@ func (jss *jetStreamSvc) CreateProcessorManagers(ctx context.Context, bucketName
 		storeWatcher := store.BuildWatermarkStoreWatcher(hbWatch, otWatch)
 		var pm *processor.ProcessorManager
 		if isReduce {
-			pm = processor.NewProcessorManager(ctx, storeWatcher, bucketName, int32(fromBufferPartitionCount), processor.WithVertexReplica(int32(i)), processor.WithIsReduce(isReduce))
+			pm = processor.NewProcessorManager(ctx, storeWatcher, int32(fromBufferPartitionCount), processor.WithVertexReplica(int32(i)), processor.WithIsReduce(isReduce))
 		} else {
-			pm = processor.NewProcessorManager(ctx, storeWatcher, bucketName, int32(fromBufferPartitionCount))
+			pm = processor.NewProcessorManager(ctx, storeWatcher, int32(fromBufferPartitionCount))
 		}
 		processorManagers = append(processorManagers, pm)
 	}

--- a/pkg/isbsvc/jetstream_service.go
+++ b/pkg/isbsvc/jetstream_service.go
@@ -28,10 +28,9 @@ import (
 	"go.uber.org/zap"
 
 	jsclient "github.com/numaproj/numaflow/pkg/shared/clients/nats"
-	"github.com/numaproj/numaflow/pkg/shared/kvs/jetstream"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 	"github.com/numaproj/numaflow/pkg/watermark/processor"
-	"github.com/numaproj/numaflow/pkg/watermark/store"
+	wmstore "github.com/numaproj/numaflow/pkg/watermark/store"
 )
 
 type jetStreamSvc struct {
@@ -146,7 +145,7 @@ func (jss *jetStreamSvc) CreateBuffersAndBuckets(ctx context.Context, buffers, b
 
 	for _, bucket := range buckets {
 		// Create offset-timeline KV
-		otKVName := JetStreamOTKVName(bucket)
+		otKVName := wmstore.JetStreamOTKVName(bucket)
 		if _, err := js.KeyValue(otKVName); err != nil {
 			if !errors.Is(err, nats.ErrBucketNotFound) && !errors.Is(err, nats.ErrStreamNotFound) {
 				return fmt.Errorf("failed to query information of bucket %q during buffer creating, %w", otKVName, err)
@@ -165,7 +164,7 @@ func (jss *jetStreamSvc) CreateBuffersAndBuckets(ctx context.Context, buffers, b
 			}
 		}
 		// Create processor KV
-		procKVName := JetStreamProcessorKVName(bucket)
+		procKVName := wmstore.JetStreamProcessorKVName(bucket)
 		if _, err := js.KeyValue(procKVName); err != nil {
 			if !errors.Is(err, nats.ErrBucketNotFound) && !errors.Is(err, nats.ErrStreamNotFound) {
 				return fmt.Errorf("failed to query information of bucket %q during buffer creating, %w", procKVName, err)
@@ -209,12 +208,12 @@ func (jss *jetStreamSvc) DeleteBuffersAndBuckets(ctx context.Context, buffers, b
 		log.Infow("Succeeded to delete a stream", zap.String("stream", streamName))
 	}
 	for _, bucket := range buckets {
-		otKVName := JetStreamOTKVName(bucket)
+		otKVName := wmstore.JetStreamOTKVName(bucket)
 		if err := js.DeleteKeyValue(otKVName); err != nil && !errors.Is(err, nats.ErrBucketNotFound) && !errors.Is(err, nats.ErrStreamNotFound) {
 			return fmt.Errorf("failed to delete offset timeline KV %q, %w", otKVName, err)
 		}
 		log.Infow("Succeeded to delete an offset timeline KV", zap.String("kvName", otKVName))
-		procKVName := JetStreamProcessorKVName(bucket)
+		procKVName := wmstore.JetStreamProcessorKVName(bucket)
 		if err := js.DeleteKeyValue(procKVName); err != nil && !errors.Is(err, nats.ErrBucketNotFound) && !errors.Is(err, nats.ErrStreamNotFound) {
 			return fmt.Errorf("failed to delete processor KV %q, %w", procKVName, err)
 		}
@@ -251,12 +250,12 @@ func (jss *jetStreamSvc) ValidateBuffersAndBuckets(ctx context.Context, buffers,
 		}
 	}
 	for _, bucket := range buckets {
-		otKVName := JetStreamOTKVName(bucket)
+		otKVName := wmstore.JetStreamOTKVName(bucket)
 		if _, err := js.KeyValue(otKVName); err != nil {
 			return fmt.Errorf("failed to query OT KV %q, %w", otKVName, err)
 		}
 
-		procKVName := JetStreamProcessorKVName(bucket)
+		procKVName := wmstore.JetStreamProcessorKVName(bucket)
 		if _, err := js.KeyValue(procKVName); err != nil {
 			return fmt.Errorf("failed to query processor KV %q, %w", procKVName, err)
 		}
@@ -326,17 +325,10 @@ func (jss *jetStreamSvc) CreateProcessorManagers(ctx context.Context, bucketName
 	}
 	// if it's not a reduce vertex, we don't need multiple watermark fetchers. We use common fetcher among all partitions.
 	for i := 0; i < fetchers; i++ {
-		hbKVName := JetStreamProcessorKVName(bucketName)
-		hbWatch, err := jetstream.NewKVJetStreamKVWatch(ctx, hbKVName, jss.jsClient)
+		storeWatcher, err := wmstore.BuildJetStreamWatermarkStoreWatcher(ctx, bucketName, jss.jsClient)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed at new JetStream watermark store watcher, %w", err)
 		}
-		otKVName := JetStreamOTKVName(bucketName)
-		otWatch, err := jetstream.NewKVJetStreamKVWatch(ctx, otKVName, jss.jsClient)
-		if err != nil {
-			return nil, err
-		}
-		storeWatcher := store.BuildWatermarkStoreWatcher(hbWatch, otWatch)
 		var pm *processor.ProcessorManager
 		if isReduce {
 			pm = processor.NewProcessorManager(ctx, storeWatcher, int32(fromBufferPartitionCount), processor.WithVertexReplica(int32(i)), processor.WithIsReduce(isReduce))
@@ -350,14 +342,6 @@ func (jss *jetStreamSvc) CreateProcessorManagers(ctx context.Context, bucketName
 
 func JetStreamName(bufferName string) string {
 	return bufferName
-}
-
-func JetStreamOTKVName(bucketName string) string {
-	return fmt.Sprintf("%s_OT", bucketName)
-}
-
-func JetStreamProcessorKVName(bucketName string) string {
-	return fmt.Sprintf("%s_PROCESSORS", bucketName)
 }
 
 func JetStreamSideInputsStoreKVName(sideInputStoreName string) string {

--- a/pkg/isbsvc/redis_service.go
+++ b/pkg/isbsvc/redis_service.go
@@ -141,6 +141,8 @@ func (r *isbsRedisSvc) GetBufferInfo(ctx context.Context, buffer string) (*Buffe
 
 // CreateProcessorManagers is used to create the processor managers for the given bucket.
 func (r *isbsRedisSvc) CreateProcessorManagers(ctx context.Context, bucketName string, fromBufferPartitionCount int, isReduce bool) ([]*processor.ProcessorManager, error) {
+	log := logging.FromContext(ctx).With("bucket", bucketName)
+	ctx = logging.WithLogger(ctx, log)
 	// Watermark fetching is not supported for Redis ATM. Creating noop watermark fetcher.
 	var processorManagers []*processor.ProcessorManager
 	fetchers := 1
@@ -153,9 +155,9 @@ func (r *isbsRedisSvc) CreateProcessorManagers(ctx context.Context, bucketName s
 		storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
 		var pm *processor.ProcessorManager
 		if isReduce {
-			pm = processor.NewProcessorManager(ctx, storeWatcher, bucketName, int32(fromBufferPartitionCount), processor.WithVertexReplica(int32(i)), processor.WithIsReduce(isReduce))
+			pm = processor.NewProcessorManager(ctx, storeWatcher, int32(fromBufferPartitionCount), processor.WithVertexReplica(int32(i)), processor.WithIsReduce(isReduce))
 		} else {
-			pm = processor.NewProcessorManager(ctx, storeWatcher, bucketName, int32(fromBufferPartitionCount))
+			pm = processor.NewProcessorManager(ctx, storeWatcher, int32(fromBufferPartitionCount))
 		}
 		processorManagers = append(processorManagers, pm)
 	}

--- a/pkg/isbsvc/redis_service.go
+++ b/pkg/isbsvc/redis_service.go
@@ -24,12 +24,10 @@ import (
 	"go.uber.org/zap"
 
 	redis2 "github.com/numaproj/numaflow/pkg/isb/stores/redis"
-	"github.com/numaproj/numaflow/pkg/shared/kvs/noop"
-	"github.com/numaproj/numaflow/pkg/watermark/processor"
-	"github.com/numaproj/numaflow/pkg/watermark/store"
-
 	redisclient "github.com/numaproj/numaflow/pkg/shared/clients/redis"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
+	"github.com/numaproj/numaflow/pkg/watermark/processor"
+	"github.com/numaproj/numaflow/pkg/watermark/store"
 )
 
 type isbsRedisSvc struct {
@@ -150,9 +148,7 @@ func (r *isbsRedisSvc) CreateProcessorManagers(ctx context.Context, bucketName s
 		fetchers = fromBufferPartitionCount
 	}
 	for i := 0; i < fetchers; i++ {
-		hbWatcher := noop.NewKVOpWatch()
-		otWatcher := noop.NewKVOpWatch()
-		storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
+		storeWatcher, _ := store.BuildNoOpWatermarkStoreWatcher()
 		var pm *processor.ProcessorManager
 		if isReduce {
 			pm = processor.NewProcessorManager(ctx, storeWatcher, int32(fromBufferPartitionCount), processor.WithVertexReplica(int32(i)), processor.WithIsReduce(isReduce))

--- a/pkg/reduce/data_forward_test.go
+++ b/pkg/reduce/data_forward_test.go
@@ -1284,7 +1284,7 @@ func fetcherAndPublisher(ctx context.Context, fromBuffer *simplebuffer.InMemoryB
 	)
 
 	sourcePublishEntity := processor.NewProcessorEntity(fromBuffer.GetName())
-	store, hbWatcherCh, otWatcherCh, _ := wmstore.BuildInmemWatermarkStore(ctx, pipelineName, keyspace)
+	store, hbWatcherCh, otWatcherCh, _ := wmstore.BuildInmemWatermarkStore(ctx, keyspace)
 
 	// publisher for source
 	sourcePublisher := publish.NewPublish(ctx, sourcePublishEntity, store, 1, publish.WithAutoRefreshHeartbeatDisabled())
@@ -1302,7 +1302,7 @@ func fetcherAndPublisher(ctx context.Context, fromBuffer *simplebuffer.InMemoryB
 		}
 	}()
 
-	storeWatcher, _ := wmstore.BuildInmemWatermarkStoreWatcher(ctx, pipelineName, keyspace, hbWatcherCh, otWatcherCh)
+	storeWatcher, _ := wmstore.BuildInmemWatermarkStoreWatcher(ctx, keyspace, hbWatcherCh, otWatcherCh)
 	pm := processor.NewProcessorManager(ctx, storeWatcher, 1, processor.WithIsReduce(true))
 	for waitForReadyP := pm.GetProcessor(fromBuffer.GetName()); waitForReadyP == nil; waitForReadyP = pm.GetProcessor(fromBuffer.GetName()) {
 		// wait until the test processor has been added to the processor list
@@ -1330,7 +1330,7 @@ func buildPublisherMapAndOTStore(ctx context.Context, toBuffers map[string][]isb
 	index := int32(0)
 	for key, partitionedBuffers := range toBuffers {
 		publishEntity := processor.NewProcessorEntity(key)
-		store, hbKVEntry, otKVEntry, _ := wmstore.BuildInmemWatermarkStore(ctx, pipelineName, key)
+		store, hbKVEntry, otKVEntry, _ := wmstore.BuildInmemWatermarkStore(ctx, key)
 		otStores[key] = store.OffsetTimelineStore()
 		p := publish.NewPublish(ctx, publishEntity, store, int32(len(partitionedBuffers)), publish.WithAutoRefreshHeartbeatDisabled(), publish.WithPodHeartbeatRate(1))
 		publishers[key] = p

--- a/pkg/reduce/data_forward_test.go
+++ b/pkg/reduce/data_forward_test.go
@@ -1309,7 +1309,7 @@ func fetcherAndPublisher(ctx context.Context, fromBuffer *simplebuffer.InMemoryB
 	hbWatcher, _ := inmem.NewInMemWatch(ctx, pipelineName, keyspace+"_PROCESSORS", hbWatcherCh)
 	otWatcher, _ := inmem.NewInMemWatch(ctx, pipelineName, keyspace+"_OT", otWatcherCh)
 	storeWatcher := wmstore.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
-	pm := processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", 1, processor.WithIsReduce(true))
+	pm := processor.NewProcessorManager(ctx, storeWatcher, 1, processor.WithIsReduce(true))
 	for waitForReadyP := pm.GetProcessor(fromBuffer.GetName()); waitForReadyP == nil; waitForReadyP = pm.GetProcessor(fromBuffer.GetName()) {
 		// wait until the test processor has been added to the processor list
 		time.Sleep(time.Millisecond * 100)

--- a/pkg/reduce/pnf/processandforward_test.go
+++ b/pkg/reduce/pnf/processandforward_test.go
@@ -452,7 +452,7 @@ func buildPublisherMapAndOTStore(toBuffers map[string][]isb.BufferWriter) (map[s
 	publishers := make(map[string]publish.Publisher)
 	otStores := make(map[string]kvs.KVStorer)
 	for key, partitionedBuffers := range toBuffers {
-		store, _, _, _ := wmstore.BuildInmemWatermarkStore(ctx, testPipelineName, publisherKeyspace)
+		store, _, _, _ := wmstore.BuildInmemWatermarkStore(ctx, publisherKeyspace)
 		otStores[key] = store.OffsetTimelineStore()
 		p := publish.NewPublish(ctx, processorEntity, store, int32(len(partitionedBuffers)), publish.WithAutoRefreshHeartbeatDisabled(), publish.WithPodHeartbeatRate(1))
 		publishers[key] = p

--- a/pkg/shared/kvs/inmem/kv_store.go
+++ b/pkg/shared/kvs/inmem/kv_store.go
@@ -25,9 +25,9 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/numaproj/numaflow/pkg/shared/kvs"
 	"go.uber.org/zap"
 
+	"github.com/numaproj/numaflow/pkg/shared/kvs"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 )
 

--- a/pkg/shared/kvs/inmem/kv_store.go
+++ b/pkg/shared/kvs/inmem/kv_store.go
@@ -55,25 +55,23 @@ func (k kvEntry) Operation() kvs.KVWatchOp {
 
 // inMemStore implements the watermark's KV store backed up by in mem store.
 type inMemStore struct {
-	pipelineName string
-	bucketName   string
-	kv           map[string][]byte
-	kvLock       sync.RWMutex
-	kvEntryCh    chan kvs.KVEntry
-	isClosed     bool
-	log          *zap.SugaredLogger
+	bucketName string
+	kv         map[string][]byte
+	kvLock     sync.RWMutex
+	kvEntryCh  chan kvs.KVEntry
+	isClosed   bool
+	log        *zap.SugaredLogger
 }
 
 var _ kvs.KVStorer = (*inMemStore)(nil)
 
 // NewKVInMemKVStore returns inMemStore.
-func NewKVInMemKVStore(ctx context.Context, pipelineName string, bucketName string) (kvs.KVStorer, chan kvs.KVEntry, error) {
+func NewKVInMemKVStore(ctx context.Context, bucketName string) (kvs.KVStorer, chan kvs.KVEntry, error) {
 	s := &inMemStore{
-		pipelineName: pipelineName,
-		bucketName:   bucketName,
-		kv:           make(map[string][]byte),
-		kvEntryCh:    make(chan kvs.KVEntry, 10),
-		log:          logging.FromContext(ctx).With("pipeline", pipelineName).With("bucketName", bucketName),
+		bucketName: bucketName,
+		kv:         make(map[string][]byte),
+		kvEntryCh:  make(chan kvs.KVEntry, 10),
+		log:        logging.FromContext(ctx).With("bucketName", bucketName),
 	}
 	return s, s.kvEntryCh, nil
 }

--- a/pkg/shared/kvs/inmem/kv_watch.go
+++ b/pkg/shared/kvs/inmem/kv_watch.go
@@ -29,7 +29,6 @@ import (
 
 // inMemWatch implements the watermark's KV store backed up by in memory store.
 type inMemWatch struct {
-	pipelineName string
 	bucketName   string
 	kvEntryCh    <-chan kvs.KVEntry
 	kvHistory    []kvs.KVEntry
@@ -42,15 +41,14 @@ type inMemWatch struct {
 var _ kvs.KVWatcher = (*inMemWatch)(nil)
 
 // NewInMemWatch returns inMemWatch which implements the KVWatcher interface.
-func NewInMemWatch(ctx context.Context, pipelineName string, bucketName string, kvEntryCh <-chan kvs.KVEntry) (kvs.KVWatcher, error) {
+func NewInMemWatch(ctx context.Context, bucketName string, kvEntryCh <-chan kvs.KVEntry) (kvs.KVWatcher, error) {
 	k := &inMemWatch{
-		pipelineName: pipelineName,
 		bucketName:   bucketName,
 		kvEntryCh:    kvEntryCh,
 		kvHistory:    []kvs.KVEntry{},
 		updatesChMap: make(map[string]chan kvs.KVEntry),
 		doneCh:       make(chan struct{}),
-		log:          logging.FromContext(ctx).With("pipeline", pipelineName).With("bucketName", bucketName),
+		log:          logging.FromContext(ctx).With("bucketName", bucketName),
 	}
 	return k, nil
 }

--- a/pkg/shared/kvs/jetstream/kv_store.go
+++ b/pkg/shared/kvs/jetstream/kv_store.go
@@ -42,11 +42,11 @@ type jetStreamStore struct {
 var _ kvs.KVStorer = (*jetStreamStore)(nil)
 
 // NewKVJetStreamKVStore returns KVJetStreamStore.
-func NewKVJetStreamKVStore(ctx context.Context, pipelineName string, kvName string, client *jsclient.NATSClient, opts ...JSKVStoreOption) (kvs.KVStorer, error) {
+func NewKVJetStreamKVStore(ctx context.Context, kvName string, client *jsclient.NATSClient, opts ...JSKVStoreOption) (kvs.KVStorer, error) {
 	var err error
 	var jsStore = &jetStreamStore{
 		client: client,
-		log:    logging.FromContext(ctx).With("pipeline", pipelineName).With("kvName", kvName),
+		log:    logging.FromContext(ctx).With("kvName", kvName),
 	}
 
 	// for JetStream KeyValue store, the bucket should have been created in advance

--- a/pkg/shared/kvs/jetstream/kv_watch.go
+++ b/pkg/shared/kvs/jetstream/kv_watch.go
@@ -45,7 +45,7 @@ type jetStreamWatch struct {
 var _ kvs.KVWatcher = (*jetStreamWatch)(nil)
 
 // NewKVJetStreamKVWatch returns KVJetStreamWatch specific to JetStream which implements the KVWatcher interface.
-func NewKVJetStreamKVWatch(ctx context.Context, pipelineName string, kvName string, client *jsclient.NATSClient, opts ...Option) (kvs.KVWatcher, error) {
+func NewKVJetStreamKVWatch(ctx context.Context, kvName string, client *jsclient.NATSClient, opts ...Option) (kvs.KVWatcher, error) {
 
 	kvOpts := defaultOptions()
 
@@ -66,7 +66,7 @@ func NewKVJetStreamKVWatch(ctx context.Context, pipelineName string, kvName stri
 		kvwTimer: time.NewTimer(kvOpts.watcherCreationThreshold),
 		opts:     kvOpts,
 		doneCh:   make(chan struct{}),
-		log:      logging.FromContext(ctx).With("pipeline", pipelineName).With("kvName", kvName),
+		log:      logging.FromContext(ctx).With("kvName", kvName),
 	}
 	return jsw, nil
 }

--- a/pkg/sideinputs/initializer/initializer.go
+++ b/pkg/sideinputs/initializer/initializer.go
@@ -80,7 +80,7 @@ func (sii *sideInputsInitializer) Run(ctx context.Context) error {
 	}
 	// Load the required KV bucket and create a sideInputWatcher for it
 	kvName := isbsvc.JetStreamSideInputsStoreKVName(sii.sideInputsStore)
-	sideInputWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, sii.pipelineName, kvName, natsClient)
+	sideInputWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, kvName, natsClient)
 	if err != nil {
 		return fmt.Errorf("failed to create a sideInputWatcher, %w", err)
 	}

--- a/pkg/sideinputs/initializer/initializer_test.go
+++ b/pkg/sideinputs/initializer/initializer_test.go
@@ -27,10 +27,9 @@ func cleanup(mountPath string) {
 // by reading from the side input bucket.
 func TestSideInputsInitializer_Success(t *testing.T) {
 	var (
-		keyspace     = "sideInputTestWatch"
-		pipelineName = "testPipeline"
-		sideInputs   = []string{"TEST", "TEST2"}
-		dataTest     = []string{"HELLO", "HELLO2"}
+		keyspace   = "sideInputTestWatch"
+		sideInputs = []string{"TEST", "TEST2"}
+		dataTest   = []string{"HELLO", "HELLO2"}
 	)
 	mountPath, err := os.MkdirTemp("", "side-input")
 	assert.NoError(t, err)
@@ -66,7 +65,7 @@ func TestSideInputsInitializer_Success(t *testing.T) {
 	assert.NoError(t, err)
 
 	bucketName := keyspace
-	sideInputWatcher, _ := jetstream.NewKVJetStreamKVWatch(ctx, pipelineName, bucketName, nc)
+	sideInputWatcher, _ := jetstream.NewKVJetStreamKVWatch(ctx, bucketName, nc)
 	for x := range sideInputs {
 		_, err = kv.Put(sideInputs[x], []byte(dataTest[x]))
 		if err != nil {
@@ -97,9 +96,8 @@ func TestSideInputsInitializer_Success(t *testing.T) {
 // write any values to the store
 func TestSideInputsTimeout(t *testing.T) {
 	var (
-		keyspace     = "sideInputTestWatch"
-		pipelineName = "testPipeline"
-		sideInputs   = []string{"TEST", "TEST2"}
+		keyspace   = "sideInputTestWatch"
+		sideInputs = []string{"TEST", "TEST2"}
 	)
 	mountPath, err := os.MkdirTemp("", "side-input")
 	assert.NoError(t, err)
@@ -136,7 +134,7 @@ func TestSideInputsTimeout(t *testing.T) {
 	assert.NoError(t, err)
 
 	bucketName := keyspace
-	sideInputWatcher, _ := jetstream.NewKVJetStreamKVWatch(ctx, pipelineName, bucketName, nc)
+	sideInputWatcher, _ := jetstream.NewKVJetStreamKVWatch(ctx, bucketName, nc)
 
 	_ = startSideInputInitializer(ctx, sideInputWatcher, mountPath, sideInputs)
 	assert.Equal(t, context.DeadlineExceeded, ctx.Err())

--- a/pkg/sideinputs/synchronizer/synchronizer.go
+++ b/pkg/sideinputs/synchronizer/synchronizer.go
@@ -80,7 +80,7 @@ func (sis *sideInputsSynchronizer) Start(ctx context.Context) error {
 	}
 	// Create a new watcher for the side input KV store
 	kvName := isbsvc.JetStreamSideInputsStoreKVName(sis.sideInputsStore)
-	sideInputWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, sis.pipelineName, kvName, natsClient)
+	sideInputWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, kvName, natsClient)
 	if err != nil {
 		return fmt.Errorf("failed to create a sideInputWatcher, %w", err)
 	}

--- a/pkg/sideinputs/synchronizer/synchronizer_test.go
+++ b/pkg/sideinputs/synchronizer/synchronizer_test.go
@@ -27,10 +27,9 @@ func cleanup(mountPath string) {
 // side input store path with updated values from the side input bucket.
 func TestSideInputsValueUpdates(t *testing.T) {
 	var (
-		keyspace     = "sideInputTestWatch"
-		pipelineName = "testPipeline"
-		sideInputs   = []string{"TEST", "TEST2"}
-		dataTest     = []string{"HELLO", "HELLO2"}
+		keyspace   = "sideInputTestWatch"
+		sideInputs = []string{"TEST", "TEST2"}
+		dataTest   = []string{"HELLO", "HELLO2"}
 	)
 	mountPath, err := os.MkdirTemp("/tmp", "side-input")
 	assert.NoError(t, err)
@@ -77,7 +76,7 @@ func TestSideInputsValueUpdates(t *testing.T) {
 	}
 
 	bucketName := keyspace
-	sideInputWatcher, _ := jetstream.NewKVJetStreamKVWatch(ctx, pipelineName, bucketName, nc)
+	sideInputWatcher, _ := jetstream.NewKVJetStreamKVWatch(ctx, bucketName, nc)
 	go startSideInputSynchronizer(ctx, sideInputWatcher, mountPath)
 	for x := range sideInputs {
 		_, err = kv.Put(sideInputs[x], []byte(dataTest[x]))

--- a/pkg/sources/forward/data_forward_test.go
+++ b/pkg/sources/forward/data_forward_test.go
@@ -31,8 +31,6 @@ import (
 	"github.com/numaproj/numaflow/pkg/isb"
 	"github.com/numaproj/numaflow/pkg/isb/stores/simplebuffer"
 	"github.com/numaproj/numaflow/pkg/isb/testutils"
-	"github.com/numaproj/numaflow/pkg/shared/kvs/inmem"
-	"github.com/numaproj/numaflow/pkg/shared/kvs/noop"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 	udfapplier "github.com/numaproj/numaflow/pkg/udf/function"
 	"github.com/numaproj/numaflow/pkg/watermark/generic"
@@ -46,8 +44,7 @@ import (
 const (
 	testPipelineName    = "testPipeline"
 	testProcessorEntity = "publisherTestPod"
-	publisherHBKeyspace = testPipelineName + "_" + testProcessorEntity + "_%s_" + "PROCESSORS"
-	publisherOTKeyspace = testPipelineName + "_" + testProcessorEntity + "_%s_" + "OT"
+	publishKeyspace     = testPipelineName + "_" + testProcessorEntity + "_%s"
 )
 
 var (
@@ -1235,9 +1232,8 @@ func buildToVertexWatermarkStores(toBuffers map[string][]isb.BufferWriter) map[s
 	var ctx = context.Background()
 	otStores := make(map[string]wmstore.WatermarkStore)
 	for key := range toBuffers {
-		heartbeatKV, _, _ := inmem.NewKVInMemKVStore(ctx, testPipelineName, fmt.Sprintf(publisherHBKeyspace, key))
-		otKV, _, _ := inmem.NewKVInMemKVStore(ctx, testPipelineName, fmt.Sprintf(publisherOTKeyspace, key))
-		otStores[key] = wmstore.BuildWatermarkStore(heartbeatKV, otKV)
+		store, _, _, _ := wmstore.BuildInmemWatermarkStore(ctx, testPipelineName, fmt.Sprintf(publishKeyspace, key))
+		otStores[key] = store
 	}
 	return otStores
 }
@@ -1245,7 +1241,7 @@ func buildToVertexWatermarkStores(toBuffers map[string][]isb.BufferWriter) map[s
 func buildNoOpToVertexStores(toBuffers map[string][]isb.BufferWriter) map[string]wmstore.WatermarkStore {
 	toVertexStores := make(map[string]wmstore.WatermarkStore)
 	for key := range toBuffers {
-		store := wmstore.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
+		store, _ := wmstore.BuildNoOpWatermarkStore()
 		toVertexStores[key] = store
 	}
 	return toVertexStores

--- a/pkg/sources/forward/data_forward_test.go
+++ b/pkg/sources/forward/data_forward_test.go
@@ -1232,7 +1232,7 @@ func buildToVertexWatermarkStores(toBuffers map[string][]isb.BufferWriter) map[s
 	var ctx = context.Background()
 	otStores := make(map[string]wmstore.WatermarkStore)
 	for key := range toBuffers {
-		store, _, _, _ := wmstore.BuildInmemWatermarkStore(ctx, testPipelineName, fmt.Sprintf(publishKeyspace, key))
+		store, _, _, _ := wmstore.BuildInmemWatermarkStore(ctx, fmt.Sprintf(publishKeyspace, key))
 		otStores[key] = store
 	}
 	return otStores

--- a/pkg/sources/generator/tickgen_test.go
+++ b/pkg/sources/generator/tickgen_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/numaproj/numaflow/pkg/forward/applier"
 	"github.com/numaproj/numaflow/pkg/isb"
 	"github.com/numaproj/numaflow/pkg/isb/stores/simplebuffer"
-	"github.com/numaproj/numaflow/pkg/shared/kvs/noop"
 	"github.com/numaproj/numaflow/pkg/watermark/generic"
 	"github.com/numaproj/numaflow/pkg/watermark/store"
 
@@ -67,7 +66,7 @@ func TestRead(t *testing.T) {
 		Replica:  0,
 	}
 
-	publishWMStore := store.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
+	publishWMStore, _ := store.BuildNoOpWatermarkStore()
 	toBuffers := map[string][]isb.BufferWriter{
 		"writer": {dest},
 	}
@@ -126,7 +125,7 @@ func TestStop(t *testing.T) {
 		Hostname: "TestRead",
 		Replica:  0,
 	}
-	publishWMStore := store.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
+	publishWMStore, _ := store.BuildNoOpWatermarkStore()
 	toBuffers := map[string][]isb.BufferWriter{
 		"writer": {dest},
 	}
@@ -230,7 +229,7 @@ func TestWatermark(t *testing.T) {
 		"writer": {dest},
 	}
 
-	publishWMStore := store.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
+	publishWMStore, _ := store.BuildNoOpWatermarkStore()
 	mgen, err := NewMemGen(m, toBuffers, myForwardToAllTest{}, applier.Terminal, nil, nil, publishWMStore, nil)
 	assert.NoError(t, err)
 	stop := mgen.Start()

--- a/pkg/sources/http/http_test.go
+++ b/pkg/sources/http/http_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/numaproj/numaflow/pkg/shared/kvs/noop"
 	"github.com/numaproj/numaflow/pkg/watermark/store"
 	"github.com/stretchr/testify/assert"
 
@@ -80,7 +79,7 @@ func Test_NewHTTP(t *testing.T) {
 	toBuffers := map[string][]isb.BufferWriter{
 		"test": {dest},
 	}
-	publishWMStores := store.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
+	publishWMStores, _ := store.BuildNoOpWatermarkStore()
 	fetchWatermark, _ := generic.BuildNoOpWatermarkProgressorsFromBufferMap(map[string][]isb.BufferWriter{})
 	toVertexWmStores := map[string]store.WatermarkStore{
 		"test": publishWMStores,

--- a/pkg/sources/kafka/handler_test.go
+++ b/pkg/sources/kafka/handler_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/numaproj/numaflow/pkg/forward/applier"
 	"github.com/numaproj/numaflow/pkg/isb"
 	"github.com/numaproj/numaflow/pkg/isb/stores/simplebuffer"
-	"github.com/numaproj/numaflow/pkg/shared/kvs/noop"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 	"github.com/numaproj/numaflow/pkg/watermark/generic"
 	"github.com/numaproj/numaflow/pkg/watermark/store"
@@ -76,7 +75,7 @@ func TestMessageHandling(t *testing.T) {
 		Hostname: "test-host",
 		Replica:  0,
 	}
-	publishWMStore := store.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
+	publishWMStore, _ := store.BuildNoOpWatermarkStore()
 	fetchWatermark, _ := generic.BuildNoOpWatermarkProgressorsFromBufferMap(map[string][]isb.BufferWriter{})
 	toVertexWmStores := map[string]store.WatermarkStore{
 		"test": publishWMStore,

--- a/pkg/sources/kafka/reader_test.go
+++ b/pkg/sources/kafka/reader_test.go
@@ -22,15 +22,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/numaproj/numaflow/pkg/shared/kvs/noop"
-	"github.com/numaproj/numaflow/pkg/watermark/store"
-
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaflow/pkg/forward/applier"
 	"github.com/numaproj/numaflow/pkg/isb"
 	"github.com/numaproj/numaflow/pkg/isb/stores/simplebuffer"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 	"github.com/numaproj/numaflow/pkg/watermark/generic"
+	"github.com/numaproj/numaflow/pkg/watermark/store"
 )
 
 func TestNewKafkasource(t *testing.T) {
@@ -55,7 +53,7 @@ func TestNewKafkasource(t *testing.T) {
 		Hostname: "test-host",
 		Replica:  0,
 	}
-	publishWMStore := store.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
+	publishWMStore, _ := store.BuildNoOpWatermarkStore()
 	fetchWatermark, _ := generic.BuildNoOpWatermarkProgressorsFromBufferMap(map[string][]isb.BufferWriter{})
 	toVertexWmStores := map[string]store.WatermarkStore{
 		"testVertex": publishWMStore,
@@ -98,7 +96,7 @@ func TestGroupNameOverride(t *testing.T) {
 		Hostname: "test-host",
 		Replica:  0,
 	}
-	publishWMStore := store.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
+	publishWMStore, _ := store.BuildNoOpWatermarkStore()
 	fetchWatermark, _ := generic.BuildNoOpWatermarkProgressorsFromBufferMap(map[string][]isb.BufferWriter{})
 	toVertexWmStores := map[string]store.WatermarkStore{
 		"testVertex": publishWMStore,
@@ -131,7 +129,7 @@ func TestDefaultBufferSize(t *testing.T) {
 		Hostname: "test-host",
 		Replica:  0,
 	}
-	publishWMStore := store.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
+	publishWMStore, _ := store.BuildNoOpWatermarkStore()
 	fetchWatermark, _ := generic.BuildNoOpWatermarkProgressorsFromBufferMap(map[string][]isb.BufferWriter{})
 	toVertexWmStores := map[string]store.WatermarkStore{
 		"testVertex": publishWMStore,
@@ -164,7 +162,7 @@ func TestBufferSizeOverrides(t *testing.T) {
 		Hostname: "test-host",
 		Replica:  0,
 	}
-	publishWMStore := store.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
+	publishWMStore, _ := store.BuildNoOpWatermarkStore()
 	fetchWatermark, _ := generic.BuildNoOpWatermarkProgressorsFromBufferMap(map[string][]isb.BufferWriter{})
 	toVertexWmStores := map[string]store.WatermarkStore{
 		"testVertex": publishWMStore,

--- a/pkg/sources/nats/nats_test.go
+++ b/pkg/sources/nats/nats_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	natslib "github.com/nats-io/nats.go"
-	"github.com/numaproj/numaflow/pkg/shared/kvs/noop"
 	"github.com/stretchr/testify/assert"
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
@@ -77,7 +76,7 @@ func newInstance(t *testing.T, vi *dfv1.VertexInstance) (*natsSource, error) {
 		"test": {dest},
 	}
 
-	publishWMStores := store.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
+	publishWMStores, _ := store.BuildNoOpWatermarkStore()
 	fetchWatermark, _ := generic.BuildNoOpWatermarkProgressorsFromBufferMap(map[string][]isb.BufferWriter{})
 	toVertexWmStores := map[string]store.WatermarkStore{
 		"testVertex": publishWMStores,

--- a/pkg/sources/source.go
+++ b/pkg/sources/source.go
@@ -23,7 +23,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/numaproj/numaflow/pkg/shared/kvs/noop"
 	"github.com/numaproj/numaflow/pkg/watermark/processor"
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
@@ -58,11 +57,11 @@ type SourceProcessor struct {
 
 func (sp *SourceProcessor) Start(ctx context.Context) error {
 	var (
-		sourcePublisherStores   = store.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
-		processorManagers       map[string]*processor.ProcessorManager
-		toVertexWatermarkStores = make(map[string]store.WatermarkStore)
-		log                     = logging.FromContext(ctx)
-		writersMap              = make(map[string][]isb.BufferWriter)
+		sourcePublisherStores, _ = store.BuildNoOpWatermarkStore()
+		processorManagers        map[string]*processor.ProcessorManager
+		toVertexWatermarkStores  = make(map[string]store.WatermarkStore)
+		log                      = logging.FromContext(ctx)
+		writersMap               = make(map[string][]isb.BufferWriter)
 	)
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -78,7 +77,7 @@ func (sp *SourceProcessor) Start(ctx context.Context) error {
 	// create a no op publisher stores
 
 	for _, e := range sp.VertexInstance.Vertex.Spec.ToEdges {
-		toVertexWatermarkStores[e.To] = store.BuildWatermarkStore(noop.NewKVNoOpStore(), noop.NewKVNoOpStore())
+		toVertexWatermarkStores[e.To], _ = store.BuildNoOpWatermarkStore()
 	}
 
 	switch sp.ISBSvcType {

--- a/pkg/watermark/fetch/edge_fetcher.go
+++ b/pkg/watermark/fetch/edge_fetcher.go
@@ -47,7 +47,7 @@ type edgeFetcher struct {
 
 // NewEdgeFetcher returns a new edge fetcher.
 func NewEdgeFetcher(ctx context.Context, manager *processor.ProcessorManager, fromBufferPartitionCount int) *edgeFetcher {
-	log := logging.FromContext(ctx).With("bucketName", manager.GetBucket())
+	log := logging.FromContext(ctx)
 	log.Info("Creating a new edge watermark fetcher")
 	var lastProcessedWm []int64
 
@@ -99,7 +99,7 @@ func (e *edgeFetcher) updateWatermark(inputOffset isb.Offset, fromPartitionIdx i
 		// if the pod is not active and the head offset of all the timelines is less than the input offset, delete the processor
 		// (this means we are processing data later than what the stale processor has processed)
 		if p.IsDeleted() && (offset > headOffset) {
-			e.log.Info("Deleting processor because it's stale", zap.String("processor", p.GetEntity().GetName()))
+			e.log.Infow("Deleting processor because it's stale", zap.String("processor", p.GetEntity().GetName()))
 			e.processorManager.DeleteProcessor(p.GetEntity().GetName())
 		}
 	}

--- a/pkg/watermark/fetch/edge_fetcher_set_test.go
+++ b/pkg/watermark/fetch/edge_fetcher_set_test.go
@@ -24,9 +24,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/numaproj/numaflow/pkg/shared/kvs/noop"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
@@ -187,9 +184,7 @@ func Test_EdgeFetcherSet_ComputeWatermark(t *testing.T) {
 }
 
 func createProcessorManager(ctx context.Context, partitionCount int32) *processor.ProcessorManager {
-	hbWatcher := noop.NewKVOpWatch()
-	otWatcher := noop.NewKVOpWatch()
-	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
+	storeWatcher, _ := store.BuildNoOpWatermarkStoreWatcher()
 	return processor.NewProcessorManager(ctx, storeWatcher, partitionCount)
 }
 
@@ -378,10 +373,8 @@ func Test_EdgeFetcherSet_GetHeadWMB(t *testing.T) {
 	// 3. all publishers Idle but somehow the GetWatermark() of one of the EdgeFetchers is higher than the returned value
 
 	var (
-		ctx          = context.Background()
-		hbWatcher    = noop.NewKVOpWatch()
-		otWatcher    = noop.NewKVOpWatch()
-		storeWatcher = store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
+		ctx             = context.Background()
+		storeWatcher, _ = store.BuildNoOpWatermarkStoreWatcher()
 
 		edge1ProcessorManagerIdle    = processor.NewProcessorManager(ctx, storeWatcher, 2)
 		edge1ProcessorManagerNonIdle = processor.NewProcessorManager(ctx, storeWatcher, 2)

--- a/pkg/watermark/fetch/edge_fetcher_set_test.go
+++ b/pkg/watermark/fetch/edge_fetcher_set_test.go
@@ -94,7 +94,7 @@ func Test_EdgeFetcherSet_ComputeWatermark(t *testing.T) {
 		testPodsByVertex[vertex] = make([]*processor.ProcessorToFetch, numPods)
 		for pod := 0; pod < numPods; pod++ {
 			name := fmt.Sprintf("test-pod-%d-%d", vertex, pod)
-			testPodsByVertex[vertex][pod] = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity(name), "test-bucket", 5, partitionCount)
+			testPodsByVertex[vertex][pod] = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity(name), 5, partitionCount)
 			for _, watermark := range testPodTimelines[vertex][pod] {
 				testPodsByVertex[vertex][pod].GetOffsetTimelines()[watermark.Partition].Put(watermark)
 			}
@@ -190,13 +190,13 @@ func createProcessorManager(ctx context.Context, partitionCount int32) *processo
 	hbWatcher := noop.NewKVOpWatch()
 	otWatcher := noop.NewKVOpWatch()
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
-	return processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", partitionCount)
+	return processor.NewProcessorManager(ctx, storeWatcher, partitionCount)
 }
 
 func edge1Idle(ctx context.Context, processorManager *processor.ProcessorManager) {
 	var (
-		testPod0     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), "test-bucket", 5, 2)
-		testPod1     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), "test-bucket", 5, 2)
+		testPod0     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), 5, 2)
+		testPod1     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), 5, 2)
 		pod0Timeline = []wmb.WMB{
 			{
 				Idle:      true,
@@ -239,8 +239,8 @@ func edge1Idle(ctx context.Context, processorManager *processor.ProcessorManager
 
 func edge1NonIdle(ctx context.Context, processorManager *processor.ProcessorManager) {
 	var (
-		testPod0     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), "test-bucket", 5, 2)
-		testPod1     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), "test-bucket", 5, 2)
+		testPod0     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), 5, 2)
+		testPod1     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), 5, 2)
 		pod0Timeline = []wmb.WMB{
 			{
 				Idle:      false,
@@ -283,8 +283,8 @@ func edge1NonIdle(ctx context.Context, processorManager *processor.ProcessorMana
 
 func edge2Idle(ctx context.Context, processorManager *processor.ProcessorManager) {
 	var (
-		testPod0     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), "test-bucket", 5, 2)
-		testPod1     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), "test-bucket", 5, 2)
+		testPod0     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), 5, 2)
+		testPod1     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), 5, 2)
 		pod0Timeline = []wmb.WMB{
 			{
 				Idle:      true,
@@ -327,8 +327,8 @@ func edge2Idle(ctx context.Context, processorManager *processor.ProcessorManager
 
 func edge2NonIdle(ctx context.Context, processorManager *processor.ProcessorManager) {
 	var (
-		testPod0     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), "test-bucket", 5, 2)
-		testPod1     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), "test-bucket", 5, 2)
+		testPod0     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), 5, 2)
+		testPod1     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), 5, 2)
 		pod0Timeline = []wmb.WMB{
 			{
 				Idle:      false,
@@ -383,11 +383,11 @@ func Test_EdgeFetcherSet_GetHeadWMB(t *testing.T) {
 		otWatcher    = noop.NewKVOpWatch()
 		storeWatcher = store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
 
-		edge1ProcessorManagerIdle    = processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", 2)
-		edge1ProcessorManagerNonIdle = processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", 2)
+		edge1ProcessorManagerIdle    = processor.NewProcessorManager(ctx, storeWatcher, 2)
+		edge1ProcessorManagerNonIdle = processor.NewProcessorManager(ctx, storeWatcher, 2)
 
-		edge2ProcessorManagerIdle    = processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", 2)
-		edge2ProcessorManagerNonIdle = processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", 2)
+		edge2ProcessorManagerIdle    = processor.NewProcessorManager(ctx, storeWatcher, 2)
+		edge2ProcessorManagerNonIdle = processor.NewProcessorManager(ctx, storeWatcher, 2)
 	)
 
 	edge1Idle(ctx, edge1ProcessorManagerIdle)

--- a/pkg/watermark/fetch/edge_fetcher_test.go
+++ b/pkg/watermark/fetch/edge_fetcher_test.go
@@ -50,11 +50,11 @@ func TestBuffer_updateWatermarkWithOnePartition(t *testing.T) {
 	hbWatcher := noop.NewKVOpWatch()
 	otWatcher := noop.NewKVOpWatch()
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
-	processorManager := processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", 1)
+	processorManager := processor.NewProcessorManager(ctx, storeWatcher, 1)
 	var (
-		testPod0     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), "test-bucket", 5, 1)
-		testPod1     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), "test-bucket", 5, 1)
-		testPod2     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), "test-bucket", 5, 1)
+		testPod0     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), 5, 1)
+		testPod1     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), 5, 1)
+		testPod2     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), 5, 1)
 		pod0Timeline = []wmb.WMB{
 			{Watermark: 11, Offset: 9, Partition: 0},
 			{Watermark: 12, Offset: 20, Partition: 0},
@@ -178,11 +178,11 @@ func TestBuffer_updateWatermarkWithMultiplePartition(t *testing.T) {
 	otWatcher := noop.NewKVOpWatch()
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
 	partitionCount := int32(3)
-	processorManager := processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", partitionCount)
+	processorManager := processor.NewProcessorManager(ctx, storeWatcher, partitionCount)
 	var (
-		testPod0     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), "test-bucket", 5, partitionCount)
-		testPod1     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), "test-bucket", 5, partitionCount)
-		testPod2     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), "test-bucket", 5, partitionCount)
+		testPod0     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), 5, partitionCount)
+		testPod1     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), 5, partitionCount)
+		testPod2     = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), 5, partitionCount)
 		pod0Timeline = []wmb.WMB{
 			{Watermark: 11, Offset: 9, Partition: 0},
 			{Watermark: 12, Offset: 20, Partition: 1},
@@ -340,8 +340,8 @@ func Test_edgeFetcher_ComputeHeadWatermark(t *testing.T) {
 		hbWatcher         = noop.NewKVOpWatch()
 		otWatcher         = noop.NewKVOpWatch()
 		storeWatcher      = store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
-		processorManager1 = processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", partitionCount)
-		processorManager2 = processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", partitionCount)
+		processorManager1 = processor.NewProcessorManager(ctx, storeWatcher, partitionCount)
+		processorManager2 = processor.NewProcessorManager(ctx, storeWatcher, partitionCount)
 	)
 
 	computeHeadWMTest1(ctx, processorManager1)
@@ -377,9 +377,9 @@ func Test_edgeFetcher_ComputeHeadWatermark(t *testing.T) {
 func computeHeadWMTest1(ctx context.Context, processorManager1 *processor.ProcessorManager) {
 	var (
 		partitionCount = int32(2)
-		testPod0       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), "test-bucket", 5, partitionCount)
-		testPod1       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), "test-bucket", 5, partitionCount)
-		testPod2       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), "test-bucket", 5, partitionCount)
+		testPod0       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), 5, partitionCount)
+		testPod1       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), 5, partitionCount)
+		testPod2       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), 5, partitionCount)
 		pod0Timeline   = []wmb.WMB{
 			{
 				Idle:      true,
@@ -441,9 +441,9 @@ func computeHeadWMTest1(ctx context.Context, processorManager1 *processor.Proces
 func computeHeadWMTest2(ctx context.Context, processorManager2 *processor.ProcessorManager) {
 	var (
 		partitionCount = int32(2)
-		testPod0       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), "test-bucket", 5, partitionCount)
-		testPod1       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), "test-bucket", 5, partitionCount)
-		testPod2       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), "test-bucket", 5, partitionCount)
+		testPod0       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), 5, partitionCount)
+		testPod1       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), 5, partitionCount)
+		testPod2       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), 5, partitionCount)
 		pod0Timeline   = []wmb.WMB{
 			{
 				Idle:      false,
@@ -509,10 +509,10 @@ func Test_edgeFetcher_updateHeadIdleWMB(t *testing.T) {
 		hbWatcher         = noop.NewKVOpWatch()
 		otWatcher         = noop.NewKVOpWatch()
 		storeWatcher      = store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
-		processorManager1 = processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", partitionCount)
-		processorManager2 = processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", partitionCount)
-		processorManager3 = processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", partitionCount)
-		processorManager4 = processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", partitionCount)
+		processorManager1 = processor.NewProcessorManager(ctx, storeWatcher, partitionCount)
+		processorManager2 = processor.NewProcessorManager(ctx, storeWatcher, partitionCount)
+		processorManager3 = processor.NewProcessorManager(ctx, storeWatcher, partitionCount)
+		processorManager4 = processor.NewProcessorManager(ctx, storeWatcher, partitionCount)
 	)
 
 	updateHeadIdleWMBTest1(ctx, processorManager1)
@@ -570,9 +570,9 @@ func Test_edgeFetcher_updateHeadIdleWMB(t *testing.T) {
 func updateHeadIdleWMBTest1(ctx context.Context, processorManager1 *processor.ProcessorManager) {
 	var (
 		partitionCount = int32(3)
-		testPod0       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), "test-bucket", 5, partitionCount)
-		testPod1       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), "test-bucket", 5, partitionCount)
-		testPod2       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), "test-bucket", 5, partitionCount)
+		testPod0       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), 5, partitionCount)
+		testPod1       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), 5, partitionCount)
+		testPod2       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), 5, partitionCount)
 		pod0Timeline   = []wmb.WMB{
 			{
 				Idle:      true,
@@ -652,9 +652,9 @@ func updateHeadIdleWMBTest1(ctx context.Context, processorManager1 *processor.Pr
 func updateHeadIdleWMBTest2(ctx context.Context, processorManager2 *processor.ProcessorManager) {
 	var (
 		partitionCount = int32(3)
-		testPod0       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), "test-bucket", 5, partitionCount)
-		testPod1       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), "test-bucket", 5, partitionCount)
-		testPod2       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), "test-bucket", 5, partitionCount)
+		testPod0       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), 5, partitionCount)
+		testPod1       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), 5, partitionCount)
+		testPod2       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), 5, partitionCount)
 		pod0Timeline   = []wmb.WMB{
 			{
 				Idle:      false,
@@ -734,9 +734,9 @@ func updateHeadIdleWMBTest2(ctx context.Context, processorManager2 *processor.Pr
 func updateHeadIdleWMBTest3(ctx context.Context, processorManager3 *processor.ProcessorManager) {
 	var (
 		partitionCount = int32(3)
-		testPod0       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), "test-bucket", 5, partitionCount)
-		testPod1       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), "test-bucket", 5, partitionCount)
-		testPod2       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), "test-bucket", 5, partitionCount)
+		testPod0       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), 5, partitionCount)
+		testPod1       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), 5, partitionCount)
+		testPod2       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), 5, partitionCount)
 		pod0Timeline   = []wmb.WMB{
 			{
 				Idle:      false,
@@ -816,9 +816,9 @@ func updateHeadIdleWMBTest3(ctx context.Context, processorManager3 *processor.Pr
 func updateHeadIdleWMBTest4(ctx context.Context, processorManager4 *processor.ProcessorManager) {
 	var (
 		partitionCount = int32(3)
-		testPod0       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), "test-bucket", 5, partitionCount)
-		testPod1       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), "test-bucket", 5, partitionCount)
-		testPod2       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), "test-bucket", 5, partitionCount)
+		testPod0       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod1"), 5, partitionCount)
+		testPod1       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod2"), 5, partitionCount)
+		testPod2       = processor.NewProcessorToFetch(ctx, processor.NewProcessorEntity("testPod3"), 5, partitionCount)
 	)
 	processorManager4.AddProcessor("testPod0", testPod0)
 	processorManager4.AddProcessor("testPod1", testPod1)
@@ -865,7 +865,7 @@ func TestFetcherWithSameOTBucket_InMem(t *testing.T) {
 	otWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_OT", otWatcherCh)
 	assert.NoError(t, err)
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
-	var processorManager = processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", 1)
+	var processorManager = processor.NewProcessorManager(ctx, storeWatcher, 1)
 	var fetcher = NewEdgeFetcher(ctx, processorManager, 1)
 
 	var heartBeatManagerMap = make(map[string]*heartBeatManager)
@@ -1103,7 +1103,7 @@ func TestFetcherWithSameOTBucketWithSinglePartition(t *testing.T) {
 	otWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, "testFetch", keyspace+"_OT", defaultJetStreamClient)
 	assert.NoError(t, err)
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
-	processorManager := processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", 1)
+	processorManager := processor.NewProcessorManager(ctx, storeWatcher, 1)
 	fetcher := NewEdgeFetcher(ctx, processorManager, 1)
 
 	var heartBeatManagerMap = make(map[string]*heartBeatManager)
@@ -1394,7 +1394,7 @@ func TestFetcherWithSameOTBucketWithMultiplePartition(t *testing.T) {
 	otWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, "testFetch", keyspace+"_OT", defaultJetStreamClient)
 	assert.NoError(t, err)
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
-	processorManager := processor.NewProcessorManager(ctx, storeWatcher, "test-bucket", 3)
+	processorManager := processor.NewProcessorManager(ctx, storeWatcher, 3)
 	fetcher := NewEdgeFetcher(ctx, processorManager, 3)
 
 	var heartBeatManagerMap = make(map[string]*heartBeatManager)

--- a/pkg/watermark/fetch/edge_fetcher_test.go
+++ b/pkg/watermark/fetch/edge_fetcher_test.go
@@ -1088,19 +1088,19 @@ func TestFetcherWithSameOTBucketWithSinglePartition(t *testing.T) {
 	defaultJetStreamClient := natstest.JetStreamClient(t, s)
 
 	// create hbStore
-	hbStore, err := jetstream.NewKVJetStreamKVStore(ctx, "testFetch", keyspace+"_PROCESSORS", defaultJetStreamClient)
+	hbStore, err := jetstream.NewKVJetStreamKVStore(ctx, keyspace+"_PROCESSORS", defaultJetStreamClient)
 	assert.NoError(t, err)
 	defer hbStore.Close()
 
 	// create otStore
-	otStore, err := jetstream.NewKVJetStreamKVStore(ctx, "testFetch", keyspace+"_OT", defaultJetStreamClient)
+	otStore, err := jetstream.NewKVJetStreamKVStore(ctx, keyspace+"_OT", defaultJetStreamClient)
 	assert.NoError(t, err)
 	defer otStore.Close()
 
 	// create watchers for heartbeat and offset timeline
-	hbWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, "testFetch", keyspace+"_PROCESSORS", defaultJetStreamClient)
+	hbWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, keyspace+"_PROCESSORS", defaultJetStreamClient)
 	assert.NoError(t, err)
-	otWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, "testFetch", keyspace+"_OT", defaultJetStreamClient)
+	otWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, keyspace+"_OT", defaultJetStreamClient)
 	assert.NoError(t, err)
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
 	processorManager := processor.NewProcessorManager(ctx, storeWatcher, 1)
@@ -1379,19 +1379,19 @@ func TestFetcherWithSameOTBucketWithMultiplePartition(t *testing.T) {
 	defaultJetStreamClient := natstest.JetStreamClient(t, s)
 
 	// create hbStore
-	hbStore, err := jetstream.NewKVJetStreamKVStore(ctx, "testFetch", keyspace+"_PROCESSORS", defaultJetStreamClient)
+	hbStore, err := jetstream.NewKVJetStreamKVStore(ctx, keyspace+"_PROCESSORS", defaultJetStreamClient)
 	assert.NoError(t, err)
 	defer hbStore.Close()
 
 	// create otStore
-	otStore, err := jetstream.NewKVJetStreamKVStore(ctx, "testFetch", keyspace+"_OT", defaultJetStreamClient)
+	otStore, err := jetstream.NewKVJetStreamKVStore(ctx, keyspace+"_OT", defaultJetStreamClient)
 	assert.NoError(t, err)
 	defer otStore.Close()
 
 	// create watchers for heartbeat and offset timeline
-	hbWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, "testFetch", keyspace+"_PROCESSORS", defaultJetStreamClient)
+	hbWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, keyspace+"_PROCESSORS", defaultJetStreamClient)
 	assert.NoError(t, err)
-	otWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, "testFetch", keyspace+"_OT", defaultJetStreamClient)
+	otWatcher, err := jetstream.NewKVJetStreamKVWatch(ctx, keyspace+"_OT", defaultJetStreamClient)
 	assert.NoError(t, err)
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
 	processorManager := processor.NewProcessorManager(ctx, storeWatcher, 3)

--- a/pkg/watermark/fetch/edge_fetcher_test.go
+++ b/pkg/watermark/fetch/edge_fetcher_test.go
@@ -828,7 +828,6 @@ func otValueToBytes(offset int64, watermark int64, idle bool, partitionIdx int32
 func TestFetcherWithSameOTBucket_InMem(t *testing.T) {
 	var (
 		err          error
-		pipelineName       = "testFetch"
 		keyspace           = "fetcherTest"
 		hbBucketName       = keyspace + "_PROCESSORS"
 		otBucketName       = keyspace + "_OT"
@@ -839,16 +838,16 @@ func TestFetcherWithSameOTBucket_InMem(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, hbBucketName)
+	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, hbBucketName)
 	assert.NoError(t, err)
 	defer hbStore.Close()
-	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, otBucketName)
+	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, otBucketName)
 	assert.NoError(t, err)
 	defer otStore.Close()
 
 	epoch += 60000
 
-	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, "testFetch", keyspace, hbWatcherCh, otWatcherCh)
+	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, keyspace, hbWatcherCh, otWatcherCh)
 	assert.NoError(t, err)
 	var processorManager = processor.NewProcessorManager(ctx, storeWatcher, 1)
 	var fetcher = NewEdgeFetcher(ctx, processorManager, 1)

--- a/pkg/watermark/fetch/source_fetcher.go
+++ b/pkg/watermark/fetch/source_fetcher.go
@@ -41,7 +41,7 @@ type sourceFetcher struct {
 // NewSourceFetcher returns a new source fetcher, processorManager has the details about the processors responsible for writing to the
 // buckets of the source buffer.
 func NewSourceFetcher(ctx context.Context, manager *processor.ProcessorManager) Fetcher {
-	log := logging.FromContext(ctx).With("sourceBufferName", manager.GetBucket())
+	log := logging.FromContext(ctx)
 	log.Info("Creating a new source watermark fetcher")
 	return &sourceFetcher{
 		processorManager: manager,

--- a/pkg/watermark/generic/jetstream/generic.go
+++ b/pkg/watermark/generic/jetstream/generic.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/numaproj/numaflow/pkg/shared/kvs/jetstream"
 	"github.com/numaproj/numaflow/pkg/shared/kvs/noop"
+	"github.com/numaproj/numaflow/pkg/shared/logging"
 	"github.com/numaproj/numaflow/pkg/watermark/processor"
 	"github.com/numaproj/numaflow/pkg/watermark/store"
 
@@ -75,8 +76,9 @@ func buildProcessorManagerForBucket(ctx context.Context, vertexInstance *v1alpha
 
 	// create a store watcher that watches the heartbeat and ot store.
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatch, otWatch)
+	log := logging.FromContext(ctx).With("bucket", fromBucket)
 	// create processor manager with the store watcher which will keep track of all the active processors and updates the offset timelines accordingly.
-	processManager := processor.NewProcessorManager(ctx, storeWatcher, fromBucket, int32(len(vertexInstance.Vertex.OwnedBuffers())),
+	processManager := processor.NewProcessorManager(logging.WithLogger(ctx, log), storeWatcher, int32(len(vertexInstance.Vertex.OwnedBuffers())),
 		processor.WithVertexReplica(vertexInstance.Replica), processor.WithIsReduce(vertexInstance.Vertex.IsReduceUDF()), processor.WithIsSource(vertexInstance.Vertex.IsASource()))
 
 	return processManager, nil

--- a/pkg/watermark/processor/processor_manager.go
+++ b/pkg/watermark/processor/processor_manager.go
@@ -33,7 +33,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/numaproj/numaflow/pkg/shared/kvs"
-
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 	"github.com/numaproj/numaflow/pkg/watermark/store"
 	"github.com/numaproj/numaflow/pkg/watermark/wmb"

--- a/pkg/watermark/processor/processor_manager_test.go
+++ b/pkg/watermark/processor/processor_manager_test.go
@@ -67,7 +67,7 @@ func TestProcessorManager(t *testing.T) {
 	otWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_OT", otWatcherCh)
 	assert.NoError(t, err)
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
-	var processorManager = NewProcessorManager(ctx, storeWatcher, "my-bucket", 1)
+	var processorManager = NewProcessorManager(ctx, storeWatcher, 1)
 	// start p1 heartbeat for 3 loops then delete p1
 	go func() {
 		var err error
@@ -157,7 +157,7 @@ func TestProcessorManagerWatchForMapWithOnePartition(t *testing.T) {
 	otWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_OT", otWatcherCh)
 	assert.NoError(t, err)
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
-	var processorManager = NewProcessorManager(ctx, storeWatcher, "", 1)
+	var processorManager = NewProcessorManager(ctx, storeWatcher, 1)
 	// start p1 heartbeat for 3 loops
 	go func(ctx context.Context) {
 		for {
@@ -256,7 +256,7 @@ func TestProcessorManagerWatchForReduce(t *testing.T) {
 	otWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_OT", otWatcherCh)
 	assert.NoError(t, err)
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
-	var processorManager = NewProcessorManager(ctx, storeWatcher, "my-bucket", 1, WithIsReduce(true), WithVertexReplica(2))
+	var processorManager = NewProcessorManager(ctx, storeWatcher, 1, WithIsReduce(true), WithVertexReplica(2))
 	// start p1 heartbeat for 3 loops
 	go func(ctx context.Context) {
 		for {
@@ -369,7 +369,7 @@ func TestProcessorManagerWatchForMapWithMultiplePartition(t *testing.T) {
 	otWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_OT", otWatcherCh)
 	assert.NoError(t, err)
 	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
-	var processorManager = NewProcessorManager(ctx, storeWatcher, "my-bucket", 3)
+	var processorManager = NewProcessorManager(ctx, storeWatcher, 3)
 	// start p1 heartbeat for 3 loops
 	go func(ctx context.Context) {
 		var err error

--- a/pkg/watermark/processor/processor_manager_test.go
+++ b/pkg/watermark/processor/processor_manager_test.go
@@ -62,11 +62,8 @@ func TestProcessorManager(t *testing.T) {
 	defer otStore.Close()
 	defer cancel()
 
-	hbWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_PROCESSORS", hbWatcherCh)
+	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, "testFetch", keyspace, hbWatcherCh, otWatcherCh)
 	assert.NoError(t, err)
-	otWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_OT", otWatcherCh)
-	assert.NoError(t, err)
-	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
 	var processorManager = NewProcessorManager(ctx, storeWatcher, 1)
 	// start p1 heartbeat for 3 loops then delete p1
 	go func() {
@@ -152,11 +149,8 @@ func TestProcessorManagerWatchForMapWithOnePartition(t *testing.T) {
 	defer hbStore.Close()
 	defer otStore.Close()
 
-	hbWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_PROCESSORS", hbWatcherCh)
+	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, "testFetch", keyspace, hbWatcherCh, otWatcherCh)
 	assert.NoError(t, err)
-	otWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_OT", otWatcherCh)
-	assert.NoError(t, err)
-	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
 	var processorManager = NewProcessorManager(ctx, storeWatcher, 1)
 	// start p1 heartbeat for 3 loops
 	go func(ctx context.Context) {
@@ -251,11 +245,8 @@ func TestProcessorManagerWatchForReduce(t *testing.T) {
 	defer otStore.Close()
 	defer cancel()
 
-	hbWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_PROCESSORS", hbWatcherCh)
+	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, "testFetch", keyspace, hbWatcherCh, otWatcherCh)
 	assert.NoError(t, err)
-	otWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_OT", otWatcherCh)
-	assert.NoError(t, err)
-	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
 	var processorManager = NewProcessorManager(ctx, storeWatcher, 1, WithIsReduce(true), WithVertexReplica(2))
 	// start p1 heartbeat for 3 loops
 	go func(ctx context.Context) {
@@ -364,11 +355,8 @@ func TestProcessorManagerWatchForMapWithMultiplePartition(t *testing.T) {
 	assert.NoError(t, err)
 	defer otStore.Close()
 
-	hbWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_PROCESSORS", hbWatcherCh)
+	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, "testFetch", keyspace, hbWatcherCh, otWatcherCh)
 	assert.NoError(t, err)
-	otWatcher, err := inmem.NewInMemWatch(ctx, "testFetch", keyspace+"_OT", otWatcherCh)
-	assert.NoError(t, err)
-	storeWatcher := store.BuildWatermarkStoreWatcher(hbWatcher, otWatcher)
 	var processorManager = NewProcessorManager(ctx, storeWatcher, 3)
 	// start p1 heartbeat for 3 loops
 	go func(ctx context.Context) {

--- a/pkg/watermark/processor/processor_manager_test.go
+++ b/pkg/watermark/processor/processor_manager_test.go
@@ -48,21 +48,20 @@ func TestMain(m *testing.M) {
 func TestProcessorManager(t *testing.T) {
 	var (
 		err          error
-		pipelineName = "testFetch"
 		keyspace     = "fetcherTest"
 		hbBucketName = keyspace + "_PROCESSORS"
 		otBucketName = keyspace + "_OT"
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, hbBucketName)
+	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, hbBucketName)
 	assert.NoError(t, err)
-	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, otBucketName)
+	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, otBucketName)
 	assert.NoError(t, err)
 	defer hbStore.Close()
 	defer otStore.Close()
 	defer cancel()
 
-	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, "testFetch", keyspace, hbWatcherCh, otWatcherCh)
+	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, keyspace, hbWatcherCh, otWatcherCh)
 	assert.NoError(t, err)
 	var processorManager = NewProcessorManager(ctx, storeWatcher, 1)
 	// start p1 heartbeat for 3 loops then delete p1
@@ -132,7 +131,6 @@ func TestProcessorManager(t *testing.T) {
 func TestProcessorManagerWatchForMapWithOnePartition(t *testing.T) {
 	var (
 		err          error
-		pipelineName       = "testFetch"
 		keyspace           = "fetcherTest"
 		hbBucketName       = keyspace + "_PROCESSORS"
 		otBucketName       = keyspace + "_OT"
@@ -140,16 +138,16 @@ func TestProcessorManagerWatchForMapWithOnePartition(t *testing.T) {
 		testOffset   int64 = 100
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, hbBucketName)
+	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, hbBucketName)
 	assert.NoError(t, err)
-	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, otBucketName)
+	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, otBucketName)
 	assert.NoError(t, err)
 
 	defer cancel()
 	defer hbStore.Close()
 	defer otStore.Close()
 
-	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, "testFetch", keyspace, hbWatcherCh, otWatcherCh)
+	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, keyspace, hbWatcherCh, otWatcherCh)
 	assert.NoError(t, err)
 	var processorManager = NewProcessorManager(ctx, storeWatcher, 1)
 	// start p1 heartbeat for 3 loops
@@ -229,7 +227,6 @@ func TestProcessorManagerWatchForMapWithOnePartition(t *testing.T) {
 func TestProcessorManagerWatchForReduce(t *testing.T) {
 	var (
 		err          error
-		pipelineName       = "testFetch"
 		keyspace           = "fetcherTest"
 		hbBucketName       = keyspace + "_PROCESSORS"
 		otBucketName       = keyspace + "_OT"
@@ -237,15 +234,15 @@ func TestProcessorManagerWatchForReduce(t *testing.T) {
 		testOffset   int64 = 100
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, hbBucketName)
+	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, hbBucketName)
 	assert.NoError(t, err)
-	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, otBucketName)
+	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, otBucketName)
 	assert.NoError(t, err)
 	defer hbStore.Close()
 	defer otStore.Close()
 	defer cancel()
 
-	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, "testFetch", keyspace, hbWatcherCh, otWatcherCh)
+	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, keyspace, hbWatcherCh, otWatcherCh)
 	assert.NoError(t, err)
 	var processorManager = NewProcessorManager(ctx, storeWatcher, 1, WithIsReduce(true), WithVertexReplica(2))
 	// start p1 heartbeat for 3 loops
@@ -338,7 +335,6 @@ func TestProcessorManagerWatchForReduce(t *testing.T) {
 func TestProcessorManagerWatchForMapWithMultiplePartition(t *testing.T) {
 	var (
 		err            error
-		pipelineName         = "testFetch"
 		keyspace             = "fetcherTest"
 		hbBucketName         = keyspace + "_PROCESSORS"
 		otBucketName         = keyspace + "_OT"
@@ -348,14 +344,14 @@ func TestProcessorManagerWatchForMapWithMultiplePartition(t *testing.T) {
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, hbBucketName)
+	hbStore, hbWatcherCh, err := inmem.NewKVInMemKVStore(ctx, hbBucketName)
 	assert.NoError(t, err)
 	defer hbStore.Close()
-	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, pipelineName, otBucketName)
+	otStore, otWatcherCh, err := inmem.NewKVInMemKVStore(ctx, otBucketName)
 	assert.NoError(t, err)
 	defer otStore.Close()
 
-	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, "testFetch", keyspace, hbWatcherCh, otWatcherCh)
+	storeWatcher, err := store.BuildInmemWatermarkStoreWatcher(ctx, keyspace, hbWatcherCh, otWatcherCh)
 	assert.NoError(t, err)
 	var processorManager = NewProcessorManager(ctx, storeWatcher, 3)
 	// start p1 heartbeat for 3 loops

--- a/pkg/watermark/processor/processor_to_fetch.go
+++ b/pkg/watermark/processor/processor_to_fetch.go
@@ -79,11 +79,11 @@ func (p *ProcessorToFetch) String() string {
 }
 
 // NewProcessorToFetch creates ProcessorToFetch.
-func NewProcessorToFetch(ctx context.Context, processor ProcessorEntitier, bucket string, capacity int, fromBufferPartitionCount int32) *ProcessorToFetch {
+func NewProcessorToFetch(ctx context.Context, processor ProcessorEntitier, capacity int, fromBufferPartitionCount int32) *ProcessorToFetch {
 
 	var offsetTimelines []*timeline.OffsetTimeline
 	for i := int32(0); i < fromBufferPartitionCount; i++ {
-		t := timeline.NewOffsetTimeline(ctx, capacity, bucket)
+		t := timeline.NewOffsetTimeline(ctx, capacity)
 		offsetTimelines = append(offsetTimelines, t)
 	}
 	p := &ProcessorToFetch{

--- a/pkg/watermark/processor/processor_to_fetch_test.go
+++ b/pkg/watermark/processor/processor_to_fetch_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestFromProcessor_setStatus(t *testing.T) {
 	var ctx = context.Background()
-	p := NewProcessorToFetch(ctx, NewProcessorEntity("test-pod"), "test-bucket", 5, 1)
+	p := NewProcessorToFetch(ctx, NewProcessorEntity("test-pod"), 5, 1)
 	p.setStatus(_inactive)
 	assert.Equal(t, _inactive, p.status)
 }

--- a/pkg/watermark/publish/publisher_inmem_test.go
+++ b/pkg/watermark/publish/publisher_inmem_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestPublisherWithSharedOTBuckets_InMem(t *testing.T) {
 	var ctx = context.Background()
-	wmstore, _, _, err := store.BuildInmemWatermarkStore(ctx, "testPublisher", "test")
+	wmstore, _, _, err := store.BuildInmemWatermarkStore(ctx, "test")
 	assert.NoError(t, err)
 	publishEntity := processor.NewProcessorEntity("publisherTestPod1")
 

--- a/pkg/watermark/publish/publisher_inmem_test.go
+++ b/pkg/watermark/publish/publisher_inmem_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/numaproj/numaflow/pkg/isb"
-	"github.com/numaproj/numaflow/pkg/shared/kvs/inmem"
 	"github.com/numaproj/numaflow/pkg/watermark/processor"
 	"github.com/numaproj/numaflow/pkg/watermark/store"
 	"github.com/numaproj/numaflow/pkg/watermark/wmb"
@@ -34,20 +33,11 @@ import (
 
 func TestPublisherWithSharedOTBuckets_InMem(t *testing.T) {
 	var ctx = context.Background()
-
-	var publisherHBKeyspace = "publisherTest_PROCESSORS"
-
-	// this test uses separate OT buckets, so it is an OT bucket per processor
-	var publisherOTKeyspace = "publisherTest_OT_publisherTestPod1"
-
-	heartbeatKV, _, err := inmem.NewKVInMemKVStore(ctx, "testPublisher", publisherHBKeyspace)
+	wmstore, _, _, err := store.BuildInmemWatermarkStore(ctx, "testPublisher", "test")
 	assert.NoError(t, err)
-	otKV, _, err := inmem.NewKVInMemKVStore(ctx, "testPublisher", publisherOTKeyspace)
-	assert.NoError(t, err)
-
 	publishEntity := processor.NewProcessorEntity("publisherTestPod1")
 
-	p := NewPublish(ctx, publishEntity, store.BuildWatermarkStore(heartbeatKV, otKV), 1, WithAutoRefreshHeartbeatDisabled(), WithPodHeartbeatRate(1)).(*publish)
+	p := NewPublish(ctx, publishEntity, wmstore, 1, WithAutoRefreshHeartbeatDisabled(), WithPodHeartbeatRate(1)).(*publish)
 
 	var epoch int64 = 1651161600000
 	var location, _ = time.LoadLocation("UTC")

--- a/pkg/watermark/publish/publisher_test.go
+++ b/pkg/watermark/publish/publisher_test.go
@@ -67,9 +67,9 @@ func TestPublisherWithSharedOTBucket(t *testing.T) {
 
 	publishEntity := processor.NewProcessorEntity("publisherTestPod1")
 
-	heartbeatKV, err := jetstream.NewKVJetStreamKVStore(ctx, "testPublisher", keyspace+"_PROCESSORS", defaultJetStreamClient)
+	heartbeatKV, err := jetstream.NewKVJetStreamKVStore(ctx, keyspace+"_PROCESSORS", defaultJetStreamClient)
 	assert.NoError(t, err)
-	otKV, err := jetstream.NewKVJetStreamKVStore(ctx, "testPublisher", keyspace+"_OT", defaultJetStreamClient)
+	otKV, err := jetstream.NewKVJetStreamKVStore(ctx, keyspace+"_OT", defaultJetStreamClient)
 	assert.NoError(t, err)
 
 	p := NewPublish(ctx, publishEntity, store.BuildWatermarkStore(heartbeatKV, otKV), 1, WithAutoRefreshHeartbeatDisabled(), WithPodHeartbeatRate(1)).(*publish)

--- a/pkg/watermark/publish/publisher_test.go
+++ b/pkg/watermark/publish/publisher_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/numaproj/numaflow/pkg/isb"
 	natstest "github.com/numaproj/numaflow/pkg/shared/clients/nats/test"
-	"github.com/numaproj/numaflow/pkg/shared/kvs/jetstream"
 	"github.com/numaproj/numaflow/pkg/watermark/processor"
 	"github.com/numaproj/numaflow/pkg/watermark/store"
 	"github.com/numaproj/numaflow/pkg/watermark/wmb"
@@ -67,12 +66,10 @@ func TestPublisherWithSharedOTBucket(t *testing.T) {
 
 	publishEntity := processor.NewProcessorEntity("publisherTestPod1")
 
-	heartbeatKV, err := jetstream.NewKVJetStreamKVStore(ctx, keyspace+"_PROCESSORS", defaultJetStreamClient)
-	assert.NoError(t, err)
-	otKV, err := jetstream.NewKVJetStreamKVStore(ctx, keyspace+"_OT", defaultJetStreamClient)
+	wmstore, err := store.BuildJetStreamWatermarkStore(ctx, keyspace, defaultJetStreamClient)
 	assert.NoError(t, err)
 
-	p := NewPublish(ctx, publishEntity, store.BuildWatermarkStore(heartbeatKV, otKV), 1, WithAutoRefreshHeartbeatDisabled(), WithPodHeartbeatRate(1)).(*publish)
+	p := NewPublish(ctx, publishEntity, wmstore, 1, WithAutoRefreshHeartbeatDisabled(), WithPodHeartbeatRate(1)).(*publish)
 
 	var epoch int64 = 1651161600000
 	var location, _ = time.LoadLocation("UTC")

--- a/pkg/watermark/store/watermark_store.go
+++ b/pkg/watermark/store/watermark_store.go
@@ -59,9 +59,9 @@ func BuildNoOpWatermarkStore() (WatermarkStore, error) {
 }
 
 // BuildInmemWatermarkStore returns an in-mem WatermarkStore instance, and the HB, OT entry channels
-func BuildInmemWatermarkStore(ctx context.Context, pipeline, bucket string) (WatermarkStore, chan kvs.KVEntry, chan kvs.KVEntry, error) {
-	hbKV, hbKVEntry, _ := inmem.NewKVInMemKVStore(ctx, pipeline, bucket+"_PROCESSORS")
-	otKV, otKVEntry, _ := inmem.NewKVInMemKVStore(ctx, pipeline, bucket+"_OT")
+func BuildInmemWatermarkStore(ctx context.Context, bucket string) (WatermarkStore, chan kvs.KVEntry, chan kvs.KVEntry, error) {
+	hbKV, hbKVEntry, _ := inmem.NewKVInMemKVStore(ctx, bucket+"_PROCESSORS")
+	otKV, otKVEntry, _ := inmem.NewKVInMemKVStore(ctx, bucket+"_OT")
 	return &watermarkStore{
 		heartbeatStore:      hbKV,
 		offsetTimelineStore: otKV,

--- a/pkg/watermark/store/watermark_store.go
+++ b/pkg/watermark/store/watermark_store.go
@@ -81,6 +81,7 @@ func BuildJetStreamWatermarkStore(ctx context.Context, bucket string, client *js
 	otStoreKVName := JetStreamOTKVName(bucket)
 	otStore, err := jetstream.NewKVJetStreamKVStore(ctx, otStoreKVName, client)
 	if err != nil {
+		hbStore.Close()
 		return nil, fmt.Errorf("failed at new JetStream OT KV store %q, %w", otStoreKVName, err)
 	}
 	return &watermarkStore{

--- a/pkg/watermark/store/watermark_store.go
+++ b/pkg/watermark/store/watermark_store.go
@@ -16,7 +16,16 @@ limitations under the License.
 
 package store
 
-import "github.com/numaproj/numaflow/pkg/shared/kvs"
+import (
+	"context"
+	"fmt"
+
+	jsclient "github.com/numaproj/numaflow/pkg/shared/clients/nats"
+	"github.com/numaproj/numaflow/pkg/shared/kvs"
+	"github.com/numaproj/numaflow/pkg/shared/kvs/inmem"
+	"github.com/numaproj/numaflow/pkg/shared/kvs/jetstream"
+	noopkv "github.com/numaproj/numaflow/pkg/shared/kvs/noop"
+)
 
 // watermarkStore wraps a pair of heartbeatStore and offsetTimelineStore,
 // it implements interface WatermarkStore.
@@ -26,14 +35,6 @@ type watermarkStore struct {
 }
 
 var _ WatermarkStore = (*watermarkStore)(nil)
-
-// BuildWatermarkStore returns a WatermarkStore instance
-func BuildWatermarkStore(hbStore, otStore kvs.KVStorer) WatermarkStore {
-	return &watermarkStore{
-		heartbeatStore:      hbStore,
-		offsetTimelineStore: otStore,
-	}
-}
 
 func (ws *watermarkStore) HeartbeatStore() kvs.KVStorer {
 	return ws.heartbeatStore
@@ -47,4 +48,51 @@ func (ws *watermarkStore) Close() error {
 	ws.heartbeatStore.Close()
 	ws.offsetTimelineStore.Close()
 	return nil
+}
+
+// BuildNoOpWatermarkStore returns a NoOp WatermarkStore instance
+func BuildNoOpWatermarkStore() (WatermarkStore, error) {
+	return &watermarkStore{
+		heartbeatStore:      noopkv.NewKVNoOpStore(),
+		offsetTimelineStore: noopkv.NewKVNoOpStore(),
+	}, nil
+}
+
+// BuildInmemWatermarkStore returns an in-mem WatermarkStore instance, and the HB, OT entry channels
+func BuildInmemWatermarkStore(ctx context.Context, pipeline, bucket string) (WatermarkStore, chan kvs.KVEntry, chan kvs.KVEntry, error) {
+	hbKV, hbKVEntry, _ := inmem.NewKVInMemKVStore(ctx, pipeline, bucket+"_PROCESSORS")
+	otKV, otKVEntry, _ := inmem.NewKVInMemKVStore(ctx, pipeline, bucket+"_OT")
+	return &watermarkStore{
+		heartbeatStore:      hbKV,
+		offsetTimelineStore: otKV,
+	}, hbKVEntry, otKVEntry, nil
+}
+
+// BuildJetStreamWatermarkStore returns a JetStream WatermarkStore instance
+func BuildJetStreamWatermarkStore(ctx context.Context, bucket string, client *jsclient.NATSClient) (WatermarkStore, error) {
+	// build heartBeat store
+	hbKVName := JetStreamProcessorKVName(bucket)
+	hbStore, err := jetstream.NewKVJetStreamKVStore(ctx, hbKVName, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed at new JetStream HB KV store %q, %w", hbKVName, err)
+	}
+
+	// build offsetTimeline store
+	otStoreKVName := JetStreamOTKVName(bucket)
+	otStore, err := jetstream.NewKVJetStreamKVStore(ctx, otStoreKVName, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed at new JetStream OT KV store %q, %w", otStoreKVName, err)
+	}
+	return &watermarkStore{
+		heartbeatStore:      hbStore,
+		offsetTimelineStore: otStore,
+	}, nil
+}
+
+func JetStreamProcessorKVName(bucketName string) string {
+	return fmt.Sprintf("%s_PROCESSORS", bucketName)
+}
+
+func JetStreamOTKVName(bucketName string) string {
+	return fmt.Sprintf("%s_OT", bucketName)
 }

--- a/pkg/watermark/store/watermark_store_watcher.go
+++ b/pkg/watermark/store/watermark_store_watcher.go
@@ -52,9 +52,9 @@ func BuildNoOpWatermarkStoreWatcher() (WatermarkStoreWatcher, error) {
 }
 
 // BuildInmemWatermarkStoreWatcher returns an in-mem WatermarkStoreWatcher instance
-func BuildInmemWatermarkStoreWatcher(ctx context.Context, pipeline, bucket string, hbKVEntryCh, otKVEntryCh <-chan kvs.KVEntry) (WatermarkStoreWatcher, error) {
-	hbWatcher, _ := inmem.NewInMemWatch(ctx, pipeline, bucket+"_PROCESSORS", hbKVEntryCh)
-	otWatcher, _ := inmem.NewInMemWatch(ctx, pipeline, bucket+"_OT", otKVEntryCh)
+func BuildInmemWatermarkStoreWatcher(ctx context.Context, bucket string, hbKVEntryCh, otKVEntryCh <-chan kvs.KVEntry) (WatermarkStoreWatcher, error) {
+	hbWatcher, _ := inmem.NewInMemWatch(ctx, bucket+"_PROCESSORS", hbKVEntryCh)
+	otWatcher, _ := inmem.NewInMemWatch(ctx, bucket+"_OT", otKVEntryCh)
 	return &watermarkStoreWatcher{
 		heartbeatStoreWatcher:      hbWatcher,
 		offsetTimelineStoreWatcher: otWatcher,

--- a/pkg/watermark/store/watermark_store_watcher.go
+++ b/pkg/watermark/store/watermark_store_watcher.go
@@ -72,6 +72,7 @@ func BuildJetStreamWatermarkStoreWatcher(ctx context.Context, bucket string, cli
 	otKVName := JetStreamOTKVName(bucket)
 	otWatch, err := jetstream.NewKVJetStreamKVWatch(ctx, otKVName, client)
 	if err != nil {
+		hbWatch.Close()
 		return nil, fmt.Errorf("failed at new JetStream OT KV watch for %q, %w", otKVName, err)
 	}
 	return &watermarkStoreWatcher{

--- a/pkg/watermark/store/watermark_store_watcher.go
+++ b/pkg/watermark/store/watermark_store_watcher.go
@@ -16,7 +16,16 @@ limitations under the License.
 
 package store
 
-import "github.com/numaproj/numaflow/pkg/shared/kvs"
+import (
+	"context"
+	"fmt"
+
+	jsclient "github.com/numaproj/numaflow/pkg/shared/clients/nats"
+	"github.com/numaproj/numaflow/pkg/shared/kvs"
+	"github.com/numaproj/numaflow/pkg/shared/kvs/inmem"
+	"github.com/numaproj/numaflow/pkg/shared/kvs/jetstream"
+	noopkv "github.com/numaproj/numaflow/pkg/shared/kvs/noop"
+)
 
 // watermarkStoreWatcher defines a pair of heartbeatStoreWatcher and offsetTimelineStoreWatcher,
 // it implements interface WatermarkStoreWatcher
@@ -34,10 +43,39 @@ func (w *watermarkStoreWatcher) OffsetTimelineWatcher() kvs.KVWatcher {
 	return w.offsetTimelineStoreWatcher
 }
 
-// BuildWatermarkStoreWatcher returns a WatermarkStoreWatcher instance
-func BuildWatermarkStoreWatcher(hbStoreWatcher, otStoreWatcher kvs.KVWatcher) WatermarkStoreWatcher {
+// BuildNoOpWatermarkStoreWatcher returns a NoOp WatermarkStoreWatcher instance
+func BuildNoOpWatermarkStoreWatcher() (WatermarkStoreWatcher, error) {
 	return &watermarkStoreWatcher{
-		heartbeatStoreWatcher:      hbStoreWatcher,
-		offsetTimelineStoreWatcher: otStoreWatcher,
+		heartbeatStoreWatcher:      noopkv.NewKVOpWatch(),
+		offsetTimelineStoreWatcher: noopkv.NewKVOpWatch(),
+	}, nil
+}
+
+// BuildInmemWatermarkStoreWatcher returns an in-mem WatermarkStoreWatcher instance
+func BuildInmemWatermarkStoreWatcher(ctx context.Context, pipeline, bucket string, hbKVEntryCh, otKVEntryCh <-chan kvs.KVEntry) (WatermarkStoreWatcher, error) {
+	hbWatcher, _ := inmem.NewInMemWatch(ctx, pipeline, bucket+"_PROCESSORS", hbKVEntryCh)
+	otWatcher, _ := inmem.NewInMemWatch(ctx, pipeline, bucket+"_OT", otKVEntryCh)
+	return &watermarkStoreWatcher{
+		heartbeatStoreWatcher:      hbWatcher,
+		offsetTimelineStoreWatcher: otWatcher,
+	}, nil
+}
+
+// BuildJetStreamWatermarkStoreWatcher returns a JetStream WatermarkStoreWatcher instance
+func BuildJetStreamWatermarkStoreWatcher(ctx context.Context, bucket string, client *jsclient.NATSClient) (WatermarkStoreWatcher, error) {
+	hbKVName := JetStreamProcessorKVName(bucket)
+	hbWatch, err := jetstream.NewKVJetStreamKVWatch(ctx, hbKVName, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed at new JetStream HB KV watch for %q, %w", hbKVName, err)
 	}
+
+	otKVName := JetStreamOTKVName(bucket)
+	otWatch, err := jetstream.NewKVJetStreamKVWatch(ctx, otKVName, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed at new JetStream OT KV watch for %q, %w", otKVName, err)
+	}
+	return &watermarkStoreWatcher{
+		heartbeatStoreWatcher:      hbWatch,
+		offsetTimelineStoreWatcher: otWatch,
+	}, nil
 }

--- a/pkg/watermark/timeline/offset_timeline.go
+++ b/pkg/watermark/timeline/offset_timeline.go
@@ -42,13 +42,13 @@ type OffsetTimeline struct {
 }
 
 // NewOffsetTimeline returns OffsetTimeline.
-func NewOffsetTimeline(ctx context.Context, c int, bucket string) *OffsetTimeline {
+func NewOffsetTimeline(ctx context.Context, c int) *OffsetTimeline {
 	// Initialize a new empty watermarks DLL with nil values of the size capacity.
 	// This is to avoid length check: when a new element is added, the tail element will be deleted.
 	offsetTimeline := OffsetTimeline{
 		ctx:      ctx,
 		capacity: c,
-		log:      logging.FromContext(ctx).With("bucket", bucket),
+		log:      logging.FromContext(ctx),
 	}
 
 	for i := 0; i < c; i++ {

--- a/pkg/watermark/timeline/offset_timeline_test.go
+++ b/pkg/watermark/timeline/offset_timeline_test.go
@@ -29,8 +29,8 @@ import (
 func TestTimeline_GetEventTime(t *testing.T) {
 	var (
 		ctx            = context.Background()
-		emptyTimeline  = NewOffsetTimeline(ctx, 5, "myBucket")
-		testTimeline   = NewOffsetTimeline(ctx, 10, "myBucket")
+		emptyTimeline  = NewOffsetTimeline(ctx, 5)
+		testTimeline   = NewOffsetTimeline(ctx, 10)
 		testwatermarks = []wmb.WMB{
 			{Watermark: 10, Offset: 9},
 			{Watermark: 12, Offset: 10},
@@ -127,7 +127,7 @@ func TestTimeline_GetEventTime(t *testing.T) {
 func TestOffsetTimeline_GetOffset(t *testing.T) {
 	var (
 		ctx            = context.Background()
-		testTimeline   = NewOffsetTimeline(ctx, 10, "myBucket")
+		testTimeline   = NewOffsetTimeline(ctx, 10)
 		testwatermarks = []wmb.WMB{
 			{Watermark: 10, Offset: 9},
 			{Watermark: 12, Offset: 20},
@@ -223,7 +223,7 @@ func TestOffsetTimeline_GetOffset(t *testing.T) {
 func TestOffsetTimeline_PutIdle(t *testing.T) {
 	var (
 		ctx          = context.Background()
-		testTimeline = NewOffsetTimeline(ctx, 10, "myBucket")
+		testTimeline = NewOffsetTimeline(ctx, 10)
 		setUps       = []wmb.WMB{
 			{Idle: false, Watermark: 10, Offset: 9},
 			{Idle: false, Watermark: 12, Offset: 20},


### PR DESCRIPTION
1. Functions to build `WatermarkStore` and `WatermarkStoreWatcher` directly from `bucket`.
2. Remove `bucket` (only for logging) as an arg, use `ctx` to pass it.
3. Remove `pipeline` (only for logging) as an arg, use `ctx` to pass it.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
