### PR TITLE
fix bulleted list

### DIFF
--- a/docs/user-guide/reference/join-vertex.md
+++ b/docs/user-guide/reference/join-vertex.md
@@ -1,11 +1,13 @@
 # Joins and Cycles
 
 As of Numaflow v0.10, Pipeline Edges can be defined such that multiple Vertices send to a single vertex. This includes:
+
 - UDF Map Vertices
 - UDF Reduce Vertices
 - Sink Vertices
 
 Please see the following examples:
+
 - [Join on Map Vertex](https://github.com/numaproj/numaflow/blob/main/examples/11-join-on-map.yaml)
 - [Join on Reduce Vertex](https://github.com/numaproj/numaflow/blob/main/examples/11-join-on-reduce.yaml)
 - [Join on Sink Vertex](https://github.com/numaproj/numaflow/blob/main/examples/11-join-on-sink.yaml)
@@ -17,5 +19,6 @@ A special case of a "Join" is a **Cycle** (a Vertex which can send either to its
 Cycles are permitted, except in the case that there's a Reduce Vertex at or downstream of the cycle. (This is because a cycle inevitably produces late data, which would get dropped by the Reduce Vertex. For this reason, cycles should be used sparingly.)
 
 The following examples are of Cycles:
+
 - [Cycle to Self](https://github.com/numaproj/numaflow/blob/main/examples/10-cycle-to-self.yaml)
 - [Cycle to Previous](https://github.com/numaproj/numaflow/blob/main/examples/10-cycle-to-prev.yaml)


### PR DESCRIPTION
It seems bulleted lists don't reliably work unless there's a blank line before them? https://meta.stackexchange.com/questions/36298/list-markdown-doesnt-work-unless-preceded-by-a-blank-line

see result [here](https://github.com/juliev0/numaflow/blob/join-doc-bullets/docs/user-guide/reference/join-vertex.md)

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
