### PR TITLE
fix: missing edges on UI

### DIFF
--- a/ui/src/components/pages/Pipeline/partials/Graph/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/index.tsx
@@ -66,8 +66,8 @@ const getLayoutedElements = (
     // We are shifting the dagre node position (anchor=center) to the top left
     // so that it matches the React Flow node anchor point (top left).
     node.position = {
-      x: nodeWithPosition.x + Math.random() / 1000,
-      y: nodeWithPosition.y,
+      x: nodeWithPosition.x - nodeWidth / 2,
+      y: nodeWithPosition.y - nodeHeight / 2,
     };
   });
 

--- a/ui/src/components/pages/Pipeline/partials/Graph/style.css
+++ b/ui/src/components/pages/Pipeline/partials/Graph/style.css
@@ -17,3 +17,5 @@
 .Graph .controls button:first-child {
     margin-right: 10px;
 }
+
+.react-flow svg { overflow: visible; }


### PR DESCRIPTION
Fixes #952 
Added a fix for missing edges for some pipelines on UI
- Fixed the overflow attribute to display edges which rendered outside the `svg container` and `overflow:visible` was overridden by parent component 
<img width="1685" alt="image" src="https://github.com/numaproj/numaflow/assets/49195734/7ddb260d-c425-4142-a6c8-072ee0473a9f">