### PR TITLE
fix: seg fault inside controller

### DIFF
--- a/pkg/reconciler/vertex/controller.go
+++ b/pkg/reconciler/vertex/controller.go
@@ -112,7 +112,7 @@ func (r *vertexReconciler) reconcile(ctx context.Context, vertex *dfv1.Vertex) (
 		return ctrl.Result{}, err
 	}
 	if !isbSvc.Status.IsReady() {
-		r.markPhaseLogEvent(vertex, log, "ISBSvcNotReady", err.Error(), "isbsvc not ready", zap.String("isbsvc", isbSvcName), zap.Error(err))
+		r.markPhaseLogEvent(vertex, log, "ISBSvcNotReady", "isbsvc not ready", "isbsvc not ready", zap.String("isbsvc", isbSvcName))
 		return ctrl.Result{}, fmt.Errorf("isbsvc not ready")
 	}
 


### PR DESCRIPTION
<details>
<summary>logs</summary>

```bash
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x18f18bd]

goroutine 575 [running]:
github.com/numaproj/numaflow/pkg/reconciler/vertex.(*vertexReconciler).reconcile(0xc0007139f0, {0x257c138, 0xc000b4eae0}, 0xc0001d7180)
	/home/runner/work/numaflow/numaflow/pkg/reconciler/vertex/controller.go:115 +0x9bd
github.com/numaproj/numaflow/pkg/reconciler/vertex.(*vertexReconciler).Reconcile(0xc0007139f0, {0x257c138, 0xc000b4e930}, {{{0xc000c92450?, 0x20d4800?}, {0xc000744198?, 0x30?}}})
	/home/runner/work/numaflow/numaflow/pkg/reconciler/vertex/controller.go:75 +0x5c5
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc000cb8370, {0x257c138, 0xc000b4e900}, {{{0xc000c92450?, 0x20d4800?}, {0xc000744198?, 0x4045d4?}}})
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:114 +0x28b
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000cb8370, {0x257c090, 0xc0006c7ec0}, {0x1f915a0?, 0xc000ad8040?})
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:311 +0x352
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000cb8370, {0x257c090, 0xc0006c7ec0})
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:266 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:227 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:223 +0x31c

```
</details>