### PR TITLE
feat: colored logs for UI with toggle for logs order

### DIFF
--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.test.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.test.tsx
@@ -1,15 +1,64 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react-test-renderer";
+import { TextEncoder, TextDecoder } from "util";
 import { PodLogs } from "./index";
 
+Object.assign(global, { TextDecoder, TextEncoder });
+
 describe("PodLogs", () => {
+  let originFetch: any;
+  beforeEach(() => {
+    originFetch = (global as any).fetch;
+  });
+  afterEach(() => {
+    (global as any).fetch = originFetch;
+  });
+
   it("Load PodLogs screen", async () => {
-    const { container } = render(
-      <PodLogs
-        namespaceId={"numaflow-system"}
-        containerName={"numa"}
-        podName={"simple-pipeline-infer-0-xah5w"}
-      />
-    );
+    const mRes = {
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            Buffer.from(
+              `{"level":"info","ts":"2023-09-04T11:50:19.712416709Z","logger":"numaflow.Source-processor","caller":"publish/publisher.go:180","msg":"Skip publishing the new watermark because it's older than the current watermark","pipeline":"simple-pipeline","vertex":"in","entityID":"simple-pipeline-in-0","otStore":"default-simple-pipeline-in-cat_OT","hbStore":"default-simple-pipeline-in-cat_PROCESSORS","toVertexPartitionIdx":0,"entity":"simple-pipeline-in-0","head":1693828217394,"new":-1}`
+            )
+          );
+          controller.enqueue(
+            Buffer.from(
+              `{"level":"error","ts":"2023-09-04T11:50:19.712416709Z","logger":"numaflow.Source-processor","caller":"publish/publisher.go:180","msg":"Skip publishing the new watermark because it's older than the current watermark","pipeline":"simple-pipeline","vertex":"in","entityID":"simple-pipeline-in-0","otStore":"default-simple-pipeline-in-cat_OT","hbStore":"default-simple-pipeline-in-cat_PROCESSORS","toVertexPartitionIdx":0,"entity":"simple-pipeline-in-0","head":1693828217394,"new":-1}`
+            )
+          );
+          controller.enqueue(
+            Buffer.from(
+              `{"level":"warn","ts":"2023-09-04T11:50:19.712416709Z","logger":"numaflow.Source-processor","caller":"publish/publisher.go:180","msg":"Skip publishing the new watermark because it's older than the current watermark","pipeline":"simple-pipeline","vertex":"in","entityID":"simple-pipeline-in-0","otStore":"default-simple-pipeline-in-cat_OT","hbStore":"default-simple-pipeline-in-cat_PROCESSORS","toVertexPartitionIdx":0,"entity":"simple-pipeline-in-0","head":1693828217394,"new":-1}`
+            )
+          );
+          controller.enqueue(
+            Buffer.from(
+              `{"level":"debug","ts":"2023-09-04T11:50:19.712416709Z","logger":"numaflow.Source-processor","caller":"publish/publisher.go:180","msg":"Skip publishing the new watermark because it's older than the current watermark","pipeline":"simple-pipeline","vertex":"in","entityID":"simple-pipeline-in-0","otStore":"default-simple-pipeline-in-cat_OT","hbStore":"default-simple-pipeline-in-cat_PROCESSORS","toVertexPartitionIdx":0,"entity":"simple-pipeline-in-0","head":1693828217394,"new":-1}`
+            )
+          );
+          controller.close();
+        },
+      }),
+      ok: true,
+    };
+    const mockedFetch = jest.fn().mockResolvedValue(mRes as any);
+    (global as any).fetch = mockedFetch;
+    let container;
+    await act(async () => {
+      const { container: cont } = render(
+        <PodLogs
+          namespaceId={"numaflow-system"}
+          containerName={"numa"}
+          podName={"simple-pipeline-infer-0-xah5w"}
+        />
+      );
+      container = cont;
+    });
+
+    expect(mockedFetch).toBeCalledTimes(1);
+
     //search for logs
     fireEvent.change(
       container.getElementsByClassName(
@@ -17,6 +66,14 @@ describe("PodLogs", () => {
       )[0],
       { target: { value: "load" } }
     );
+    //search for logs not present
+    fireEvent.change(
+      container.getElementsByClassName(
+        "MuiInputBase-input css-yz9k0d-MuiInputBase-input"
+      )[0],
+      { target: { value: "xyz" } }
+    );
+    expect(screen.getByText("No logs matching search.")).toBeVisible();
     //negate logs search
     fireEvent.click(
       container.getElementsByClassName(
@@ -29,9 +86,41 @@ describe("PodLogs", () => {
     fireEvent.click(screen.getByTestId("clear-button"));
     //pause logs
     expect(screen.getByTestId("pause-button")).toBeVisible();
-    //pause
-    fireEvent.click(screen.getByTestId("pause-button"));
-    //unpause
-    fireEvent.click(screen.getByTestId("pause-button"));
+    act(() => {
+      fireEvent.click(screen.getByTestId("pause-button"));
+      //play logs
+      fireEvent.click(screen.getByTestId("pause-button"));
+    });
+    //toggle theme
+    expect(screen.getByTestId("color-mode-button")).toBeVisible();
+    fireEvent.click(screen.getByTestId("color-mode-button"));
+    //toggle logs order
+    expect(screen.getByTestId("order-button")).toBeVisible();
+    fireEvent.click(screen.getByTestId("order-button"));
+  });
+
+  it("Trigger PodLogs parsing error", async () => {
+    const mRes = {
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(Buffer.from("something"));
+          controller.close();
+        },
+      }),
+      ok: true,
+    };
+    const mockedFetch = jest.fn().mockResolvedValueOnce(mRes as any);
+    (global as any).fetch = mockedFetch;
+    await act(async () => {
+      render(
+        <PodLogs
+          namespaceId={"numaflow-system"}
+          containerName={"numa"}
+          podName={"simple-pipeline-infer-0-xah5w"}
+        />
+      );
+    });
+
+    expect(mockedFetch).toBeCalledTimes(1);
   });
 });

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
@@ -10,6 +10,7 @@ import ArrowUpward from "@mui/icons-material/ArrowUpward";
 import ArrowDownward from "@mui/icons-material/ArrowDownward";
 import LightMode from "@mui/icons-material/LightMode";
 import DarkMode from "@mui/icons-material/DarkMode";
+import Tooltip from "@mui/material/Tooltip";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Checkbox from "@mui/material/Checkbox";
 import Highlighter from "react-highlight-words";
@@ -220,15 +221,45 @@ export function PodLogs({ namespaceId, podName, containerName }: PodLogsProps) {
           }
           label="Negate search"
         />
-        <IconButton data-testid="pause-button" onClick={handlePause}>
-          {paused ? <PlayArrowIcon /> : <PauseIcon />}
-        </IconButton>
-        <IconButton data-testid="color-mode-button" onClick={handleColorMode}>
-          {colorMode === "light" ? <DarkMode /> : <LightMode />}
-        </IconButton>
-        <IconButton data-testid="order-button" onClick={handleOrder}>
-          {logsOrder === "asc" ? <ArrowDownward /> : <ArrowUpward />}
-        </IconButton>
+        <Tooltip
+          title={
+            <div className={"icon-tooltip"}>
+              {paused ? "Play" : "Pause"} logs
+            </div>
+          }
+          placement={"top"}
+          arrow
+        >
+          <IconButton data-testid="pause-button" onClick={handlePause}>
+            {paused ? <PlayArrowIcon /> : <PauseIcon />}
+          </IconButton>
+        </Tooltip>
+        <Tooltip
+          title={
+            <div className={"icon-tooltip"}>
+              {colorMode === "light" ? "Dark" : "Light"} mode
+            </div>
+          }
+          placement={"top"}
+          arrow
+        >
+          <IconButton data-testid="color-mode-button" onClick={handleColorMode}>
+            {colorMode === "light" ? <DarkMode /> : <LightMode />}
+          </IconButton>
+        </Tooltip>
+        <Tooltip
+          title={
+            <div className={"icon-tooltip"}>
+              {logsOrder === "asc" ? "Descending" : "Ascending"} order
+            </div>
+          }
+          placement={"top"}
+          arrow
+        >
+          <IconButton data-testid="order-button" onClick={handleOrder}>
+            {logsOrder === "asc" ? <ArrowDownward /> : <ArrowUpward />}
+          </IconButton>
+        </Tooltip>
       </Box>
       <Box
         sx={{

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/style.css
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/style.css
@@ -1,3 +1,7 @@
 .PodLogs-search {
   margin-right: 1rem;
 }
+
+.icon-tooltip {
+  font-size: 0.8125rem;
+}


### PR DESCRIPTION
Fixes #794 
Fixes #701 

- Added color support for logs based on log levels - (info, error, warn, debug)
- Added initial timestamp to logs for a consistent view
- Added toggles for logs theme (dark/light mode) and logs order (asc/desc order)
- Used bold text for logs for better visibility

![image](https://github.com/numaproj/numaflow/assets/49195734/0571d896-62d2-4f1a-9e37-af0b87b96118)
![image](https://github.com/numaproj/numaflow/assets/49195734/d019656f-8e46-4bce-af82-e59c9182d088)
![image](https://github.com/numaproj/numaflow/assets/49195734/c1990e90-a349-436e-b8eb-2058e12ac6a6)
![image](https://github.com/numaproj/numaflow/assets/49195734/1e320d1d-42d7-4003-8191-507a9e186baf)
