### PR TITLE
fix: calculate processing rate for sink vertices

### DIFF
--- a/pkg/daemon/server/service/rater/pod_tracker.go
+++ b/pkg/daemon/server/service/rater/pod_tracker.go
@@ -93,6 +93,8 @@ func (pt *PodTracker) Start(ctx context.Context) error {
 						vType = "reduce"
 					} else if v.IsASource() {
 						vType = "source"
+					} else if v.IsASink() {
+						vType = "sink"
 					} else {
 						vType = "other"
 					}

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -121,7 +121,7 @@ func (s *FunctionalSuite) TestCreateSimplePipeline() {
 		for {
 			accurateCount := 0
 			for _, vertexName := range vertexNames {
-				m, err := client.GetVertexMetrics(context.Background(), pipelineName, "p1")
+				m, err := client.GetVertexMetrics(context.Background(), pipelineName, vertexName)
 				assert.NoError(s.T(), err)
 				assert.Equal(s.T(), pipelineName, *m[0].Pipeline)
 				oneMinRate := m[0].ProcessingRates["1m"]

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -117,13 +117,20 @@ func (s *FunctionalSuite) TestCreateSimplePipeline() {
 	waitInterval := 10 * time.Second
 	succeedChan := make(chan struct{})
 	go func() {
+		vertexNames := []string{"input", "p1", "output"}
 		for {
-			m, err := client.GetVertexMetrics(context.Background(), pipelineName, "p1")
-			assert.NoError(s.T(), err)
-			assert.Equal(s.T(), pipelineName, *m[0].Pipeline)
-			oneMinRate := m[0].ProcessingRates["1m"]
-			// the rate should be around 5
-			if oneMinRate < 4 || oneMinRate > 6 {
+			accurateCount := 0
+			for _, vertexName := range vertexNames {
+				m, err := client.GetVertexMetrics(context.Background(), pipelineName, "p1")
+				assert.NoError(s.T(), err)
+				assert.Equal(s.T(), pipelineName, *m[0].Pipeline)
+				oneMinRate := m[0].ProcessingRates["1m"]
+				// the rate should be around 5
+				if oneMinRate > 4 || oneMinRate < 6 {
+					accurateCount++
+				}
+			}
+			if accurateCount != len(vertexNames) {
 				time.Sleep(waitInterval)
 			} else {
 				succeedChan <- struct{}{}


### PR DESCRIPTION
Before PR

![Screenshot 2023-09-08 at 12 17 17 PM](https://github.com/numaproj/numaflow/assets/13165977/de1aefdd-2824-4e55-8bfc-1792fe27ef9f)

After PR

![Screenshot 2023-09-08 at 12 37 05 PM](https://github.com/numaproj/numaflow/assets/13165977/5dfb26eb-2d5f-43c6-919b-2f8babad84ea)

After we separate the sink forwarder, we changed the readTotal metric name to `sink_read_total`, hence we need to introduce a new vertex type key to the pod tracker such that the type key name "sink" can be used to determine which metric to look for.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
