### PR TITLE
feat: update vertex and get vertices metrics APIs

### DIFF
--- a/server/apis/v1_1/handler.go
+++ b/server/apis/v1_1/handler.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaflow/pkg/apis/proto/daemon"
 	dfv1versiond "github.com/numaproj/numaflow/pkg/client/clientset/versioned"
 	dfv1clients "github.com/numaproj/numaflow/pkg/client/clientset/versioned/typed/numaflow/v1alpha1"
 	daemonclient "github.com/numaproj/numaflow/pkg/daemon/client"
@@ -437,87 +438,83 @@ func (h *handler) GetPipelineWatermarks(c *gin.Context) {
 
 // UpdateVertex is used to provide the vertex spec
 func (h *handler) UpdateVertex(c *gin.Context) {
-	// TODO
-	// var (
-	// 	requestBody     dfv1.AbstractVertex
-	// 	inputVertexName = c.Param("vertex")
-	// )
-	// pl, err := h.numaflowClient.Pipelines(c.Param("namespace")).Get(context.Background(), c.Param("pipeline"), metav1.GetOptions{})
-	// if err != nil {
-	// 	errMsg := fmt.Sprintf("Failed to update the vertex: namespace %q pipeline %q vertex %q: %v", c.Param("namespace"), c.Param("pipeline"), inputVertexName, err.Error())
-	// 	c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
-	// 	return
-	// }
-	// err = json.NewDecoder(c.Request.Body).Decode(&requestBody)
-	// if err != nil {
-	// 	errMsg := fmt.Sprintf("Failed to update the vertex: namespace %q pipeline %q vertex %q: %v", c.Param("namespace"), c.Param("pipeline"), inputVertexName, err.Error())
-	// 	c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
-	// 	return
-	// }
-	// if requestBody.Name != inputVertexName {
-	// 	errMsg := fmt.Sprintf("Failed to update the vertex: vertex name %q is immutable", inputVertexName)
-	// 	c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
-	// 	return
-	// }
-	// for index, vertex := range pl.Spec.Vertices {
-	// 	if vertex.Name == inputVertexName {
-	// 		if vertex.IsASource() && requestBody.IsASource() {
-	// 		} else if vertex.IsMapUDF() && requestBody.IsMapUDF() {
-	// 		} else if vertex.IsReduceUDF() && requestBody.IsReduceUDF() {
-	// 		} else if vertex.IsASink() && requestBody.IsASink() {
-	// 		} else if vertex.IsUDSource() && requestBody.IsUDSource() {
-	// 		} else if vertex.IsUDSource() && requestBody.IsUDSink() {
-	// 		} else {
-	// 			errMsg := fmt.Sprintf("Failed to update the vertex: vertex type is immutable")
-	// 			c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
-	// 			return
-	// 		}
-	// 		pl.Spec.Vertices[index] = requestBody
-	// 		break
-	// 	}
-	// }
-	// _, err = h.numaflowClient.Pipelines(c.Param("namespace")).Update(context.Background(), pl, metav1.UpdateOptions{})
-	// if err != nil {
-	// 	errMsg := fmt.Sprintf("Failed to update the vertex: namespace %q pipeline %q vertex %q: %v", c.Param("namespace"), c.Param("pipeline"), inputVertexName, err.Error())
-	// 	c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
-	// 	return
-	// }
-	// c.JSON(http.StatusOK, NewNumaflowAPIResponse(nil, pl.Spec))
-	c.JSON(http.StatusOK, NewNumaflowAPIResponse(nil, nil))
+	var (
+		requestBody     dfv1.AbstractVertex
+		inputVertexName = c.Param("vertex")
+	)
+	pl, err := h.numaflowClient.Pipelines(c.Param("namespace")).Get(context.Background(), c.Param("pipeline"), metav1.GetOptions{})
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to update the vertex: namespace %q pipeline %q vertex %q: %v", c.Param("namespace"), c.Param("pipeline"), inputVertexName, err.Error())
+		c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
+		return
+	}
+	err = json.NewDecoder(c.Request.Body).Decode(&requestBody)
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to update the vertex: namespace %q pipeline %q vertex %q: %v", c.Param("namespace"), c.Param("pipeline"), inputVertexName, err.Error())
+		c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
+		return
+	}
+	if requestBody.Name != inputVertexName {
+		errMsg := fmt.Sprintf("Failed to update the vertex: vertex name %q is immutable", inputVertexName)
+		c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
+		return
+	}
+	for index, vertex := range pl.Spec.Vertices {
+		if vertex.Name == inputVertexName {
+			if vertex.IsASource() && requestBody.IsASource() {
+			} else if vertex.IsMapUDF() && requestBody.IsMapUDF() {
+			} else if vertex.IsReduceUDF() && requestBody.IsReduceUDF() {
+			} else if vertex.IsASink() && requestBody.IsASink() {
+			} else if vertex.IsUDSource() && requestBody.IsUDSource() {
+			} else if vertex.IsUDSource() && requestBody.IsUDSink() {
+			} else {
+				errMsg := fmt.Sprintf("Failed to update the vertex: vertex type is immutable")
+				c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
+				return
+			}
+			pl.Spec.Vertices[index] = requestBody
+			break
+		}
+	}
+	_, err = h.numaflowClient.Pipelines(c.Param("namespace")).Update(context.Background(), pl, metav1.UpdateOptions{})
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to update the vertex: namespace %q pipeline %q vertex %q: %v", c.Param("namespace"), c.Param("pipeline"), inputVertexName, err.Error())
+		c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
+		return
+	}
+	c.JSON(http.StatusOK, NewNumaflowAPIResponse(nil, pl.Spec))
 }
 
 // GetVerticesMetrics is used to provide information about all the vertices for the given pipeline including processing rates.
 func (h *handler) GetVerticesMetrics(c *gin.Context) {
-	// TODO
-	// ns := c.Param("namespace")
-	// pipeline := c.Param("pipeline")
-	// pl, err := h.numaflowClient.Pipelines(pipeline).Get(context.Background(), pipeline, metav1.GetOptions{})
-	// if err != nil {
-	// 	errMsg := fmt.Sprintf("Failed to get the vertices metrics: namespace %q pipeline %q: %v", c.Param("namespace"), c.Param("pipeline"), err.Error())
-	// 	c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
-	// 	return
-	// }
-	// client, err := daemonclient.NewDaemonServiceClient(daemonSvcAddress(ns, pipeline))
-	// if err != nil {
-	// 	errMsg := fmt.Sprintf("Failed to get the vertices metrics: namespace %q pipeline %q: %v", c.Param("namespace"), c.Param("pipeline"), err.Error())
-	// 	c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
-	// 	return
-	// }
-	// defer func() {
-	// 	_ = client.Close()
-	// }()
-	// var results [][]*daemon.VertexMetrics
-	// for _, vertex := range pl.Spec.Vertices {
-	// 	l, err := client.GetVertexMetrics(context.Background(), pipeline, vertex.Name)
-	// 	if err != nil {
-	// 		errMsg := fmt.Sprintf("Failed to get the vertices metrics: namespace %q pipeline %q vertex %q: %v", c.Param("namespace"), c.Param("pipeline"), vertex.Name, err.Error())
-	// 		c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
-	// 		return
-	// 	}
-	// 	results = append(results, l)
-	// }
-	// c.JSON(http.StatusOK, results)
-	c.JSON(http.StatusOK, NewNumaflowAPIResponse(nil, nil))
+	ns := c.Param("namespace")
+	pipeline := c.Param("pipeline")
+	pl, err := h.numaflowClient.Pipelines(pipeline).Get(context.Background(), pipeline, metav1.GetOptions{})
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to get the vertices metrics: namespace %q pipeline %q: %v", c.Param("namespace"), c.Param("pipeline"), err.Error())
+		c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
+		return
+	}
+	client, err := daemonclient.NewDaemonServiceClient(daemonSvcAddress(ns, pipeline))
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to get the vertices metrics: namespace %q pipeline %q: %v", c.Param("namespace"), c.Param("pipeline"), err.Error())
+		c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
+		return
+	}
+	defer func() {
+		_ = client.Close()
+	}()
+	var results [][]*daemon.VertexMetrics
+	for _, vertex := range pl.Spec.Vertices {
+		l, err := client.GetVertexMetrics(context.Background(), pipeline, vertex.Name)
+		if err != nil {
+			errMsg := fmt.Sprintf("Failed to get the vertices metrics: namespace %q pipeline %q vertex %q: %v", c.Param("namespace"), c.Param("pipeline"), vertex.Name, err.Error())
+			c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
+			return
+		}
+		results = append(results, l)
+	}
+	c.JSON(http.StatusOK, results)
 }
 
 // ListVertexPods is used to provide all the pods of a vertex

--- a/server/apis/v1_1/handler.go
+++ b/server/apis/v1_1/handler.go
@@ -489,15 +489,15 @@ func (h *handler) UpdateVertex(c *gin.Context) {
 func (h *handler) GetVerticesMetrics(c *gin.Context) {
 	ns := c.Param("namespace")
 	pipeline := c.Param("pipeline")
-	pl, err := h.numaflowClient.Pipelines(pipeline).Get(context.Background(), pipeline, metav1.GetOptions{})
+	pl, err := h.numaflowClient.Pipelines(ns).Get(context.Background(), pipeline, metav1.GetOptions{})
 	if err != nil {
-		errMsg := fmt.Sprintf("Failed to get the vertices metrics: namespace %q pipeline %q: %v", c.Param("namespace"), c.Param("pipeline"), err.Error())
+		errMsg := fmt.Sprintf("Failed to get the vertices metrics: namespace %q pipeline %q: %v", ns, pipeline, err.Error())
 		c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
 		return
 	}
 	client, err := daemonclient.NewDaemonServiceClient(daemonSvcAddress(ns, pipeline))
 	if err != nil {
-		errMsg := fmt.Sprintf("Failed to get the vertices metrics: namespace %q pipeline %q: %v", c.Param("namespace"), c.Param("pipeline"), err.Error())
+		errMsg := fmt.Sprintf("Failed to get the vertices metrics: failed to get demon service client for namespace %q pipeline %q: %v", ns, pipeline, err.Error())
 		c.JSON(http.StatusOK, NewNumaflowAPIResponse(&errMsg, nil))
 		return
 	}

--- a/server/routes/routes_v1_1.go
+++ b/server/routes/routes_v1_1.go
@@ -41,10 +41,10 @@ func v1_1Routes(r gin.IRouter) {
 	r.GET("/namespaces/:namespace/pipelines/:pipeline/isbs", handler.ListPipelineBuffers)
 	// Get all the watermarks information of a pipeline.
 	r.GET("/namespaces/:namespace/pipelines/:pipeline/watermarks", handler.GetPipelineWatermarks)
-	// Update a vertex spec. // TODO
-	r.PUT("/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex")
-	// Get all the vertex metrics of a pipeline. // TODO
-	r.GET("/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/metrics")
+	// Update a vertex spec.
+	r.PUT("/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex", handler.UpdateVertex)
+	// Get all the vertex metrics of a pipeline.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/vertices/metrics", handler.GetVerticesMetrics)
 	// Get all the pods of a vertex.
 	r.GET("/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/pods", handler.ListVertexPods)
 	// Get the metrics such as cpu, memory usage for a pod.


### PR DESCRIPTION
- add get vertices metrics API
- add update vertex API

Tested with basic use case locally.

TODO: improvement and more testing

=== Local Test on get vertices metrics ===
<img width="883" alt="image" src="https://github.com/numaproj/numaflow/assets/19543684/7e247a23-59b7-450f-80ce-6695bff5a459">

=== Local Test on Update ===
unable to update type
<img width="672" alt="image" src="https://github.com/numaproj/numaflow/assets/19543684/00e351dc-3661-44fc-badc-05fc8f5eaf32">
unable to update name
<img width="700" alt="image" src="https://github.com/numaproj/numaflow/assets/19543684/ee5678dd-9508-4e7f-a2ab-361d5b2cd9c1">
update rpu
<img width="539" alt="image" src="https://github.com/numaproj/numaflow/assets/19543684/3ce79a0c-4e2f-4737-b672-6475dc7ff2e9">
update scale min
<img width="424" alt="image" src="https://github.com/numaproj/numaflow/assets/19543684/0af784a7-c93c-4754-8b03-8fe6a0de2b4b">

<img width="1311" alt="image" src="https://github.com/numaproj/numaflow/assets/19543684/c432ba9f-fdbf-4393-9596-4f5e12f0fe34">

