### PR TITLE
fix: K8s events API

### DIFF
--- a/server/apis/v1_1/handler.go
+++ b/server/apis/v1_1/handler.go
@@ -619,7 +619,7 @@ func (h *handler) GetNamespaceEvents(c *gin.Context) {
 		if event.LastTimestamp.Time == defaultTimeObject {
 			continue
 		}
-		var newEvent = NewK8sEventsResponse(event.LastTimestamp.UnixMilli(), event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message)
+		var newEvent = NewK8sEventsResponse(event.LastTimestamp.UnixMilli(), event.Type, event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message)
 		response = append(response, newEvent)
 	}
 

--- a/server/apis/v1_1/handler.go
+++ b/server/apis/v1_1/handler.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -614,6 +615,12 @@ func (h *handler) GetNamespaceEvents(c *gin.Context) {
 		var newEvent = NewK8sEventsResponse(event.LastTimestamp.UnixMilli(), event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message)
 		response = append(response, newEvent)
 	}
+
+	// sort the events by timestamp
+	// from most recent events to older events
+	sort.Slice(response, func(i int, j int) bool {
+		return response[i].TimeStamp >= response[j].TimeStamp
+	})
 
 	c.JSON(http.StatusOK, NewNumaflowAPIResponse(nil, response))
 }

--- a/server/apis/v1_1/handler.go
+++ b/server/apis/v1_1/handler.go
@@ -611,7 +611,7 @@ func (h *handler) GetNamespaceEvents(c *gin.Context) {
 	var response []K8sEventsResponse
 
 	for _, event := range events.Items {
-		var newEvent = NewK8sEventsResponse(event.LastTimestamp.String(), event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message)
+		var newEvent = NewK8sEventsResponse(event.LastTimestamp.UTC().UnixMilli(), event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message)
 		response = append(response, newEvent)
 	}
 

--- a/server/apis/v1_1/handler.go
+++ b/server/apis/v1_1/handler.go
@@ -608,7 +608,14 @@ func (h *handler) GetNamespaceEvents(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, NewNumaflowAPIResponse(nil, events.Items))
+	var response []K8sEventsResponse
+
+	for _, event := range events.Items {
+		var newEvent = NewK8sEventsResponse(event.LastTimestamp.String(), event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message)
+		response = append(response, newEvent)
+	}
+
+	c.JSON(http.StatusOK, NewNumaflowAPIResponse(nil, response))
 }
 
 // ValidatePipeline is used to validate the pipeline spec

--- a/server/apis/v1_1/handler.go
+++ b/server/apis/v1_1/handler.go
@@ -611,7 +611,7 @@ func (h *handler) GetNamespaceEvents(c *gin.Context) {
 	var response []K8sEventsResponse
 
 	for _, event := range events.Items {
-		var newEvent = NewK8sEventsResponse(event.LastTimestamp.UTC().UnixMilli(), event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message)
+		var newEvent = NewK8sEventsResponse(event.LastTimestamp.UnixMilli(), event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message)
 		response = append(response, newEvent)
 	}
 

--- a/server/apis/v1_1/handler.go
+++ b/server/apis/v1_1/handler.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	corev1 "k8s.io/api/core/v1"
@@ -609,9 +610,15 @@ func (h *handler) GetNamespaceEvents(c *gin.Context) {
 		return
 	}
 
-	var response []K8sEventsResponse
+	var (
+		response          []K8sEventsResponse
+		defaultTimeObject time.Time
+	)
 
 	for _, event := range events.Items {
+		if event.LastTimestamp.Time == defaultTimeObject {
+			continue
+		}
 		var newEvent = NewK8sEventsResponse(event.LastTimestamp.UnixMilli(), event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message)
 		response = append(response, newEvent)
 	}

--- a/server/apis/v1_1/response_cluster_summary.go
+++ b/server/apis/v1_1/response_cluster_summary.go
@@ -33,14 +33,14 @@ type IsbServiceSummary struct {
 // of all the namespaces in a cluster wrapped in a list.
 type ClusterSummaryResponse []ClusterSummary
 
-// ClusterSummary summarizes information for a given namespace
+// ClusterSummary summarizes information for a given namespace.
 type ClusterSummary struct {
 	Namespace         string            `json:"namespace"`
 	PipelineSummary   PipelineSummary   `json:"pipelineSummary"`
 	IsbServiceSummary IsbServiceSummary `json:"isbServiceSummary"`
 }
 
-// NewClusterSummary creates a new ClusterSummary object with the given specifications
+// NewClusterSummary creates a new ClusterSummary object with the given specifications.
 func NewClusterSummary(namespace string, pipelineSummary PipelineSummary,
 	isbSummary IsbServiceSummary) ClusterSummary {
 	return ClusterSummary{

--- a/server/apis/v1_1/response_k8s_events.go
+++ b/server/apis/v1_1/response_k8s_events.go
@@ -1,15 +1,12 @@
 package v1_1
 
-type K8sEventsObject struct {
-	Kind string `json:"kind"`
-	Name string `json:"name"`
-}
+import "fmt"
 
 type K8sEventsResponse struct {
-	TimeStamp int64           `json:"timestamp"`
-	Object    K8sEventsObject `json:"object"`
-	Reason    string          `json:"reason"`
-	Message   string          `json:"message"`
+	TimeStamp int64  `json:"timestamp"`
+	Object    string `json:"object"`
+	Reason    string `json:"reason"`
+	Message   string `json:"message"`
 }
 
 // NewK8sEventsResponse creates a new K8sEventsResponse object with the given inputs.
@@ -17,11 +14,8 @@ func NewK8sEventsResponse(timestamp int64, objectKind, objectName, reason, messa
 
 	return K8sEventsResponse{
 		TimeStamp: timestamp,
-		Object: K8sEventsObject{
-			Kind: objectKind,
-			Name: objectName,
-		},
-		Reason:  reason,
-		Message: message,
+		Object:    fmt.Sprintf("%s/%s", objectKind, objectName),
+		Reason:    reason,
+		Message:   message,
 	}
 }

--- a/server/apis/v1_1/response_k8s_events.go
+++ b/server/apis/v1_1/response_k8s_events.go
@@ -1,0 +1,18 @@
+package v1_1
+
+type K8sEventsResponse struct {
+	TimeStamp string `json:"timestamp"`
+	Object    string `json:"object"`
+	Reason    string `json:"reason"`
+	Message   string `json:"message"`
+}
+
+// NewK8sEventsResponse creates a new K8sEventsResponse object with the given inputs.
+func NewK8sEventsResponse(timestamp, object, reason, message string) K8sEventsResponse {
+	return K8sEventsResponse{
+		TimeStamp: timestamp,
+		Object:    object,
+		Reason:    reason,
+		Message:   message,
+	}
+}

--- a/server/apis/v1_1/response_k8s_events.go
+++ b/server/apis/v1_1/response_k8s_events.go
@@ -6,14 +6,14 @@ type K8sEventsObject struct {
 }
 
 type K8sEventsResponse struct {
-	TimeStamp string          `json:"timestamp"`
+	TimeStamp int64           `json:"timestamp"`
 	Object    K8sEventsObject `json:"object"`
 	Reason    string          `json:"reason"`
 	Message   string          `json:"message"`
 }
 
 // NewK8sEventsResponse creates a new K8sEventsResponse object with the given inputs.
-func NewK8sEventsResponse(timestamp, objectKind, objectName, reason, message string) K8sEventsResponse {
+func NewK8sEventsResponse(timestamp int64, objectKind, objectName, reason, message string) K8sEventsResponse {
 
 	return K8sEventsResponse{
 		TimeStamp: timestamp,

--- a/server/apis/v1_1/response_k8s_events.go
+++ b/server/apis/v1_1/response_k8s_events.go
@@ -1,18 +1,27 @@
 package v1_1
 
+type K8sEventsObject struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
 type K8sEventsResponse struct {
-	TimeStamp string `json:"timestamp"`
-	Object    string `json:"object"`
-	Reason    string `json:"reason"`
-	Message   string `json:"message"`
+	TimeStamp string          `json:"timestamp"`
+	Object    K8sEventsObject `json:"object"`
+	Reason    string          `json:"reason"`
+	Message   string          `json:"message"`
 }
 
 // NewK8sEventsResponse creates a new K8sEventsResponse object with the given inputs.
-func NewK8sEventsResponse(timestamp, object, reason, message string) K8sEventsResponse {
+func NewK8sEventsResponse(timestamp, objectKind, objectName, reason, message string) K8sEventsResponse {
+
 	return K8sEventsResponse{
 		TimeStamp: timestamp,
-		Object:    object,
-		Reason:    reason,
-		Message:   message,
+		Object: K8sEventsObject{
+			Kind: objectKind,
+			Name: objectName,
+		},
+		Reason:  reason,
+		Message: message,
 	}
 }

--- a/server/apis/v1_1/response_k8s_events.go
+++ b/server/apis/v1_1/response_k8s_events.go
@@ -4,16 +4,18 @@ import "fmt"
 
 type K8sEventsResponse struct {
 	TimeStamp int64  `json:"timestamp"`
+	Type      string `json:"type"`
 	Object    string `json:"object"`
 	Reason    string `json:"reason"`
 	Message   string `json:"message"`
 }
 
 // NewK8sEventsResponse creates a new K8sEventsResponse object with the given inputs.
-func NewK8sEventsResponse(timestamp int64, objectKind, objectName, reason, message string) K8sEventsResponse {
+func NewK8sEventsResponse(timestamp int64, eventType, objectKind, objectName, reason, message string) K8sEventsResponse {
 
 	return K8sEventsResponse{
 		TimeStamp: timestamp,
+		Type:      eventType,
 		Object:    fmt.Sprintf("%s/%s", objectKind, objectName),
 		Reason:    reason,
 		Message:   message,


### PR DESCRIPTION
Update K8s Events API response structure
Sort the response by timestamp from newest to oldest 

example payload
```
{
    "data": [
        {
            "timestamp": 1695756111000,
            "object": {
                "kind": "Pod",
                "name": "isbsvc-test-js-0"
            },
            "reason": "Killing",
            "message": "Stopping container reloader"
        },
        {
            "timestamp": 1695756111000,
            "object": {
                "kind": "Pod",
                "name": "isbsvc-test-js-0"
            },
            "reason": "Killing",
            "message": "Stopping container metrics"
        },
        {
            "timestamp": 1695753312000,
            "object": {
                "kind": "Deployment",
                "name": "simple-pipeline-test-daemon"
            },
            "reason": "ScalingReplicaSet",
            "message": "Scaled up replica set simple-pipeline-test-daemon-6d8cc9f6f6 to 1"
        },
        {
            "timestamp": 1695753237000,
            "object": {
                "kind": "Pipeline",
                "name": "simple-pipeline"
            },
            "reason": "ReconcilePipelineFailed",
            "message": "Failed to check if it's safe to delete the pipeline: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp: lookup simple-pipeline-daemon-svc.default.svc on 10.96.0.10:53: no such host\""
        },
        {
            "timestamp": 1695753051000,
            "object": {
                "kind": "Pod",
                "name": "isbsvc-test-js-2"
            },
            "reason": "Started",
            "message": "Started container reloader"
        },
        {
            "timestamp": 1695753051000,
            "object": {
                "kind": "Pod",
                "name": "isbsvc-test-js-2"
            },
            "reason": "Created",
            "message": "Created container metrics"
        },
        {
            "timestamp": 1695753051000,
            "object": {
                "kind": "Pod",
                "name": "isbsvc-test-js-2"
            },
            "reason": "Started",
            "message": "Started container metrics"
        },
        {
            "timestamp": 1695753051000,
            "object": {
                "kind": "Pod",
                "name": "isbsvc-test-js-2"
            },
            "reason": "Pulled",
            "message": "Container image \"natsio/prometheus-nats-exporter:0.9.1\" already present on machine"
        },
        {
            "timestamp": 1695753050000,
            "object": {
                "kind": "Pod",
                "name": "isbsvc-test-js-1"
            },
            "reason": "Created",
            "message": "Created container metrics"
        }
    ]
}
```