### PR TITLE
chore: update return type for vertex metrics

### DIFF
--- a/server/apis/v1_1/handler.go
+++ b/server/apis/v1_1/handler.go
@@ -502,14 +502,14 @@ func (h *handler) GetVerticesMetrics(c *gin.Context) {
 	}
 	defer client.Close()
 
-	var results [][]*daemon.VertexMetrics
+	var results = make(map[string][]*daemon.VertexMetrics)
 	for _, vertex := range pl.Spec.Vertices {
 		metrics, err := client.GetVertexMetrics(context.Background(), pipeline, vertex.Name)
 		if err != nil {
 			h.respondWithError(c, fmt.Sprintf("Failed to get the vertices metrics: namespace %q pipeline %q vertex %q: %s", ns, pipeline, vertex.Name, err.Error()))
 			return
 		}
-		results = append(results, metrics)
+		results[vertex.Name] = metrics
 	}
 
 	c.JSON(http.StatusOK, NewNumaflowAPIResponse(nil, results))


### PR DESCRIPTION
example payload
the list of metrics for a given vertex is sorted by partition0~n
```
{
    "data": {
        "cat": [
            {
                "pipeline": "simple-mp-pipeline",
                "vertex": "cat",
                "processingRates": {
                    "15m": 0,
                    "1m": 0,
                    "5m": 0,
                    "default": 0
                },
                "pendings": {
                    "15m": 0,
                    "1m": 0,
                    "5m": 0,
                    "default": 0
                }
            },
            {
                "pipeline": "simple-mp-pipeline",
                "vertex": "cat",
                "processingRates": {
                    "15m": 0,
                    "1m": 0,
                    "5m": 0,
                    "default": 0
                },
                "pendings": {
                    "15m": 0,
                    "1m": 0,
                    "5m": 0,
                    "default": 0
                }
            },
            {
                "pipeline": "simple-mp-pipeline",
                "vertex": "cat",
                "processingRates": {
                    "15m": 0,
                    "1m": 0,
                    "5m": 0,
                    "default": 0
                },
                "pendings": {
                    "15m": 0,
                    "1m": 0,
                    "5m": 0,
                    "default": 0
                }
            }
        ],
        "in": [
            {
                "pipeline": "simple-mp-pipeline",
                "vertex": "in",
                "processingRates": {
                    "15m": 500,
                    "1m": 500,
                    "5m": 500,
                    "default": 500
                }
            }
        ],
        "out": [
            {
                "pipeline": "simple-mp-pipeline",
                "vertex": "out",
                "processingRates": {
                    "15m": 0,
                    "1m": 0,
                    "5m": 0,
                    "default": 0
                },
                "pendings": {
                    "15m": 3,
                    "1m": 3,
                    "5m": 3,
                    "default": 3
                }
            },
            {
                "pipeline": "simple-mp-pipeline",
                "vertex": "out",
                "processingRates": {
                    "15m": 0,
                    "1m": 0,
                    "5m": 0,
                    "default": 0
                },
                "pendings": {
                    "15m": 0,
                    "1m": 0,
                    "5m": 0,
                    "default": 0
                }
            },
            {
                "pipeline": "simple-mp-pipeline",
                "vertex": "out",
                "processingRates": {
                    "15m": 0,
                    "1m": 0,
                    "5m": 0,
                    "default": 0
                },
                "pendings": {
                    "15m": 2,
                    "1m": 2,
                    "5m": 2,
                    "default": 2
                }
            }
        ]
    }
}
```