### PR TITLE
fix: updated pods view tab for vertices

### DIFF
--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodInfo/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodInfo/index.tsx
@@ -22,6 +22,8 @@ export function PodInfo({ pod, podDetails, containerName }: PodInfoProps) {
     pod?.containerSpecMap?.get(containerName)?.cpu;
   if (!usedCPU) {
     usedCPU = "?";
+  } else if (usedCPU.endsWith("n")) {
+    usedCPU = `${(parseFloat(usedCPU) / 1e6).toFixed(2)}m`;
   }
   if (!specCPU) {
     specCPU = "?";
@@ -37,6 +39,8 @@ export function PodInfo({ pod, podDetails, containerName }: PodInfoProps) {
     pod?.containerSpecMap?.get(containerName)?.memory;
   if (!usedMem) {
     usedMem = "?";
+  } else if (usedMem.endsWith("Ki")) {
+    usedMem = `${(parseFloat(usedMem) / 1024).toFixed(2)}Mi`;
   }
   if (!specMem) {
     specMem = "?";
@@ -54,7 +58,7 @@ export function PodInfo({ pod, podDetails, containerName }: PodInfoProps) {
         display: "flex",
         flexDirection: "column",
         height: "100%",
-        color: "#DCDCDC"
+        color: "#DCDCDC",
       }}
     >
       <TableContainer sx={{ maxHeight: "37.5rem", backgroundColor: "#FFF" }}>
@@ -67,6 +71,10 @@ export function PodInfo({ pod, podDetails, containerName }: PodInfoProps) {
             <TableRow>
               <TableCell sx={{ fontWeight: 600 }}>CPU %</TableCell>
               <TableCell>{cpuPercent}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600 }}>CPU</TableCell>
+              <TableCell>{`${usedCPU} / ${specCPU}`}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell sx={{ fontWeight: 600 }}>MEMORY %</TableCell>

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
@@ -281,6 +281,7 @@ export function PodLogs({ namespaceId, podName, containerName }: PodLogsProps) {
               component="span"
               sx={{
                 whiteSpace: "nowrap",
+                paddingTop: "0.5rem",
               }}
             >
               <Highlighter
@@ -307,6 +308,7 @@ export function PodLogs({ namespaceId, podName, containerName }: PodLogsProps) {
                 component="span"
                 sx={{
                   whiteSpace: "nowrap",
+                  paddingTop: "0.5rem",
                 }}
               >
                 <Highlighter


### PR DESCRIPTION
- added CPU row for `used / spec` utilization
- updated the CPU row with millicores (instead of nanocores default)
- update the Memory row with `Mi` for both denominator and numerator
![image](https://github.com/numaproj/numaflow/assets/49195734/0b1c1390-328a-45d3-9ec0-7dbe16571c29)

- spaced the pod logs for readability
![image](https://github.com/numaproj/numaflow/assets/49195734/00eb0d38-6d95-429d-92ed-33ddbf23124d)

