### PR TITLE
fix: get pl kind apiversion

### DIFF
--- a/pkg/client/clientset/versioned/typed/numaflow/v1alpha1/pipeline.go
+++ b/pkg/client/clientset/versioned/typed/numaflow/v1alpha1/pipeline.go
@@ -68,32 +68,13 @@ func newPipelines(c *NumaflowV1alpha1Client, namespace string) *pipelines {
 // Get takes name of the pipeline, and returns the corresponding pipeline object, and an error if there is any.
 func (c *pipelines) Get(ctx context.Context, name string, options v1.GetOptions) (pipeline *v1alpha1.Pipeline, err error) {
 	pipeline = &v1alpha1.Pipeline{}
-	result := c.client.Get().
+	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("pipelines").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx)
-	// although the kind and apiversion will be reset
-	// we still want to keep the Into function behaviour
-	// original issue link https://github.com/kubernetes/kubernetes/issues/80609
-	err = result.Into(pipeline)
-	if err != nil {
-		return
-	}
-	// get the kind and api version
-	raw, err := result.Raw()
-	if err != nil {
-		return
-	}
-	var info struct{
-		Kind string `json:"kind,omitempty"`
-		APIVersion string `json:"apiVersion,omitempty"`
-	}
-	json.Unmarshal(raw, &info)
-	// set the kind and api version
-	pipeline.Kind = info.Kind
-	pipeline.APIVersion = info.APIVersion
+		Do(ctx).
+		Into(pipeline)
 	return
 }
 

--- a/pkg/client/clientset/versioned/typed/numaflow/v1alpha1/pipeline.go
+++ b/pkg/client/clientset/versioned/typed/numaflow/v1alpha1/pipeline.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	v1alpha1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"

--- a/pkg/client/clientset/versioned/typed/numaflow/v1alpha1/pipeline.go
+++ b/pkg/client/clientset/versioned/typed/numaflow/v1alpha1/pipeline.go
@@ -85,7 +85,7 @@ func (c *pipelines) Get(ctx context.Context, name string, options v1.GetOptions)
 	json.Unmarshal(raw, &info)
 	// although the kind and apiversion will be reset
 	// we still want to keep the Into function behaviour
-	// original issue: https://github.com/kubernetes/kubernetes/issues/80609
+	// original issue link https://github.com/kubernetes/kubernetes/issues/80609
 	err = result.Into(pipeline)
 	if err != nil {
 		return

--- a/pkg/client/clientset/versioned/typed/numaflow/v1alpha1/pipeline.go
+++ b/pkg/client/clientset/versioned/typed/numaflow/v1alpha1/pipeline.go
@@ -74,15 +74,6 @@ func (c *pipelines) Get(ctx context.Context, name string, options v1.GetOptions)
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
 		Do(ctx)
-	raw, err := result.Raw()
-	if err != nil {
-		return
-	}
-	var info struct{
-		Kind string `json:"kind,omitempty" protobuf:"bytes,1,opt,name=kind"`
-		APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,2,opt,name=apiVersion"`
-	}
-	json.Unmarshal(raw, &info)
 	// although the kind and apiversion will be reset
 	// we still want to keep the Into function behaviour
 	// original issue link https://github.com/kubernetes/kubernetes/issues/80609
@@ -90,6 +81,17 @@ func (c *pipelines) Get(ctx context.Context, name string, options v1.GetOptions)
 	if err != nil {
 		return
 	}
+	// get the kind and api version
+	raw, err := result.Raw()
+	if err != nil {
+		return
+	}
+	var info struct{
+		Kind string `json:"kind,omitempty"`
+		APIVersion string `json:"apiVersion,omitempty"`
+	}
+	json.Unmarshal(raw, &info)
+	// set the kind and api version
 	pipeline.Kind = info.Kind
 	pipeline.APIVersion = info.APIVersion
 	return

--- a/pkg/client/clientset/versioned/typed/numaflow/v1alpha1/pipeline.go
+++ b/pkg/client/clientset/versioned/typed/numaflow/v1alpha1/pipeline.go
@@ -65,15 +65,15 @@ func newPipelines(c *NumaflowV1alpha1Client, namespace string) *pipelines {
 }
 
 // Get takes name of the pipeline, and returns the corresponding pipeline object, and an error if there is any.
-func (c *pipelines) Get(ctx context.Context, name string, options v1.GetOptions) (pipeline *v1alpha1.Pipeline, err error) {
-	pipeline = &v1alpha1.Pipeline{}
+func (c *pipelines) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Pipeline, err error) {
+	result = &v1alpha1.Pipeline{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("pipelines").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
 		Do(ctx).
-		Into(pipeline)
+		Into(result)
 	return
 }
 

--- a/server/apis/v1/handler.go
+++ b/server/apis/v1/handler.go
@@ -211,7 +211,7 @@ func (h *handler) GetPipeline(c *gin.Context) {
 	}
 	// set pl kind and apiVersion
 	pl.Kind = "Pipeline"
-	pl.APIVersion = "numaflow.numaproj.io/v1alpha1"
+	pl.APIVersion = dfv1.SchemeGroupVersion.String()
 
 	// get pipeline source and sink vertex
 	var (

--- a/server/apis/v1/handler.go
+++ b/server/apis/v1/handler.go
@@ -209,6 +209,9 @@ func (h *handler) GetPipeline(c *gin.Context) {
 		h.respondWithError(c, fmt.Sprintf("Failed to fetch pipeline %q namespace %q, %s", pipeline, ns, err.Error()))
 		return
 	}
+	// set pl kind and apiVersion
+	pl.Kind = "Pipeline"
+	pl.APIVersion = "numaflow.numaproj.io/v1alpha1"
 
 	// get pipeline source and sink vertex
 	var (

--- a/server/apis/v1/handler.go
+++ b/server/apis/v1/handler.go
@@ -210,7 +210,7 @@ func (h *handler) GetPipeline(c *gin.Context) {
 		return
 	}
 	// set pl kind and apiVersion
-	pl.Kind = "Pipeline"
+	pl.Kind = dfv1.PipelineGroupVersionKind.Kind
 	pl.APIVersion = dfv1.SchemeGroupVersion.String()
 
 	// get pipeline source and sink vertex


### PR DESCRIPTION
because of https://github.com/kubernetes/kubernetes/issues/80609 
get pipeline doesn't return "kind" and "apiVersion"

since we know the value for these two fields, set the fields in handler manually

test result:
<img width="888" alt="image" src="https://github.com/numaproj/numaflow/assets/19543684/9ac5fb40-aac5-4bb6-932f-a2f97a443aea">
