### PR TITLE
chore: API cluster summary improvement

### DIFF
--- a/server/apis/v1/handler.go
+++ b/server/apis/v1/handler.go
@@ -94,6 +94,21 @@ func (h *handler) ListNamespaces(c *gin.Context) {
 
 // GetClusterSummary summarizes information of all the namespaces in a cluster and wrapped the result in a list.
 func (h *handler) GetClusterSummary(c *gin.Context) {
+	pipelineList, err := h.numaflowClient.Pipelines("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		h.respondWithError(c, fmt.Sprintf("Failed to fetch cluster summary, %s", err.Error()))
+		return
+	}
+	_ = pipelineList
+	isbsvcList, err := h.numaflowClient.InterStepBufferServices("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		h.respondWithError(c, fmt.Sprintf("Failed to fetch cluster summary, %s", err.Error()))
+		return
+	}
+	_ = isbsvcList
+}
+
+func (h *handler) GetClusterSummary0(c *gin.Context) {
 	namespaces, err := getAllNamespaces(h)
 	if err != nil {
 		h.respondWithError(c, fmt.Sprintf("Failed to fetch cluster summary, %s", err.Error()))


### PR DESCRIPTION
Get all the pipelines and isbsvcs at once instead of individual calls.
fixes:#1161

Example Response payload
```
{
    "data": [
        {
            "namespace": "numaflow-system",
            "pipelineSummary": {
                "active": {
                    "Healthy": 1,
                    "Warning": 0,
                    "Critical": 0
                },
                "inactive": 0
            },
            "isbServiceSummary": {
                "active": {
                    "Healthy": 1,
                    "Warning": 0,
                    "Critical": 0
                },
                "inactive": 0
            }
        },
        {
            "namespace": "default",
            "pipelineSummary": {
                "active": {
                    "Healthy": 2,
                    "Warning": 0,
                    "Critical": 0
                },
                "inactive": 1
            },
            "isbServiceSummary": {
                "active": {
                    "Healthy": 2,
                    "Warning": 0,
                    "Critical": 0
                },
                "inactive": 0
            }
        }
    ]
}
```