### PR TITLE
fix: update dex to work with basehref

### DIFF
--- a/config/base/dex/numaflow-dex-server-configmap.yaml
+++ b/config/base/dex/numaflow-dex-server-configmap.yaml
@@ -12,7 +12,7 @@ data:
     staticClients:
       - id: numaflow-server-app
         redirectURIs: 
-          - <HOSTNAME>/login
+          - <HOSTNAME>/<base_herf>/login
         name: 'Numaflow Server App'
         public: true
     connectors:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -16373,11 +16373,12 @@ metadata:
 apiVersion: v1
 data:
   config.yaml: "issuer: <HOSTNAME>/dex\nstorage:\n  type: memory\nweb:\n  http: 0.0.0.0:5556\nstaticClients:\n
-    \ - id: numaflow-server-app\n    redirectURIs: \n      - <HOSTNAME>/login\n    name:
-    'Numaflow Server App'\n    public: true\nconnectors:\n- type: github\n  # https://dexidp.io/docs/connectors/github/\n
-    \ id: github\n  name: GitHub\n  config:\n    clientID: $GITHUB_CLIENT_ID\n    clientSecret:
-    $GITHUB_CLIENT_SECRET\n    redirectURI: <HOSTNAME>/dex/callback\n    orgs:\n    -
-    name: <ORG_NAME>\n      teams:\n      - admin\n      - readonly\noauth2:\n  skipApprovalScreen:
+    \ - id: numaflow-server-app\n    redirectURIs: \n      - <HOSTNAME>/<base_herf>/login\n
+    \   name: 'Numaflow Server App'\n    public: true\nconnectors:\n- type: github\n
+    \ # https://dexidp.io/docs/connectors/github/\n  id: github\n  name: GitHub\n
+    \ config:\n    clientID: $GITHUB_CLIENT_ID\n    clientSecret: $GITHUB_CLIENT_SECRET\n
+    \   redirectURI: <HOSTNAME>/dex/callback\n    orgs:\n    - name: <ORG_NAME>\n
+    \     teams:\n      - admin\n      - readonly\noauth2:\n  skipApprovalScreen:
     true\n"
 kind: ConfigMap
 metadata:

--- a/config/namespace-install.yaml
+++ b/config/namespace-install.yaml
@@ -16279,11 +16279,12 @@ metadata:
 apiVersion: v1
 data:
   config.yaml: "issuer: <HOSTNAME>/dex\nstorage:\n  type: memory\nweb:\n  http: 0.0.0.0:5556\nstaticClients:\n
-    \ - id: numaflow-server-app\n    redirectURIs: \n      - <HOSTNAME>/login\n    name:
-    'Numaflow Server App'\n    public: true\nconnectors:\n- type: github\n  # https://dexidp.io/docs/connectors/github/\n
-    \ id: github\n  name: GitHub\n  config:\n    clientID: $GITHUB_CLIENT_ID\n    clientSecret:
-    $GITHUB_CLIENT_SECRET\n    redirectURI: <HOSTNAME>/dex/callback\n    orgs:\n    -
-    name: <ORG_NAME>\n      teams:\n      - admin\n      - readonly\noauth2:\n  skipApprovalScreen:
+    \ - id: numaflow-server-app\n    redirectURIs: \n      - <HOSTNAME>/<base_herf>/login\n
+    \   name: 'Numaflow Server App'\n    public: true\nconnectors:\n- type: github\n
+    \ # https://dexidp.io/docs/connectors/github/\n  id: github\n  name: GitHub\n
+    \ config:\n    clientID: $GITHUB_CLIENT_ID\n    clientSecret: $GITHUB_CLIENT_SECRET\n
+    \   redirectURI: <HOSTNAME>/dex/callback\n    orgs:\n    - name: <ORG_NAME>\n
+    \     teams:\n      - admin\n      - readonly\noauth2:\n  skipApprovalScreen:
     true\n"
 kind: ConfigMap
 metadata:

--- a/server/apis/v1/dexauth.go
+++ b/server/apis/v1/dexauth.go
@@ -48,12 +48,12 @@ type DexObject struct {
 }
 
 // NewDexObject returns a new DexObject.
-func NewDexObject(baseURL string, proxyURL string) (*DexObject, error) {
+func NewDexObject(baseURL string, baseHref string, proxyURL string) (*DexObject, error) {
 	issuerURL, err := url.JoinPath(baseURL, "/dex")
 	if err != nil {
 		return nil, err
 	}
-	redirectURI, err := url.JoinPath(baseURL, "/login")
+	redirectURI, err := url.JoinPath(baseURL, baseHref, "/login")
 	if err != nil {
 		return nil, err
 	}

--- a/server/cmd/start.go
+++ b/server/cmd/start.go
@@ -85,7 +85,9 @@ func (s *server) Start() {
 			DexServerAddr: s.options.DexServerAddr,
 			DexProxyAddr:  s.options.DexProxyAddr,
 			ServerAddr:    s.options.ServerAddr,
-		})
+		},
+		baseHref,
+	)
 	router.Use(UrlRewrite(router))
 	server := http.Server{
 		Addr:    fmt.Sprintf(":%d", s.options.Port),

--- a/server/cmd/start.go
+++ b/server/cmd/start.go
@@ -86,7 +86,7 @@ func (s *server) Start() {
 			DexProxyAddr:  s.options.DexProxyAddr,
 			ServerAddr:    s.options.ServerAddr,
 		},
-		baseHref,
+		s.options.BaseHref,
 	)
 	router.Use(UrlRewrite(router))
 	server := http.Server{

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -46,11 +46,11 @@ type AuthInfo struct {
 
 var logger = logging.NewLogger().Named("server")
 
-func Routes(r *gin.Engine, sysInfo SystemInfo, authInfo AuthInfo) {
+func Routes(r *gin.Engine, sysInfo SystemInfo, authInfo AuthInfo, baseHref string) {
 	r.GET("/livez", func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
-	dexObj, err := v1.NewDexObject(authInfo.ServerAddr, authInfo.DexProxyAddr)
+	dexObj, err := v1.NewDexObject(authInfo.ServerAddr, baseHref, authInfo.DexProxyAddr)
 	if err != nil {
 		panic(err)
 	}

--- a/server/routes/routes_test.go
+++ b/server/routes/routes_test.go
@@ -41,7 +41,7 @@ func TestRoutes(t *testing.T) {
 		DisableAuth:   false,
 		DexServerAddr: "test-dex-server-addr",
 	}
-	Routes(router, sysInfo, authInfo)
+	Routes(router, sysInfo, authInfo, "/")
 	t.Run("/404", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "/404", nil)


### PR DESCRIPTION
Local Test

Numaflow Dex Server deployment
```yaml
redirectURIs: 
  - https://localhost:8443/numaflow/login
```
Numaflow Server deployment
```yaml
 - name: main
   image: quay.io/numaproj/numaflow:latest
   args:
   - "server"
   - "--base-href=/numaflow"
```
```yaml
 - name: server-init
   image: quay.io/numaproj/numaflow:latest
   args:
   - "server-init"
   - "--base-href=/numaflow"
```
https://github.com/numaproj/numaflow/assets/19543684/8e6236e7-31d1-4e09-9fd1-b29bdf797b6e

