### PR TITLE
fix: graph overflow with large height

### DIFF
--- a/ui/src/components/pages/Pipeline/partials/Graph/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/index.tsx
@@ -283,7 +283,8 @@ const Flow = (props: FlowProps) => {
       preventScrolling={!isLocked}
       panOnDrag={!isLocked}
       panOnScroll={isPanOnScrollLocked}
-      maxZoom={2.75}
+      minZoom={0.1}
+      maxZoom={3.1}
     >
       <Panel
         position="top-left"
@@ -440,7 +441,7 @@ const Flow = (props: FlowProps) => {
               stroke="#D4D7DC"
             />
             <text x="50%" y="50%" className={"zoom-percent-text"}>
-              {(((zoomLevel - 0.5) / 1.5) * 100).toFixed(0)}%
+              {(((zoomLevel - 0.1) / 2) * 100).toFixed(0)}%
             </text>
           </g>
         </svg>


### PR DESCRIPTION
Modified minimum and maximum zoom view for the pipeline (Min % = 0, Max % = 150)

Fixes view for graph with large height, prevents the overflow beyond screen boundaries

Ex - 11 udf pods merging into a single sink - shown in a single view
![image](https://github.com/numaproj/numaflow/assets/49195734/052e2ecf-14b7-45dd-8f0d-b4dec49b48de)
