### PR TITLE
fix: update numaflow-go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe
 	github.com/nats-io/nats-server/v2 v2.10.4
 	github.com/nats-io/nats.go v1.31.0
-	github.com/numaproj/numaflow-go v0.5.1
+	github.com/numaproj/numaflow-go v0.5.2
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.37.0
 	github.com/redis/go-redis/v9 v9.0.3

--- a/go.sum
+++ b/go.sum
@@ -679,8 +679,8 @@ github.com/nats-io/nkeys v0.4.6/go.mod h1:4DxZNzenSVd1cYQoAa8948QY3QDjrHfcfVADym
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/numaproj/numaflow-go v0.5.1 h1:mvala+EmlrRtI20cr1y928zR7dO/HKUJsLai7vISHEA=
-github.com/numaproj/numaflow-go v0.5.1/go.mod h1:5zwvvREIbqaCPCKsNE1MVjVToD0kvkCh2Z90Izlhw5U=
+github.com/numaproj/numaflow-go v0.5.2 h1:U/57eDqodVVpzLQqMR/iql8eQf6HsgFMbnWCUU69HZA=
+github.com/numaproj/numaflow-go v0.5.2/go.mod h1:5zwvvREIbqaCPCKsNE1MVjVToD0kvkCh2Z90Izlhw5U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/pkg/sources/forward/data_forward.go
+++ b/pkg/sources/forward/data_forward.go
@@ -24,9 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/numaproj/numaflow-go/pkg/sourcetransformer"
 	"go.uber.org/zap"
-	"k8s.io/utils/strings/slices"
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaflow/pkg/forwarder"
@@ -522,12 +520,6 @@ func (isdf *DataForward) applyTransformer(ctx context.Context, readMessage *isb.
 		} else {
 			for index, m := range writeMessages {
 				m.ID = fmt.Sprintf("%s-%s-%d", readMessage.ReadOffset.String(), isdf.vertexName, index)
-				// if the message is dropped by the source transformer, we assign the original event time to the message.
-				// the original event time is the event time of the message before the source transformer.
-				// this way, even when the message is dropped, the event time is still preserved and be used for watermark calculation.
-				if slices.Contains(m.Tags, sourcetransformer.DROP) {
-					m.EventTime = readMessage.EventTime
-				}
 			}
 			return writeMessages, nil
 		}

--- a/pkg/sources/forward/data_forward.go
+++ b/pkg/sources/forward/data_forward.go
@@ -24,7 +24,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/numaproj/numaflow-go/pkg/sourcetransformer"
 	"go.uber.org/zap"
+	"k8s.io/utils/strings/slices"
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaflow/pkg/forwarder"
@@ -518,10 +520,12 @@ func (isdf *DataForward) applyTransformer(ctx context.Context, readMessage *isb.
 			}
 			continue
 		} else {
-			// if we do not get a time from Transformer, we set it to the time from (N-1)th vertex
 			for index, m := range writeMessages {
 				m.ID = fmt.Sprintf("%s-%s-%d", readMessage.ReadOffset.String(), isdf.vertexName, index)
-				if m.EventTime.IsZero() {
+				// if the message is dropped by the source transformer, we assign the original event time to the message.
+				// the original event time is the event time of the message before the source transformer.
+				// this way, even when the message is dropped, the event time is still preserved and be used for watermark calculation.
+				if slices.Contains(m.Tags, sourcetransformer.DROP) {
 					m.EventTime = readMessage.EventTime
 				}
 			}

--- a/pkg/udf/forward/forward.go
+++ b/pkg/udf/forward/forward.go
@@ -668,8 +668,6 @@ func (isdf *InterStepDataForward) applyUDF(ctx context.Context, readMessage *isb
 				// add vertex name to the ID, since multiple vertices can publish to the same vertex and we need uniqueness across them
 				m.ID = fmt.Sprintf("%s-%s-%d", readMessage.ReadOffset.String(), isdf.vertexName, index)
 				// if we do not get a time from map UDF, we set it to the time from (N-1)th vertex
-				// this should never happen because map UDF doesn't change the event time of the message
-				// TODO - can we remove the following check?
 				if m.EventTime.IsZero() {
 					m.EventTime = readMessage.EventTime
 				}

--- a/pkg/udf/forward/forward.go
+++ b/pkg/udf/forward/forward.go
@@ -664,10 +664,12 @@ func (isdf *InterStepDataForward) applyUDF(ctx context.Context, readMessage *isb
 			}
 			continue
 		} else {
-			// if we do not get a time from map UDF, we set it to the time from (N-1)th vertex
 			for index, m := range writeMessages {
 				// add vertex name to the ID, since multiple vertices can publish to the same vertex and we need uniqueness across them
 				m.ID = fmt.Sprintf("%s-%s-%d", readMessage.ReadOffset.String(), isdf.vertexName, index)
+				// if we do not get a time from map UDF, we set it to the time from (N-1)th vertex
+				// this should never happen because map UDF doesn't change the event time of the message
+				// TODO - can we remove the following check?
 				if m.EventTime.IsZero() {
 					m.EventTime = readMessage.EventTime
 				}

--- a/pkg/udf/forward/forward.go
+++ b/pkg/udf/forward/forward.go
@@ -667,10 +667,6 @@ func (isdf *InterStepDataForward) applyUDF(ctx context.Context, readMessage *isb
 			for index, m := range writeMessages {
 				// add vertex name to the ID, since multiple vertices can publish to the same vertex and we need uniqueness across them
 				m.ID = fmt.Sprintf("%s-%s-%d", readMessage.ReadOffset.String(), isdf.vertexName, index)
-				// if we do not get a time from map UDF, we set it to the time from (N-1)th vertex
-				if m.EventTime.IsZero() {
-					m.EventTime = readMessage.EventTime
-				}
 			}
 			return writeMessages, nil
 		}


### PR DESCRIPTION
* update the numaflow-go version hence the built-in source transformer uses the latest SDK.
* for messages dropped by the source transformer, use the original event time to calculate the source watermark.

The rationale is that a dropped message is also a processed message, it should be included in the watermark calculation.

To be determined: if a user chooses to use the source transformer to assign event time and filter, should we require assigning event time to dropped messages? (I think we should because it gives user the full control of event time. However it will be a breaking change for existing pipelines.)

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
