### PR TITLE
fix: access path for api/v1 route

### DIFF
--- a/config/advanced-install/namespaced-numaflow-server.yaml
+++ b/config/advanced-install/namespaced-numaflow-server.yaml
@@ -233,7 +233,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.base.href
-              name: numaflow-server-cmd-params-config
+              name: numaflow-cmd-params-config
               optional: true
         image: quay.io/numaproj/numaflow:latest
         imagePullPolicy: Always

--- a/config/advanced-install/numaflow-server.yaml
+++ b/config/advanced-install/numaflow-server.yaml
@@ -239,7 +239,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.base.href
-              name: numaflow-server-cmd-params-config
+              name: numaflow-cmd-params-config
               optional: true
         image: quay.io/numaproj/numaflow:latest
         imagePullPolicy: Always

--- a/config/base/numaflow-server/numaflow-server-deployment.yaml
+++ b/config/base/numaflow-server/numaflow-server-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - name: NUMAFLOW_SERVER_BASE_HREF
           valueFrom:
             configMapKeyRef:
-              name: numaflow-server-cmd-params-config
+              name: numaflow-cmd-params-config
               key: server.base.href
               optional: true
         volumeMounts:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -16695,7 +16695,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.base.href
-              name: numaflow-server-cmd-params-config
+              name: numaflow-cmd-params-config
               optional: true
         image: quay.io/numaproj/numaflow:latest
         imagePullPolicy: Always

--- a/config/namespace-install.yaml
+++ b/config/namespace-install.yaml
@@ -16592,7 +16592,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: server.base.href
-              name: numaflow-server-cmd-params-config
+              name: numaflow-cmd-params-config
               optional: true
         image: quay.io/numaproj/numaflow:latest
         imagePullPolicy: Always

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -56,7 +56,7 @@ func Routes(r *gin.Engine, sysInfo SystemInfo, authInfo AuthInfo, baseHref strin
 
 	// r1Group is a group of routes that require AuthN/AuthZ when auth is enabled.
 	// they share the AuthN/AuthZ middleware.
-	r1Group := r.Group("/api/v1")
+	r1Group := r.Group(baseHref + "api/v1")
 	if !authInfo.DisableAuth {
 		authorizer, err := authz.NewCasbinObject()
 		if err != nil {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -26,6 +26,7 @@ import {
 import { ErrorDisplay } from "./components/common/ErrorDisplay";
 import { AppContextProps, AppError, UserInfo } from "./types/declarations/app";
 import AccountMenu from "./components/common/AccountMenu";
+import { getBaseHref } from "./utils";
 import logo from "./images/icon.png";
 import textLogo from "./images/text-icon.png";
 
@@ -81,7 +82,7 @@ function App() {
     // Attempt to load user info on app load
     const fetchData = async () => {
       try {
-        const response = await fetch(`/api/v1/authinfo`);
+        const response = await fetch(`${getBaseHref()}/api/v1/authinfo`);
         if (response.ok) {
           const data = await response.json();
           const claims = data?.data?.id_token_claims;

--- a/ui/src/components/common/SlidingSidebar/partials/ISBCreate/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBCreate/index.tsx
@@ -8,7 +8,7 @@ import {
   ValidationMessage,
 } from "../../../SpecEditor";
 import { SpecEditorSidebarProps } from "../..";
-import { getAPIResponseError } from "../../../../../utils";
+import { getAPIResponseError, getBaseHref } from "../../../../../utils";
 
 import "./style.css";
 
@@ -55,7 +55,7 @@ export function ISBCreate({
       });
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespaceId}/isb-services?dry-run=false`,
+          `${getBaseHref()}/api/v1/namespaces/${namespaceId}/isb-services?dry-run=false`,
           {
             method: "POST",
             headers: {
@@ -108,7 +108,7 @@ export function ISBCreate({
       setLoading(true);
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespaceId}/isb-services?dry-run=true`,
+          `${getBaseHref()}/api/v1/namespaces/${namespaceId}/isb-services?dry-run=true`,
           {
             method: "POST",
             headers: {

--- a/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.tsx
@@ -8,7 +8,7 @@ import {
   ValidationMessage,
 } from "../../../SpecEditor";
 import { SpecEditorSidebarProps } from "../..";
-import { getAPIResponseError } from "../../../../../utils";
+import { getAPIResponseError, getBaseHref } from "../../../../../utils";
 
 import "./style.css";
 
@@ -40,7 +40,7 @@ export function ISBUpdate({
       });
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespaceId}/isb-services/${isbId}?dry-run=false`,
+          `${getBaseHref()}/api/v1/namespaces/${namespaceId}/isb-services/${isbId}?dry-run=false`,
           {
             method: "PUT",
             headers: {
@@ -93,7 +93,7 @@ export function ISBUpdate({
       setLoading(true);
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespaceId}/isb-services/${isbId}?dry-run=true`,
+          `${getBaseHref()}/api/v1/namespaces/${namespaceId}/isb-services/${isbId}?dry-run=true`,
           {
             method: "PUT",
             headers: {

--- a/ui/src/components/common/SlidingSidebar/partials/PipelineCreate/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/PipelineCreate/index.tsx
@@ -8,7 +8,7 @@ import {
   ValidationMessage,
 } from "../../../SpecEditor";
 import { SpecEditorSidebarProps } from "../..";
-import { getAPIResponseError } from "../../../../../utils";
+import { getAPIResponseError, getBaseHref } from "../../../../../utils";
 import { usePipelineUpdateFetch } from "../../../../../utils/fetchWrappers/pipelineUpdateFetch";
 
 import "./style.css";
@@ -120,7 +120,7 @@ export function PipelineCreate({
       });
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespaceId}/pipelines?dry-run=false`,
+          `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines?dry-run=false`,
           {
             method: "POST",
             headers: {
@@ -167,7 +167,7 @@ export function PipelineCreate({
       setLoading(true);
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespaceId}/pipelines?dry-run=true`,
+          `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines?dry-run=true`,
           {
             method: "POST",
             headers: {

--- a/ui/src/components/common/SlidingSidebar/partials/PipelineUpdate/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/PipelineUpdate/index.tsx
@@ -8,7 +8,7 @@ import {
   ValidationMessage,
 } from "../../../SpecEditor";
 import { SpecEditorSidebarProps } from "../..";
-import { getAPIResponseError } from "../../../../../utils";
+import { getAPIResponseError, getBaseHref } from "../../../../../utils";
 import { usePipelineUpdateFetch } from "../../../../../utils/fetchWrappers/pipelineUpdateFetch";
 
 import "./style.css";
@@ -47,7 +47,7 @@ export function PipelineUpdate({
       }
     };
   }, [updatedPipelineId, onUpdateComplete]);
-  
+
   // Track update process and close on completion
   useEffect(() => {
     if (!updatedPipelineId) {
@@ -97,7 +97,7 @@ export function PipelineUpdate({
       });
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}?dry-run=false`,
+          `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}?dry-run=false`,
           {
             method: "PUT",
             headers: {
@@ -144,7 +144,7 @@ export function PipelineUpdate({
       setLoading(true);
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}?dry-run=true`,
+          `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}?dry-run=true`,
           {
             method: "PUT",
             headers: {

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/VertexUpdate/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/VertexUpdate/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import Box from "@mui/material/Box";
 import YAML from "yaml";
-import { getAPIResponseError } from "../../../../../../../utils";
+import { getAPIResponseError, getBaseHref } from "../../../../../../../utils";
 import {
   SpecEditor,
   ViewType,
@@ -52,7 +52,7 @@ export function VertexUpdate({
       });
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertexId}?dry-run=false`,
+          `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertexId}?dry-run=false`,
           {
             method: "PUT",
             headers: {
@@ -109,7 +109,7 @@ export function VertexUpdate({
       setLoading(true);
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertexId}?dry-run=true`,
+          `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertexId}?dry-run=true`,
           {
             method: "PUT",
             headers: {

--- a/ui/src/components/pages/Namespace/partials/DeleteModal/index.tsx
+++ b/ui/src/components/pages/Namespace/partials/DeleteModal/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import Box from "@mui/material/Box";
 import Modal from "@mui/material/Modal";
 import Button from "@mui/material/Button";
-import { getAPIResponseError } from "../../../../../utils";
+import { getAPIResponseError, getBaseHref } from "../../../../../utils";
 import { ValidationMessage } from "../../../../common/SpecEditor/partials/ValidationMessage";
 import CircularProgress from "@mui/material/CircularProgress";
 
@@ -36,10 +36,10 @@ export function DeleteModal({
       let url: string;
       switch (type) {
         case "pipeline":
-          url = `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}`;
+          url = `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}`;
           break;
         case "isb":
-          url = `/api/v1/namespaces/${namespaceId}/isb-services/${isbId}`;
+          url = `${getBaseHref()}/api/v1/namespaces/${namespaceId}/isb-services/${isbId}`;
           break;
         default:
           return;

--- a/ui/src/components/pages/Namespace/partials/PipelineCard/index.tsx
+++ b/ui/src/components/pages/Namespace/partials/PipelineCard/index.tsx
@@ -25,6 +25,7 @@ import {
   RUNNING,
   PAUSING,
   DELETING,
+  getBaseHref,
 } from "../../../../../utils";
 import { usePipelineUpdateFetch } from "../../../../../utils/fetchWrappers/pipelineUpdateFetch";
 import { AppContextProps } from "../../../../../types/declarations/app";
@@ -186,7 +187,9 @@ export function PipelineCard({
     const patchStatus = async () => {
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespace}/pipelines/${data?.name}`,
+          `${getBaseHref()}/api/v1/namespaces/${namespace}/pipelines/${
+            data?.name
+          }`,
           {
             method: "PATCH",
             headers: {

--- a/ui/src/components/pages/Pipeline/partials/Graph/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/index.tsx
@@ -49,6 +49,7 @@ import {
   RUNNING,
   getAPIResponseError,
   timeAgo,
+  getBaseHref,
 } from "../../../../../utils";
 import { ErrorIndicator } from "../../../../common/ErrorIndicator";
 import { CollapseContext } from "../../../../common/SummaryPageLayout";
@@ -217,7 +218,9 @@ const Flow = (props: FlowProps) => {
     const patchStatus = async () => {
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespaceId}/pipelines/${data?.pipeline?.metadata?.name}`,
+          `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines/${
+            data?.pipeline?.metadata?.name
+          }`,
           {
             method: "PATCH",
             headers: {

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
@@ -16,6 +16,7 @@ import Checkbox from "@mui/material/Checkbox";
 import Highlighter from "react-highlight-words";
 import "@stardazed/streams-polyfill";
 import { ReadableStreamDefaultReadResult } from "stream/web";
+import { getBaseHref } from "../../../../../../../../../../../../../utils";
 import { PodLogsProps } from "../../../../../../../../../../../../../types/declarations/pods";
 
 import "./style.css";
@@ -105,7 +106,7 @@ export function PodLogs({ namespaceId, podName, containerName }: PodLogsProps) {
     setLogRequestKey(requestKey);
     setLogs(["Loading logs..."]);
     fetch(
-      `/api/v1/namespaces/${namespaceId}/pods/${podName}/logs?container=${containerName}&follow=true&tailLines=${MAX_LOGS}`
+      `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pods/${podName}/logs?container=${containerName}&follow=true&tailLines=${MAX_LOGS}`
     )
       .then((response) => {
         if (response && response.body) {

--- a/ui/src/utils/fetchWrappers/clusterSummaryFetch.ts
+++ b/ui/src/utils/fetchWrappers/clusterSummaryFetch.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useFetch, Options } from "./fetch";
+import { getBaseHref } from "../index";
 import {
   ClusterNamespaceSummary,
   ClusterSummaryData,
@@ -116,7 +117,7 @@ export const useClusterSummaryFetch = ({
     data: fetchData,
     loading: fetchLoading,
     error: fetchError,
-  } = useFetch("/api/v1/cluster-summary", undefined, options);
+  } = useFetch(`${getBaseHref()}/api/v1/cluster-summary`, undefined, options);
 
   useEffect(() => {
     setInterval(() => {

--- a/ui/src/utils/fetchWrappers/namespaceFetch.ts
+++ b/ui/src/utils/fetchWrappers/namespaceFetch.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useFetch } from "./fetch";
+import { getBaseHref } from "../index";
 
 export const useNamespaceFetch = (namespaceId: string | undefined) => {
   const [pipelines, setPipelines] = useState<string[]>([]);
@@ -9,7 +10,7 @@ export const useNamespaceFetch = (namespaceId: string | undefined) => {
     data,
     loading: fetchLoading,
     error,
-  } = useFetch(`/api/v1/namespaces/${namespaceId}/pipelines`);
+  } = useFetch(`${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines`);
 
   useEffect(() => {
     if (fetchLoading) {

--- a/ui/src/utils/fetchWrappers/namespaceK8sEventsFetch.ts
+++ b/ui/src/utils/fetchWrappers/namespaceK8sEventsFetch.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState, useMemo } from "react";
 import { useFetch, Options } from "./fetch";
+import { getBaseHref } from "../index";
 import {
   K8sEvent,
   K8sEventSummary,
@@ -60,14 +61,16 @@ export const useNamespaceK8sEventsFetch = ({
     requestKey: "",
   });
 
+  const BASE_URL = `${getBaseHref()}/api/v1/namespaces/${namespace}/events`;
+
   const urlPath = useMemo(() => {
     if (vertex) {
-      return `/api/v1/namespaces/${namespace}/events?objectType=vertex&objectName=${pipeline}-${vertex}`;
+      return `${BASE_URL}?objectType=vertex&objectName=${pipeline}-${vertex}`;
     } else if (pipeline) {
-      return `/api/v1/namespaces/${namespace}/events?objectType=pipeline&objectName=${pipeline}`;
+      return `${BASE_URL}?objectType=pipeline&objectName=${pipeline}`;
     }
-    return `/api/v1/namespaces/${namespace}/events`;
-  }, [namespace, pipeline, vertex])
+    return `${BASE_URL}`;
+  }, [namespace, pipeline, vertex]);
 
   const {
     data: fetchData,

--- a/ui/src/utils/fetchWrappers/namespaceSummaryFetch.ts
+++ b/ui/src/utils/fetchWrappers/namespaceSummaryFetch.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { useFetch, Options } from "./fetch";
+import { getBaseHref } from "../index";
 import {
   NamespacePipelineSummary,
   NamespaceSummaryData,
@@ -123,13 +124,17 @@ export const useNamespaceSummaryFetch = ({
     data: pipelineData,
     loading: pipelineLoading,
     error: pipelineError,
-  } = useFetch(`/api/v1/namespaces/${namespace}/pipelines`, undefined, options);
+  } = useFetch(
+    `${getBaseHref()}/api/v1/namespaces/${namespace}/pipelines`,
+    undefined,
+    options
+  );
   const {
     data: isbData,
     loading: isbLoading,
     error: isbError,
   } = useFetch(
-    `/api/v1/namespaces/${namespace}/isb-services`,
+    `${getBaseHref()}/api/v1/namespaces/${namespace}/isb-services`,
     undefined,
     options
   );

--- a/ui/src/utils/fetchWrappers/pipelineFetch.ts
+++ b/ui/src/utils/fetchWrappers/pipelineFetch.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { Options, useFetch } from "./fetch";
 import { PipelineSummaryFetchResult } from "../../types/declarations/pipeline";
-import {DEFAULT_ISB} from "../index";
+import { DEFAULT_ISB, getBaseHref } from "../index";
 
 const DATA_REFRESH_INTERVAL = 15000; // ms
 
@@ -36,7 +36,7 @@ export const usePipelineSummaryFetch = ({
     loading: pipelineLoading,
     error: pipelineError,
   } = useFetch(
-    `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}`,
+    `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}`,
     undefined,
     options
   );
@@ -46,7 +46,7 @@ export const usePipelineSummaryFetch = ({
     loading: isbLoading,
     error: isbError,
   } = useFetch(
-    `/api/v1/namespaces/${namespaceId}/isb-services/${isb}`,
+    `${getBaseHref()}/api/v1/namespaces/${namespaceId}/isb-services/${isb}`,
     undefined,
     isb ? options : { ...options, skip: true }
   );
@@ -104,9 +104,7 @@ export const usePipelineSummaryFetch = ({
     }
     if (pipelineData) {
       if (pipelineData.data?.pipeline?.spec?.interStepBufferServiceName) {
-        setIsb(
-          pipelineData.data?.pipeline?.spec?.interStepBufferServiceName
-        );
+        setIsb(pipelineData.data?.pipeline?.spec?.interStepBufferServiceName);
       } else {
         setIsb(DEFAULT_ISB);
       }

--- a/ui/src/utils/fetchWrappers/pipelineUpdateFetch.ts
+++ b/ui/src/utils/fetchWrappers/pipelineUpdateFetch.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Options, useFetch } from "./fetch";
+import { getBaseHref } from "../index";
 import { PipelineUpdateFetchResult } from "../../types/declarations/pipeline";
 
 const DATA_REFRESH_INTERVAL = 1000; // ms
@@ -23,7 +24,7 @@ export const usePipelineUpdateFetch = ({
   const [intervalId, setIntervalId] = useState<any>();
 
   const { data, loading, error } = useFetch(
-    `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}`,
+    `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}`,
     undefined,
     options
   );

--- a/ui/src/utils/fetchWrappers/systemInfoFetch.ts
+++ b/ui/src/utils/fetchWrappers/systemInfoFetch.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { SystemInfo } from "../models/systemInfo";
 import { useFetch } from "./fetch";
+import { getBaseHref } from "../index";
 import { useLocation } from "react-router-dom";
 
 export const useSystemInfoFetch = () => {
@@ -20,7 +21,7 @@ export const useSystemInfoFetch = () => {
     data,
     loading: fetchLoading,
     error,
-  } = useFetch(`/api/v1/sysinfo`, undefined, options);
+  } = useFetch(`${getBaseHref()}/api/v1/sysinfo`, undefined, options);
 
   useEffect(() => {
     setLoading(fetchLoading);

--- a/ui/src/utils/fetcherHooks/pipelineViewFetch.ts
+++ b/ui/src/utils/fetcherHooks/pipelineViewFetch.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Edge, MarkerType, Node } from "reactflow";
 import { isEqual } from "lodash";
+import { getBaseHref } from "../index";
 import {
   BufferInfo,
   EdgeWatermark,
@@ -45,7 +46,7 @@ export const usePipelineViewFetch = (
   const [buffersErr, setBuffersErr] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(true);
 
-  const BASE_API = `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}`;
+  const BASE_API = `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}`;
 
   const refresh = useCallback(() => {
     setRequestKey(`${Date.now()}`);

--- a/ui/src/utils/fetcherHooks/podsViewFetch.ts
+++ b/ui/src/utils/fetcherHooks/podsViewFetch.ts
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
-import { quantityToScalar } from "../index";
+import { getBaseHref, quantityToScalar } from "../index";
 import {
   Pod,
   PodContainerSpec,
@@ -30,7 +30,7 @@ export const usePodsViewFetch = (
     const fetchPods = async () => {
       try {
         const response = await fetch(
-          `/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertexId}/pods?refreshKey=${requestKey}`
+          `${getBaseHref()}/api/v1/namespaces/${namespaceId}/pipelines/${pipelineId}/vertices/${vertexId}/pods?refreshKey=${requestKey}`
         );
         if (response.ok) {
           const json = await response.json();
@@ -108,7 +108,9 @@ export const usePodsViewFetch = (
 
   useEffect(() => {
     if (pods?.length) {
-      if (!(selectedPod && pods?.find((pod) => pod?.name === selectedPod?.name))) {
+      if (
+        !(selectedPod && pods?.find((pod) => pod?.name === selectedPod?.name))
+      ) {
         setSelectedPod(pods[0]);
         setSelectedContainer(pods[0]?.containers[0]);
       }
@@ -122,7 +124,7 @@ export const usePodsViewFetch = (
     const fetchPods = async () => {
       try {
         const response = await fetch(
-          `/api/v1/metrics/namespaces/${namespaceId}/pods?refreshKey=${requestKey}`
+          `${getBaseHref()}/api/v1/metrics/namespaces/${namespaceId}/pods?refreshKey=${requestKey}`
         );
         if (response.ok) {
           const json = await response.json();


### PR DESCRIPTION
Fixes #1368 
- updated `api/v1` calls to go the access path configured from both backend and frontend
- updated configMap name used in deployment specs

TODO - access path for dex server