### PR TITLE
fix: updated access path config for root path

### DIFF
--- a/ui/src/utils/index.test.ts
+++ b/ui/src/utils/index.test.ts
@@ -178,7 +178,7 @@ describe("index", () => {
 
   // test getBaseHref
   it("getBaseHref", () => {
-    expect(getBaseHref()).toEqual("/");
+    expect(getBaseHref()).toEqual("");
   });
 
   // test getAPIResponseError
@@ -198,7 +198,7 @@ describe("index", () => {
   const clipboard = {
     writeText: jest.fn(),
   };
-  Object.defineProperty(global.navigator, 'clipboard', {
+  Object.defineProperty(global.navigator, "clipboard", {
     value: clipboard,
   });
   // test handleCopy

--- a/ui/src/utils/index.tsx
+++ b/ui/src/utils/index.tsx
@@ -49,10 +49,15 @@ export const LAST_UPDATED_SORT = "lastUpdated";
 export const LAST_CREATED_SORT = "lastCreated";
 
 export function getBaseHref(): string {
-  if (window.__RUNTIME_CONFIG__?.BASE_HREF) {
-    return window.__RUNTIME_CONFIG__.BASE_HREF;
+  const runtimeConfig = window.__RUNTIME_CONFIG__;
+  if (runtimeConfig?.BASE_HREF) {
+    let baseHref = runtimeConfig.BASE_HREF;
+    if (baseHref.endsWith("/")) {
+      baseHref = baseHref.slice(0, -1);
+    }
+    return baseHref;
   }
-  return "/";
+  return "";
 }
 
 export async function getAPIResponseError(


### PR DESCRIPTION
Setting "/" as baseHref was not working as expected while configuring the access path, due to incorrect URL creation.
