### PR TITLE
fix: server-secrets-init container restart 

### DIFF
--- a/config/advanced-install/namespaced-numaflow-server.yaml
+++ b/config/advanced-install/namespaced-numaflow-server.yaml
@@ -291,6 +291,11 @@ spec:
           name: env-volume
       - args:
         - server-secrets-init
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: quay.io/numaproj/numaflow:latest
         imagePullPolicy: Always
         name: server-secrets-init

--- a/config/advanced-install/numaflow-server.yaml
+++ b/config/advanced-install/numaflow-server.yaml
@@ -302,6 +302,11 @@ spec:
           name: env-volume
       - args:
         - server-secrets-init
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: quay.io/numaproj/numaflow:latest
         imagePullPolicy: Always
         name: server-secrets-init

--- a/config/base/numaflow-server/numaflow-server-deployment.yaml
+++ b/config/base/numaflow-server/numaflow-server-deployment.yaml
@@ -47,6 +47,11 @@ spec:
         args:
         - "server-secrets-init"
         imagePullPolicy: Always
+        env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
       containers:
         - name: main
           image: quay.io/numaproj/numaflow:latest

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -16796,6 +16796,11 @@ spec:
           name: env-volume
       - args:
         - server-secrets-init
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: quay.io/numaproj/numaflow:latest
         imagePullPolicy: Always
         name: server-secrets-init

--- a/config/namespace-install.yaml
+++ b/config/namespace-install.yaml
@@ -16688,6 +16688,11 @@ spec:
           name: env-volume
       - args:
         - server-secrets-init
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: quay.io/numaproj/numaflow:latest
         imagePullPolicy: Always
         name: server-secrets-init


### PR DESCRIPTION
- added env variable for namespace for accessing secrets and configMap for the `server-secrets-init` container
- enabled access to UI by completing initialization for the server