### PR TITLE
chore: add the unit for vertex processing rates on ui

### DIFF
--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
@@ -82,9 +82,9 @@ export function ProcessingRates({
               foundRates.map((metric) => (
                 <TableRow key={metric.partition}>
                   <TableCell>{metric.partition}</TableCell>
-                  <TableCell>{metric.oneM}</TableCell>
-                  <TableCell>{metric.fiveM}</TableCell>
-                  <TableCell>{metric.fifteenM}</TableCell>
+                  <TableCell>{metric.oneM}/sec</TableCell>
+                  <TableCell>{metric.fiveM}/sec</TableCell>
+                  <TableCell>{metric.fifteenM}/sec</TableCell>
                 </TableRow>
               ))}
           </TableBody>

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
@@ -39,14 +39,14 @@ export function ProcessingRates({
       rates.push({
         partition: index,
         oneM: item.processingRates["1m"]
-          ? item.processingRates["1m"].toFixed(2)
-          : 0,
+          ? item.processingRates["1m"].toFixed(2)+"/sec"
+          : "0/sec",
         fiveM: item.processingRates["5m"]
-          ? item.processingRates["5m"].toFixed(2)
-          : 0,
+          ? item.processingRates["5m"].toFixed(2)+"/sec"
+          : "0/sec",
         fifteenM: item.processingRates["15m"]
-          ? item.processingRates["15m"].toFixed(2)
-          : 0,
+          ? item.processingRates["15m"].toFixed(2)+"/sec"
+          : "0/sec",
       });
     });
     setFoundRates(rates);

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
@@ -39,14 +39,14 @@ export function ProcessingRates({
       rates.push({
         partition: index,
         oneM: item.processingRates["1m"]
-          ? item.processingRates["1m"].toFixed(2)+"/sec"
-          : "0/sec",
+          ? item.processingRates["1m"].toFixed(2)
+          : 0,
         fiveM: item.processingRates["5m"]
-          ? item.processingRates["5m"].toFixed(2)+"/sec"
-          : "0/sec",
+          ? item.processingRates["5m"].toFixed(2)
+          : 0,
         fifteenM: item.processingRates["15m"]
-          ? item.processingRates["15m"].toFixed(2)+"/sec"
-          : "0/sec",
+          ? item.processingRates["15m"].toFixed(2)
+          : 0,
       });
     });
     setFoundRates(rates);

--- a/ui/src/types/declarations/pipeline.d.ts
+++ b/ui/src/types/declarations/pipeline.d.ts
@@ -115,9 +115,9 @@ export interface PipelineUpdateFetchResult {
 
 export interface PipelineVertexMetric {
   partition: number;
-  oneM: string;
-  fiveM: string;
-  fifteenM: string;
+  oneM: number;
+  fiveM: number;
+  fifteenM: number;
 }
 
 export interface PipelineVertexMetrics {

--- a/ui/src/types/declarations/pipeline.d.ts
+++ b/ui/src/types/declarations/pipeline.d.ts
@@ -115,9 +115,9 @@ export interface PipelineUpdateFetchResult {
 
 export interface PipelineVertexMetric {
   partition: number;
-  oneM: number;
-  fiveM: number;
-  fifteenM: number;
+  oneM: string;
+  fiveM: string;
+  fifteenM: string;
 }
 
 export interface PipelineVertexMetrics {


### PR DESCRIPTION
Quentin Faidide from numaflow slack channel:

> The units are not shown in the Processing Rates panel. It's not the end of the world since it's easy to check against the 1m one with the unit in the graph, but it's free lunch to add it and have users figuring out instantly what the numbers means

## Before this PR

<img width="1483" alt="Screenshot 2024-01-03 at 5 01 50 PM" src="https://github.com/numaproj/numaflow/assets/13165977/72973bba-5635-4334-8c09-85e3574626ac">


## After

<img width="1467" alt="Screenshot 2024-01-03 at 5 03 36 PM" src="https://github.com/numaproj/numaflow/assets/13165977/d07ac5a8-03b4-4c1e-8398-1308d7248e61">




<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
