### PR TITLE
fix: UI Filter by status for pipelines doesn't work as expected

### DIFF
--- a/ui/src/components/pages/Namespace/partials/NamespaceListingWrapper/PipelineListing/index.tsx
+++ b/ui/src/components/pages/Namespace/partials/NamespaceListingWrapper/PipelineListing/index.tsx
@@ -152,7 +152,7 @@ export function PipelineListing({
     if (statusFilter !== ALL) {
       filtered = filtered.filter((p) => {
         const currentStatus = p?.pipeline?.status?.phase || UNKNOWN;
-        if (currentStatus.toLowerCase() === status.toLowerCase()) {
+        if (currentStatus.toLowerCase() === statusFilter.toLowerCase()) {
           return true;
         } else {
           return false;


### PR DESCRIPTION
fix: #1443

Fixes the UI filter by status for pipelines which was earlier broken.

**Previously:**

![295021328-e4ee214f-723c-483e-a472-e13ef9842900](https://github.com/numaproj/numaflow/assets/20226361/c6278a82-51b7-4291-93a3-3b5417b4f56c)


**With Change:**

![Screenshot 2024-01-09 at 8 58 17 PM](https://github.com/numaproj/numaflow/assets/20226361/89efbb51-9b0b-413f-803b-8a4b9949f470)




<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
