### PR TITLE
fix: GetDownstreamEdges is not cycle safe

### DIFF
--- a/pkg/apis/numaflow/v1alpha1/pipeline_types.go
+++ b/pkg/apis/numaflow/v1alpha1/pipeline_types.go
@@ -161,17 +161,22 @@ func (p Pipeline) GetAllBuckets() []string {
 
 // GetDownstreamEdges returns all the downstream edges of a vertex
 func (p Pipeline) GetDownstreamEdges(vertexName string) []Edge {
-	var f func(vertexName string, edges *[]Edge)
-	f = func(vertexName string, edges *[]Edge) {
+	var f func(vertexName string, edges *[]Edge, visited map[string]bool)
+	f = func(vertexName string, edges *[]Edge, visited map[string]bool) {
+		if visited[vertexName] {
+			return
+		}
+		visited[vertexName] = true
 		for _, b := range p.ListAllEdges() {
 			if b.From == vertexName {
 				*edges = append(*edges, b)
-				f(b.To, edges)
+				f(b.To, edges, visited)
 			}
 		}
 	}
 	result := []Edge{}
-	f(vertexName, &result)
+	visited := make(map[string]bool)
+	f(vertexName, &result, visited)
 	return result
 }
 

--- a/pkg/apis/numaflow/v1alpha1/pipeline_types_test.go
+++ b/pkg/apis/numaflow/v1alpha1/pipeline_types_test.go
@@ -301,18 +301,26 @@ func Test_GetDownstreamEdges(t *testing.T) {
 			Edges: []Edge{
 				{From: "input", To: "p1"},
 				{From: "p1", To: "p11"},
+				{From: "p1", To: "p1"},
 				{From: "p1", To: "p2"},
 				{From: "p2", To: "output"},
 			},
 		},
 	}
 	edges := pl.GetDownstreamEdges("input")
-	assert.Equal(t, 4, len(edges))
+	assert.Equal(t, 5, len(edges))
 	assert.Equal(t, edges, pl.ListAllEdges())
-	assert.Equal(t, edges[2], Edge{From: "p1", To: "p2"})
+	assert.Equal(t, edges[2], Edge{From: "p1", To: "p1"})
+	assert.Equal(t, edges[3], Edge{From: "p1", To: "p2"})
 
 	edges = pl.GetDownstreamEdges("p1")
-	assert.Equal(t, 3, len(edges))
+	assert.Equal(t, 4, len(edges))
+
+	edges = pl.GetDownstreamEdges("p2")
+	assert.Equal(t, 1, len(edges))
+
+	edges = pl.GetDownstreamEdges("p11")
+	assert.Equal(t, 0, len(edges))
 
 	edges = pl.GetDownstreamEdges("output")
 	assert.Equal(t, 0, len(edges))


### PR DESCRIPTION
fix: #1446

- Explained the problem in the issue linked.
- The fix is pretty straight forward, we keep track of visited vertexes in a map.
- Updated the unit test to capture the issue reported.


Thanks for reviewing! open for comments and improvements

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
