### PR TITLE
chore: enable reduce java sdk e2e test

### DIFF
--- a/test/sdks-e2e/sdks_test.go
+++ b/test/sdks-e2e/sdks_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package sdks_e2e
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"sync"
@@ -86,43 +87,42 @@ func (s *SDKsSuite) TestMapStreamUDFunctionAndSink() {
 		VertexPodLogContains("java-udsink", "hello", PodLogCheckOptionWithContainer("udsink"), PodLogCheckOptionWithCount(4))
 }
 
-// TODO(session) fix after updating java sdk
-//func (s *SDKsSuite) TestReduceSDK() {
-//	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-//	defer cancel()
-//	w := s.Given().Pipeline("@testdata/simple-keyed-reduce-pipeline.yaml").
-//		When().
-//		CreatePipelineAndWait()
-//	defer w.DeletePipelineAndWait()
-//	pipelineName := "even-odd-sum"
-//
-//	// wait for all the pods to come up
-//	w.Expect().VertexPodsRunning()
-//
-//	done := make(chan struct{})
-//	go func() {
-//		// publish messages to source vertex, with event time starting from 60000
-//		startTime := 60000
-//		for i := 0; true; i++ {
-//			select {
-//			case <-ctx.Done():
-//				return
-//			case <-done:
-//				return
-//			default:
-//				eventTime := strconv.Itoa(startTime + i*1000)
-//				w.SendMessageTo(pipelineName, "in", NewHttpPostRequest().WithBody([]byte("1")).WithHeader("X-Numaflow-Event-Time", eventTime)).
-//					SendMessageTo(pipelineName, "in", NewHttpPostRequest().WithBody([]byte("2")).WithHeader("X-Numaflow-Event-Time", eventTime)).
-//					SendMessageTo(pipelineName, "in", NewHttpPostRequest().WithBody([]byte("3")).WithHeader("X-Numaflow-Event-Time", eventTime))
-//			}
-//		}
-//	}()
-//
-//	w.Expect().
-//		VertexPodLogContains("java-udsink", "120", PodLogCheckOptionWithContainer("udsink")).
-//		VertexPodLogContains("java-udsink", "240", PodLogCheckOptionWithContainer("udsink"))
-//	done <- struct{}{}
-//}
+func (s *SDKsSuite) TestReduceSDK() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	w := s.Given().Pipeline("@testdata/simple-keyed-reduce-pipeline.yaml").
+		When().
+		CreatePipelineAndWait()
+	defer w.DeletePipelineAndWait()
+	pipelineName := "even-odd-sum"
+
+	// wait for all the pods to come up
+	w.Expect().VertexPodsRunning()
+
+	done := make(chan struct{})
+	go func() {
+		// publish messages to source vertex, with event time starting from 60000
+		startTime := 60000
+		for i := 0; true; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			case <-done:
+				return
+			default:
+				eventTime := strconv.Itoa(startTime + i*1000)
+				w.SendMessageTo(pipelineName, "in", NewHttpPostRequest().WithBody([]byte("1")).WithHeader("X-Numaflow-Event-Time", eventTime)).
+					SendMessageTo(pipelineName, "in", NewHttpPostRequest().WithBody([]byte("2")).WithHeader("X-Numaflow-Event-Time", eventTime)).
+					SendMessageTo(pipelineName, "in", NewHttpPostRequest().WithBody([]byte("3")).WithHeader("X-Numaflow-Event-Time", eventTime))
+			}
+		}
+	}()
+
+	w.Expect().
+		VertexPodLogContains("java-udsink", "120", PodLogCheckOptionWithContainer("udsink")).
+		VertexPodLogContains("java-udsink", "240", PodLogCheckOptionWithContainer("udsink"))
+	done <- struct{}{}
+}
 
 func (s *SDKsSuite) TestSourceTransformer() {
 	var wg sync.WaitGroup

--- a/test/sdks-e2e/testdata/simple-keyed-reduce-pipeline.yaml
+++ b/test/sdks-e2e/testdata/simple-keyed-reduce-pipeline.yaml
@@ -19,7 +19,7 @@ spec:
       udf:
         container:
           # compute the sum, see https://github.com/numaproj/numaflow-java/tree/main/examples/src/main/java/io/numaproj/numaflow/examples/reduce/sum
-          image: quay.io/numaio/numaflow-java/reduce-sum:v0.6.0
+          image: quay.io/numaio/numaflow-java/reduce-sum:v0.6.1
         groupBy:
           window:
             fixed:


### PR DESCRIPTION
Https://github.com/numaproj/numaflow-java/pull/90 fixed the test. I haven't merged the sdk changes but updated the image in quay.io.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
