### PR TITLE
fix(controller): incorrect cpu/mem resources calculation

### DIFF
--- a/pkg/apis/numaflow/v1alpha1/pipeline_types.go
+++ b/pkg/apis/numaflow/v1alpha1/pipeline_types.go
@@ -252,7 +252,7 @@ func (p Pipeline) GetDaemonDeploymentObj(req GetDaemonDeploymentReq) (*appv1.Dep
 		Name:            CtrMain,
 		Image:           req.Image,
 		ImagePullPolicy: req.PullPolicy,
-		Resources:       standardResources,
+		Resources:       *standardResources.DeepCopy(),
 		Env:             envVars,
 		Args:            []string{"daemon-server", "--isbsvc-type=" + string(req.ISBSvcType)},
 	}
@@ -335,7 +335,7 @@ func (p Pipeline) getDaemonPodInitContainer(req GetDaemonDeploymentReq) corev1.C
 		Env:             envVars,
 		Image:           req.Image,
 		ImagePullPolicy: req.PullPolicy,
-		Resources:       standardResources,
+		Resources:       *standardResources.DeepCopy(),
 		Args:            []string{"isbsvc-validate", "--isbsvc-type=" + string(req.ISBSvcType)},
 	}
 	c.Args = append(c.Args, "--buffers="+strings.Join(p.GetAllBuffers(), ","))

--- a/pkg/apis/numaflow/v1alpha1/redis_buffer_service.go
+++ b/pkg/apis/numaflow/v1alpha1/redis_buffer_service.go
@@ -410,7 +410,7 @@ redis_exporter`},
 		spec.Template.Spec.InitContainers = []corev1.Container{
 			{
 				Name:            "volume-permissions",
-				Resources:       standardResources,
+				Resources:       *standardResources.DeepCopy(),
 				SecurityContext: &corev1.SecurityContext{RunAsUser: &runAsUser0},
 				VolumeMounts:    []corev1.VolumeMount{{Name: req.PvcNameIfNeeded, MountPath: "/data"}},
 				Image:           req.InitContainerImage,

--- a/pkg/apis/numaflow/v1alpha1/side_inputs.go
+++ b/pkg/apis/numaflow/v1alpha1/side_inputs.go
@@ -115,7 +115,7 @@ func (si SideInput) getInitContainer(pipeline Pipeline, req GetSideInputDeployme
 		Env:             req.Env,
 		Image:           req.Image,
 		ImagePullPolicy: req.PullPolicy,
-		Resources:       standardResources,
+		Resources:       *standardResources.DeepCopy(),
 		Args:            []string{"isbsvc-validate", "--isbsvc-type=" + string(req.ISBSvcType)},
 	}
 	c.Args = append(c.Args, "--side-inputs-store="+pipeline.GetSideInputsStoreName())
@@ -144,7 +144,7 @@ func (si SideInput) getNumaContainer(pipeline Pipeline, req GetSideInputDeployme
 		Env:             envVars,
 		Image:           req.Image,
 		ImagePullPolicy: req.PullPolicy,
-		Resources:       standardResources,
+		Resources:       *standardResources.DeepCopy(),
 		Args:            []string{"side-inputs-manager", "--isbsvc-type=" + string(req.ISBSvcType), "--side-inputs-store=" + pipeline.GetSideInputsStoreName()},
 	}
 	if x := pipeline.Spec.Templates; x != nil && x.SideInputsManagerTemplate != nil && x.SideInputsManagerTemplate.ContainerTemplate != nil {

--- a/pkg/apis/numaflow/v1alpha1/vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/vertex_types.go
@@ -224,7 +224,7 @@ func (v Vertex) GetPodSpec(req GetVertexPodSpecReq) (*corev1.PodSpec, error) {
 		env:             envVars,
 		image:           req.Image,
 		imagePullPolicy: req.PullPolicy,
-		resources:       standardResources,
+		resources:       *standardResources.DeepCopy(),
 		volumeMounts:    volumeMounts,
 	})
 	if err != nil {
@@ -276,7 +276,7 @@ func (v Vertex) GetPodSpec(req GetVertexPodSpecReq) (*corev1.PodSpec, error) {
 			Env:             req.Env,
 			Image:           req.Image,
 			ImagePullPolicy: req.PullPolicy,
-			Resources:       standardResources,
+			Resources:       *standardResources.DeepCopy(),
 			Args:            []string{"side-inputs-synchronizer", "--isbsvc-type=" + string(req.ISBSvcType), "--side-inputs-store=" + req.SideInputsStoreName, "--side-inputs=" + strings.Join(v.Spec.SideInputs, ",")},
 		}
 		sideInputsWatcher.Env = append(sideInputsWatcher.Env, v.commonEnvs()...)
@@ -321,7 +321,7 @@ func (v Vertex) getInitContainers(req GetVertexPodSpecReq) []corev1.Container {
 			Env:             envVars,
 			Image:           req.Image,
 			ImagePullPolicy: req.PullPolicy,
-			Resources:       standardResources,
+			Resources:       *standardResources.DeepCopy(),
 			Args:            []string{"isbsvc-validate", "--isbsvc-type=" + string(req.ISBSvcType)},
 		},
 	}
@@ -331,7 +331,7 @@ func (v Vertex) getInitContainers(req GetVertexPodSpecReq) []corev1.Container {
 			Env:             envVars,
 			Image:           req.Image,
 			ImagePullPolicy: req.PullPolicy,
-			Resources:       standardResources,
+			Resources:       *standardResources.DeepCopy(),
 			Args:            []string{"side-inputs-init", "--isbsvc-type=" + string(req.ISBSvcType), "--side-inputs-store=" + req.SideInputsStoreName, "--side-inputs=" + strings.Join(v.Spec.SideInputs, ",")},
 		})
 	}


### PR DESCRIPTION
The default `resource` is used as a reference to all the places that need to have a resource setting (for example, a vertex numa container), once there's a customization on the particular container resource, it updates all, which is wrong. 

Fix it by referencing to a new instance of the default resource.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
