### PR TITLE
chore: use longer window to verify the reduce streamer return early before window gets closed

### DIFF
--- a/test/reduce-sdk-e2e/testdata/reduce-stream/reduce-stream-go.yaml
+++ b/test/reduce-sdk-e2e/testdata/reduce-stream/reduce-stream-go.yaml
@@ -23,7 +23,8 @@ spec:
         groupBy:
           window:
             fixed:
-              length: 60s
+              # set window size to a high number as 10 minutes so that we verify early return by reduce streamer.
+              length: 600s
               streaming: true
           keyed: true
           storage:

--- a/test/reduce-sdk-e2e/testdata/reduce-stream/reduce-stream-java.yaml
+++ b/test/reduce-sdk-e2e/testdata/reduce-stream/reduce-stream-java.yaml
@@ -23,7 +23,8 @@ spec:
         groupBy:
           window:
             fixed:
-              length: 60s
+              # set window size to a high number as 10 minutes so that we verify early return by reduce streamer.
+              length: 600s
               streaming: true
           keyed: true
           storage:


### PR DESCRIPTION
Address comment in https://github.com/numaproj/numaflow/pull/1476#discussion_r1464421083

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
