### PR TITLE
fix: add idle handler offset nil check

### DIFF
--- a/pkg/udf/map_udf.go
+++ b/pkg/udf/map_udf.go
@@ -254,7 +254,7 @@ func (u *MapUDFProcessor) Start(ctx context.Context) error {
 			defer finalWg.Done()
 			log.Infow("Start processing udf messages", zap.String("isbsvc", string(u.ISBSvcType)), zap.String("from", fromBufferPartitionName), zap.Any("to", u.VertexInstance.Vertex.GetToBuffers()))
 
-			stopped := forwarder.Start()
+			stopped := isdf.Start()
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 			go func() {
@@ -268,7 +268,7 @@ func (u *MapUDFProcessor) Start(ctx context.Context) error {
 
 			<-ctx.Done()
 			log.Info("SIGTERM, exiting inside partition...", zap.String("partition", fromBufferPartitionName))
-			forwarder.Stop()
+			isdf.Stop()
 			wg.Wait()
 			log.Info("Exited for partition...", zap.String("partition", fromBufferPartitionName))
 		}(bufferPartition, forwarder)


### PR DESCRIPTION
Add idle handler offset nil check to fix the panic.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1d493cc]
goroutine 369 [running]:
github.com/numaproj/numaflow/pkg/watermark/publish.(*publish).PublishIdleWatermark(0xc000598120, {0xc00064c640?, 0x41?, 0x3bb0be0?}, {0x0, 0x0}, 0x1)
	/home/runner/work/numaflow/numaflow/pkg/watermark/publish/publisher.go:207 +0x16c
github.com/numaproj/numaflow/pkg/shared/idlehandler.PublishIdleWatermark({0x294e5e8, 0xc0007dc300}, {0x294ed20, 0xc000222310}, {0x294eee0, 0xc000598120}, {0x294ef18, 0xc00065eb60}, 0xc00061e0a0?, {0x258897f, ...}, ...)
	/home/runner/work/numaflow/numaflow/pkg/shared/idlehandler/idlehandler.go:62 +0x645
github.com/numaproj/numaflow/pkg/udf/forward.(*InterStepDataForward).forwardAChunk(0xc00001a8c0, {0x294e5e8?, 0xc0007dc300})
	/home/runner/work/numaflow/numaflow/pkg/udf/forward/forward.go:381 +0x1ec7
github.com/numaproj/numaflow/pkg/udf/forward.(*InterStepDataForward).Start.func1()
	/home/runner/work/numaflow/numaflow/pkg/udf/forward/forward.go:156 +0xf6
created by github.com/numaproj/numaflow/pkg/udf/forward.(*InterStepDataForward).Start
	/home/runner/work/numaflow/numaflow/pkg/udf/forward/forward.go:135 +0xca
```

Also update the goroutine in map_udf.go Start function