### PR TITLE
fix: initialize inflightAcks channel to not nil channel

### DIFF
--- a/pkg/sources/kafka/handler.go
+++ b/pkg/sources/kafka/handler.go
@@ -57,14 +57,17 @@ func (consumer *consumerHandler) Setup(sess sarama.ConsumerGroupSession) error {
 	consumer.readyCloser.Do(func() {
 		close(consumer.ready)
 	})
+	consumer.logger.Info("Kafka Consumer Setup complete")
 	return nil
 }
 
 // Cleanup is run at the end of a session, once all ConsumeClaim goroutines have exited
 func (consumer *consumerHandler) Cleanup(sess sarama.ConsumerGroupSession) error {
+	consumer.logger.Info("Kafka Consumer Starting Cleanup routine, waiting for in-flight-acks to complete")
 	// wait for inflight acks to be completed.
 	<-consumer.inflightAcks
 	sess.Commit()
+	consumer.logger.Info("Kafka Consumer Cleanup complete")
 	return nil
 }
 
@@ -73,6 +76,7 @@ func (consumer *consumerHandler) ConsumeClaim(session sarama.ConsumerGroupSessio
 	// The `ConsumeClaim` itself is called within a goroutine, see:
 	// https://github.com/IBM/sarama/blob/main/consumer_group.go#L27-L29
 	for {
+		consumer.logger.Info("Kafka Consumer about to claim Messages from the Kafka broker")
 		select {
 		case msg, ok := <-claim.Messages():
 			if !ok {

--- a/pkg/sources/kafka/handler.go
+++ b/pkg/sources/kafka/handler.go
@@ -37,10 +37,17 @@ type consumerHandler struct {
 
 // new handler initializes the channel for passing messages
 func newConsumerHandler(readChanSize int) *consumerHandler {
+	// Initializing the inflightAcks channel to closed channel instead of nil will ensure that
+	// the Cleanup func below will not hang on the inflight acks to be completed in the case
+	// the Ack func was not called due to no messages being consumed.
+	var inflightAcks = make(chan bool)
+	close(inflightAcks)
+
 	return &consumerHandler{
-		ready:    make(chan bool),
-		messages: make(chan *sarama.ConsumerMessage, readChanSize),
-		logger:   logging.NewLogger(),
+		inflightAcks: inflightAcks,
+		ready:        make(chan bool),
+		messages:     make(chan *sarama.ConsumerMessage, readChanSize),
+		logger:       logging.NewLogger(),
 	}
 }
 


### PR DESCRIPTION
Closes #1541

Initialize inflightAcks channel to not nil channel to avoid hanging on cleanup function when there are no messages to acknowledge.

How to Test/Reproduce:
1. setup a Kafka client and a Kafka topic with 10 partitions
2. in a bash script, set Kafka client to send 10 messages per second
3. setup a Numaflow pipeline with source vertex to consume from the Kafka client (disable autoscaling)
4. manually scale source vertex to 12 or more pods (`kubectl scale vtx <vtx_name> --replicas=12`)
5. manually delete pod-0
6. wait for a new pod-0 to restart
7. verify it has no topics assigned to it in the metrics: `kafka_source_read_total`
8. scale down to 1 pod
9. at this point, before the fix, the messages flow to the log sink would stop. After the fix, pod-0 is not stuck in the cleanup state and can resume consuming messages (`kafka_source_read_total` should show for all 10 partitions)
