### PR TITLE
fix: error message that cause Buttons overflow in the UI

### DIFF
--- a/ui/src/components/common/SpecEditor/index.tsx
+++ b/ui/src/components/common/SpecEditor/index.tsx
@@ -228,6 +228,9 @@ export function SpecEditor({
               display: "flex",
               flexDirection: "row",
               alignItems: "center",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
             }}
           >
             {validationMessage.type === "error" && (
@@ -244,7 +247,14 @@ export function SpecEditor({
                 sx={{ marginRight: "0.5rem" }}
               />
             )}
-            <span className="spec-editor-validation-message">
+            <span
+              className="spec-editor-validation-message"
+              style={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+              >
               {validationMessage.message}
             </span>
           </Box>


### PR DESCRIPTION
Explain what this PR does.
 
This PR fixes the text over flow from the error message in the specEditor from the issue here https://github.com/numaproj/numaflow/issues/1413

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
