### PR TITLE
chore: set image pull policies to always

### DIFF
--- a/test/diamond-e2e/testdata/cycle-backward.yaml
+++ b/test/diamond-e2e/testdata/cycle-backward.yaml
@@ -18,6 +18,7 @@ spec:
         container:
           # This will try each message up to 3 times before continuing, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/retry
           image: quay.io/numaio/numaflow-go/map-retry:stable
+          imagePullPolicy: Always
     - name: out
       sink:
         udsink:

--- a/test/diamond-e2e/testdata/cycle-to-self.yaml
+++ b/test/diamond-e2e/testdata/cycle-to-self.yaml
@@ -14,6 +14,7 @@ spec:
         container:
           # This will try each message up to 3 times before continuing, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/retry
           image: quay.io/numaio/numaflow-go/map-retry:stable
+          imagePullPolicy: Always
     - name: out
       sink:
         udsink:

--- a/test/diamond-e2e/testdata/join-on-reduce-pipeline.yaml
+++ b/test/diamond-e2e/testdata/join-on-reduce-pipeline.yaml
@@ -18,6 +18,7 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: atoi-1
       partitions: 2
       scale:
@@ -26,12 +27,14 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: compute-sum
       partitions: 2
       udf:
         container:
           # Compute the sum, see https://github.com/numaproj/numaflow-go/tree/main/pkg/reducer/examples/sum
           image: quay.io/numaio/numaflow-go/reduce-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:

--- a/test/diamond-e2e/testdata/join-on-sink.yaml
+++ b/test/diamond-e2e/testdata/join-on-sink.yaml
@@ -12,6 +12,7 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: even-cat
       udf:
         builtin:

--- a/test/e2e/testdata/even-odd.yaml
+++ b/test/e2e/testdata/even-odd.yaml
@@ -13,6 +13,7 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: even-sink
       partitions: 2
       sink:

--- a/test/idle-source-e2e/testdata/idle-source-reduce-pipeline.yaml
+++ b/test/idle-source-e2e/testdata/idle-source-reduce-pipeline.yaml
@@ -24,12 +24,14 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: compute-sum
       partitions: 2
       udf:
         container:
           # Compute the sum, see https://github.com/numaproj/numaflow-go/tree/main/pkg/reducer/examples/sum
           image: quay.io/numaio/numaflow-go/reduce-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:

--- a/test/idle-source-e2e/testdata/kafka-pipeline.yaml
+++ b/test/idle-source-e2e/testdata/kafka-pipeline.yaml
@@ -30,6 +30,7 @@ spec:
       udf:
         container:
           image: quay.io/numaio/numaflow-go/reduce-counter:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:

--- a/test/reduce-one-e2e/testdata/complex-reduce-pipeline.yaml
+++ b/test/reduce-one-e2e/testdata/complex-reduce-pipeline.yaml
@@ -20,12 +20,14 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: keyed-fixed-sum
       partitions: 1
       udf:
         container:
           # Compute the sum, see https://github.com/numaproj/numaflow-go/tree/main/pkg/reducer/examples/sum
           image: quay.io/numaio/numaflow-go/reduce-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:
@@ -38,6 +40,7 @@ spec:
         container:
           # Compute the sum, see https://github.com/numaproj/numaflow-go/tree/main/pkg/reducer/examples/sum
           image: quay.io/numaio/numaflow-go/reduce-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:

--- a/test/reduce-one-e2e/testdata/complex-sliding-window-pipeline.yaml
+++ b/test/reduce-one-e2e/testdata/complex-sliding-window-pipeline.yaml
@@ -20,6 +20,7 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: keyed-fixed-sum
       containerTemplate:
         env:
@@ -30,6 +31,7 @@ spec:
         container:
           # Compute the sum, see https://github.com/numaproj/numaflow-go/tree/main/pkg/reducer/examples/sum
           image: quay.io/numaio/numaflow-go/reduce-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:
@@ -48,6 +50,7 @@ spec:
         container:
           # Compute the sum, see https://github.com/numaproj/numaflow-go/tree/main/pkg/reducer/examples/sum
           image: quay.io/numaio/numaflow-go/reduce-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:
@@ -66,6 +69,7 @@ spec:
         container:
           # Compute the sum, see https://github.com/numaproj/numaflow-go/tree/main/pkg/reducer/examples/sum
           image: quay.io/numaio/numaflow-go/reduce-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             sliding:

--- a/test/reduce-one-e2e/testdata/simple-keyed-reduce-pipeline.yaml
+++ b/test/reduce-one-e2e/testdata/simple-keyed-reduce-pipeline.yaml
@@ -20,12 +20,14 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: compute-sum
       partitions: 1
       udf:
         container:
           # Compute the sum, see https://github.com/numaproj/numaflow-go/tree/main/pkg/reducer/examples/sum
           image: quay.io/numaio/numaflow-go/reduce-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:

--- a/test/reduce-one-e2e/testdata/simple-non-keyed-reduce-pipeline.yaml
+++ b/test/reduce-one-e2e/testdata/simple-non-keyed-reduce-pipeline.yaml
@@ -20,11 +20,13 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: compute-sum
       udf:
         container:
           # Compute the sum, see https://github.com/numaproj/numaflow-go/tree/main/pkg/reducer/examples/sum
           image: quay.io/numaio/numaflow-go/reduce-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:

--- a/test/reduce-one-e2e/testdata/simple-reduce-pipeline-wal.yaml
+++ b/test/reduce-one-e2e/testdata/simple-reduce-pipeline-wal.yaml
@@ -18,12 +18,14 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: compute-sum
       partitions: 2
       udf:
         container:
           # Compute the sum, see https://github.com/numaproj/numaflow-go/tree/main/pkg/reducer/examples/sum
           image: quay.io/numaio/numaflow-go/reduce-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:

--- a/test/reduce-two-e2e/testdata/reduce-stream/reduce-stream-go.yaml
+++ b/test/reduce-two-e2e/testdata/reduce-stream/reduce-stream-go.yaml
@@ -16,12 +16,14 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: compute-sum
       partitions: 2
       udf:
         container:
           # compute the sum, see https://github.com/numaproj/numaflow-go/tree/main/pkg/reducestreamer/examples/sum
           image: quay.io/numaio/numaflow-go/reduce-stream-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:
@@ -39,6 +41,7 @@ spec:
           container:
             # A redis sink for e2e testing, see https://github.com/numaproj/numaflow-sinks/tree/main/redis-e2e-test-sink
             image: quay.io/numaio/numaflow-sink/redis-e2e-test-sink:latest
+            imagePullPolicy: Always
   edges:
     - from: in
       to: atoi

--- a/test/reduce-two-e2e/testdata/reduce-stream/reduce-stream-java.yaml
+++ b/test/reduce-two-e2e/testdata/reduce-stream/reduce-stream-java.yaml
@@ -16,12 +16,14 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/even_odd
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: compute-sum
       partitions: 2
       udf:
         container:
           # compute the sum, see https://github.com/numaproj/numaflow-java/tree/main/examples/src/main/java/io/numaproj/numaflow/examples/reducestreamer/sum
           image: quay.io/numaio/numaflow-java/reduce-stream-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:

--- a/test/reduce-two-e2e/testdata/session-reduce/simple-session-keyed-counter-pipeline-go.yaml
+++ b/test/reduce-two-e2e/testdata/session-reduce/simple-session-keyed-counter-pipeline-go.yaml
@@ -17,12 +17,14 @@ spec:
       udf:
         container:
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: compute-count
       partitions: 1
       udf:
         container:
           # see https://github.com/numaproj/numaflow-go/tree/main/pkg/sessionreducer/examples/counter
           image: quay.io/numaio/numaflow-go/session-counter:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             session:

--- a/test/reduce-two-e2e/testdata/session-reduce/simple-session-keyed-counter-pipeline-java.yaml
+++ b/test/reduce-two-e2e/testdata/session-reduce/simple-session-keyed-counter-pipeline-java.yaml
@@ -17,12 +17,14 @@ spec:
       udf:
         container:
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
+          imagePullPolicy: Always
     - name: compute-count
       partitions: 1
       udf:
         container:
           # see https://github.com/numaproj/numaflow-java/tree/main/examples/src/main/java/io/numaproj/numaflow/examples/reducesession/counter
           image: quay.io/numaio/numaflow-java/session-reduce-count:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             session:

--- a/test/sdks-e2e/testdata/flatmap-stream.yaml
+++ b/test/sdks-e2e/testdata/flatmap-stream.yaml
@@ -20,6 +20,7 @@ spec:
         container:
           # Split input message into an array with comma, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapstreamer/examples/flatmap_stream
           image: quay.io/numaio/numaflow-go/map-flatmap-stream:stable
+          imagePullPolicy: Always
     - name: go-udsink
       scale:
         min: 1
@@ -28,6 +29,7 @@ spec:
           container:
             # https://github.com/numaproj/numaflow-go/tree/main/pkg/sinker/examples/log
             image: quay.io/numaio/numaflow-go/sink-log:stable
+            imagePullPolicy: Always
     - name: go-udsink-2
       scale:
         min: 1
@@ -36,7 +38,7 @@ spec:
           container:
             # https://github.com/numaproj/numaflow-go/tree/main/pkg/sinker/examples/log
             image: quay.io/numaio/numaflow-go/sink-log:stable
-
+            imagePullPolicy: Always
     - name: python-split
       partitions: 3
       metadata:
@@ -53,6 +55,7 @@ spec:
             - example.py
           # Split input message into an array with comma, https://github.com/numaproj/numaflow-python/tree/main/examples/mapstream/flatmap_stream
           image: quay.io/numaio/numaflow-python/map-flatmap-stream:stable
+          imagePullPolicy: Always
     - name: python-udsink
       scale:
         min: 1
@@ -64,6 +67,7 @@ spec:
               - example.py
             # https://github.com/numaproj/numaflow-python/tree/main/examples/sink/log
             image: quay.io/numaio/numaflow-python/sink-log:stable
+            imagePullPolicy: Always
     - name: java-split
       partitions: 3
       metadata:
@@ -77,6 +81,7 @@ spec:
         container:
           # Split input message into an array with comma, see https://github.com/numaproj/numaflow-java/tree/main/examples/src/main/java/io/numaproj/numaflow/examples/mapstream/flatmapstream
           image: quay.io/numaio/numaflow-java/flat-map-stream:stable
+          imagePullPolicy: Always
     - name: java-udsink
       scale:
         min: 1
@@ -85,6 +90,7 @@ spec:
           container:
             # https://github.com/numaproj/numaflow-java/tree/main/examples/src/main/java/io/numaproj/numaflow/examples/sink/simple
             image: quay.io/numaio/numaflow-java/simple-sink:stable
+            imagePullPolicy: Always
   edges:
     - from: in
       to: go-split

--- a/test/sdks-e2e/testdata/flatmap.yaml
+++ b/test/sdks-e2e/testdata/flatmap.yaml
@@ -14,6 +14,7 @@ spec:
         container:
           # Split input message into an array with comma, see https://github.com/numaproj/numaflow-go/tree/main/pkg/mapper/examples/flatmap
           image: quay.io/numaio/numaflow-go/map-flatmap:stable
+          imagePullPolicy: Always
     - name: go-udsink
       scale:
         min: 1
@@ -22,7 +23,7 @@ spec:
           container:
             # https://github.com/numaproj/numaflow-go/tree/main/pkg/sinker/examples/log
             image: quay.io/numaio/numaflow-go/sink-log:stable
-
+            imagePullPolicy: Always
     - name: python-split
       scale:
         min: 1
@@ -33,6 +34,7 @@ spec:
             - example.py
           # Split input message into an array with comma, https://github.com/numaproj/numaflow-python/tree/main/examples/map/flatmap
           image: quay.io/numaio/numaflow-python/map-flatmap:stable
+          imagePullPolicy: Always
     - name: python-udsink
       scale:
         min: 1
@@ -44,6 +46,7 @@ spec:
             - example.py
             # https://github.com/numaproj/numaflow-python/tree/main/examples/sink/log
             image: quay.io/numaio/numaflow-python/sink-log:stable
+            imagePullPolicy: Always
     - name: java-split
       scale:
         min: 1
@@ -51,6 +54,7 @@ spec:
         container:
           # Split input message into an array with comma, see https://github.com/numaproj/numaflow-java/tree/main/examples/src/main/java/io/numaproj/numaflow/examples/map/flatmap
           image: quay.io/numaio/numaflow-java/map-flatmap:stable
+          imagePullPolicy: Always
     - name: java-udsink
       scale:
         min: 1
@@ -59,6 +63,7 @@ spec:
           container:
             # https://github.com/numaproj/numaflow-java/tree/main/examples/src/main/java/io/numaproj/numaflow/examples/sink/simple
             image: quay.io/numaio/numaflow-java/simple-sink:stable
+            imagePullPolicy: Always
   edges:
     - from: in
       to: go-split

--- a/test/sdks-e2e/testdata/simple-keyed-reduce-pipeline.yaml
+++ b/test/sdks-e2e/testdata/simple-keyed-reduce-pipeline.yaml
@@ -14,12 +14,14 @@ spec:
         container:
           # Tell the input number is even or odd, see https://github.com/numaproj/numaflow-java/tree/main/examples/src/main/java/io/numaproj/numaflow/examples/map/evenodd
           image: quay.io/numaio/numaflow-java/even-odd:stable
+          imagePullPolicy: Always
     - name: compute-sum
       partitions: 2
       udf:
         container:
           # compute the sum, see https://github.com/numaproj/numaflow-java/tree/main/examples/src/main/java/io/numaproj/numaflow/examples/reduce/sum
           image: quay.io/numaio/numaflow-java/reduce-sum:stable
+          imagePullPolicy: Always
         groupBy:
           window:
             fixed:
@@ -35,6 +37,7 @@ spec:
           container:
             # https://github.com/numaproj/numaflow-java/tree/main/examples/src/main/java/io/numaproj/numaflow/examples/sink/simple
             image: quay.io/numaio/numaflow-java/simple-sink:stable
+            imagePullPolicy: Always
   edges:
     - from: in
       to: atoi

--- a/test/sdks-e2e/testdata/transformer/event-time-filter-go.yaml
+++ b/test/sdks-e2e/testdata/transformer/event-time-filter-go.yaml
@@ -11,6 +11,7 @@ spec:
           container:
             # Filter messages based on event time, see https://github.com/numaproj/numaflow-go/tree/main/pkg/sourcetransformer/examples/event_time_filter
             image: quay.io/numaio/numaflow-go/mapt-event-time-filter:stable
+            imagePullPolicy: Always
     - name: sink-within-2022
       partitions: 2
       scale:

--- a/test/sdks-e2e/testdata/transformer/event-time-filter-java.yaml
+++ b/test/sdks-e2e/testdata/transformer/event-time-filter-java.yaml
@@ -11,6 +11,7 @@ spec:
           container:
             # Filter messages based on event time, see https://github.com/numaproj/numaflow-java/tree/main/examples/src/main/java/io/numaproj/numaflow/examples/sourcetransformer/eventtimefilter
             image: quay.io/numaio/numaflow-java/mapt-event-time-filter-function:stable
+            imagePullPolicy: Always
     - name: sink-within-2022
       scale:
         min: 1

--- a/test/sdks-e2e/testdata/transformer/event-time-filter-python.yaml
+++ b/test/sdks-e2e/testdata/transformer/event-time-filter-python.yaml
@@ -13,6 +13,7 @@ spec:
           container:
             # Filter messages based on event time, see https://github.com/numaproj/numaflow-python/tree/main/examples/sourcetransform/event_time_filter
             image: quay.io/numaio/numaflow-python/mapt-event-time-filter:stable
+            imagePullPolicy: Always
     - name: sink-within-2022
       scale:
         min: 1

--- a/test/udsource-e2e/testdata/simple-source-go.yaml
+++ b/test/udsource-e2e/testdata/simple-source-go.yaml
@@ -11,6 +11,7 @@ spec:
             # A simple user-defined source for e2e testing
             # See https://github.com/numaproj/numaflow-go/tree/main/pkg/sourcer/examples/simple_source
             image: quay.io/numaio/numaflow-go/source-simple-source:stable
+            imagePullPolicy: Always
       limits:
         readBatchSize: 500
       scale:

--- a/test/udsource-e2e/testdata/simple-source-java.yaml
+++ b/test/udsource-e2e/testdata/simple-source-java.yaml
@@ -11,6 +11,7 @@ spec:
             # A simple user-defined source for e2e testing
             # See https://github.com/numaproj/numaflow-java/tree/main/examples/src/main/java/io/numaproj/numaflow/examples/source/simple
             image: quay.io/numaio/numaflow-java/source-simple-source:stable
+            imagePullPolicy: Always
       limits:
         readBatchSize: 500
     - name: out


### PR DESCRIPTION
Set the `imagePullPolicy` to `Always`. This is because an issue arises when testing locally, where if changes are made and pushed to the same tag, i.e. `stable`, the cached image is used, and so the changes will not be reflected. This is because, the default image pull policy when the `imagePullPolicy` is not set and the tag `latest` is not used, is `IfNotPresent`. This is not the behaviour we would like, i.e. we want to pull the new image each time we overwrite the `stable`, `test`, etc. tag. 

![image](https://github.com/numaproj/numaflow/assets/28912731/1475b1ee-d8bc-4912-b04d-89fed2f38f65)


<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
