### PR TITLE
fix: flaky TestDropOnFull 

### DIFF
--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -1,3 +1,5 @@
+//go:build test
+
 /*
 Copyright 2022 The Numaproj Authors.
 

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -1,5 +1,3 @@
-//go:build test
-
 /*
 Copyright 2022 The Numaproj Authors.
 
@@ -240,7 +238,8 @@ func (s *FunctionalSuite) TestDropOnFull() {
 	time.Sleep(time.Second * 5)
 	w.SendMessageTo(pipelineName, "in", NewHttpPostRequest().WithBody([]byte("2")))
 
-	expectedDropMetric := `forwarder_drop_total{partition_name="numaflow-system-drop-on-full-sink-0",pipeline="drop-on-full",replica="0",vertex="in",vertex_type="Source"} 1`
+	expectedDropMetricOne := `forwarder_drop_total{partition_name="numaflow-system-drop-on-full-sink-0",pipeline="drop-on-full",replica="0",vertex="in",vertex_type="Source"} 1`
+	expectedDropMetricTwo := `forwarder_drop_total{partition_name="numaflow-system-drop-on-full-sink-1",pipeline="drop-on-full",replica="0",vertex="in",vertex_type="Source"} 1`
 	// wait for the drop metric to be updated, time out after 10s.
 	timeoutChan := time.After(time.Second * 10)
 	ticker := time.NewTicker(time.Second * 2)
@@ -251,7 +250,7 @@ func (s *FunctionalSuite) TestDropOnFull() {
 			metricsString := HTTPExpect(s.T(), "https://localhost:8001").GET("/metrics").
 				Expect().
 				Status(200).Body().Raw()
-			if strings.Contains(metricsString, expectedDropMetric) {
+			if strings.Contains(metricsString, expectedDropMetricOne) || strings.Contains(metricsString, expectedDropMetricTwo) {
 				return
 			}
 		case <-timeoutChan:


### PR DESCRIPTION
We hash the message ID and distribute the messages to different partitions based on that hash value. Now messages can end up in any partition, not just the first one