### PR TITLE
chore: do not create init-secrets when auth is disabled

### DIFF
--- a/cmd/commands/server_secrets_init.go
+++ b/cmd/commands/server_secrets_init.go
@@ -21,23 +21,26 @@ import (
 
 	"github.com/spf13/cobra"
 
+	sharedutil "github.com/numaproj/numaflow/pkg/shared/util"
 	secretinitcmd "github.com/numaproj/numaflow/server/cmd/serversecretinit"
 )
 
 func NewServerSecretsInitCommand() *cobra.Command {
+	var disableAuth bool
 
 	command := &cobra.Command{
 		Use:   "server-secrets-init",
-		Short: "Initialize numaflow-server-secrets with admin password and jwt secret key",
+		Short: "Initialize numaflow-server-secrets with admin password and jwt secret key if needed",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
+			if disableAuth { // Skip when auth is disabled
+				return nil
+			}
 			if err := secretinitcmd.Start(); err != nil {
 				return fmt.Errorf("failed to start server secrets init service: %w", err)
 			}
-
 			return nil
 		},
 	}
-
+	command.Flags().BoolVar(&disableAuth, "disable-auth", sharedutil.LookupEnvBoolOr("NUMAFLOW_SERVER_DISABLE_AUTH", false), "Whether to disable authentication and authorization, defaults to false.")
 	return command
 }

--- a/config/advanced-install/namespaced-numaflow-server.yaml
+++ b/config/advanced-install/namespaced-numaflow-server.yaml
@@ -308,6 +308,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: NUMAFLOW_SERVER_DISABLE_AUTH
+          valueFrom:
+            configMapKeyRef:
+              key: server.disable.auth
+              name: numaflow-cmd-params-config
+              optional: true
         image: quay.io/numaproj/numaflow:latest
         imagePullPolicy: Always
         name: server-secrets-init

--- a/config/advanced-install/numaflow-server.yaml
+++ b/config/advanced-install/numaflow-server.yaml
@@ -319,6 +319,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: NUMAFLOW_SERVER_DISABLE_AUTH
+          valueFrom:
+            configMapKeyRef:
+              key: server.disable.auth
+              name: numaflow-cmd-params-config
+              optional: true
         image: quay.io/numaproj/numaflow:latest
         imagePullPolicy: Always
         name: server-secrets-init

--- a/config/base/numaflow-server/numaflow-server-deployment.yaml
+++ b/config/base/numaflow-server/numaflow-server-deployment.yaml
@@ -52,6 +52,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: NUMAFLOW_SERVER_DISABLE_AUTH
+            valueFrom:
+              configMapKeyRef:
+                name: numaflow-cmd-params-config
+                key: server.disable.auth
+                optional: true
       containers:
         - name: main
           image: quay.io/numaproj/numaflow:latest

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -17661,6 +17661,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: NUMAFLOW_SERVER_DISABLE_AUTH
+          valueFrom:
+            configMapKeyRef:
+              key: server.disable.auth
+              name: numaflow-cmd-params-config
+              optional: true
         image: quay.io/numaproj/numaflow:latest
         imagePullPolicy: Always
         name: server-secrets-init

--- a/config/namespace-install.yaml
+++ b/config/namespace-install.yaml
@@ -17553,6 +17553,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: NUMAFLOW_SERVER_DISABLE_AUTH
+          valueFrom:
+            configMapKeyRef:
+              key: server.disable.auth
+              name: numaflow-cmd-params-config
+              optional: true
         image: quay.io/numaproj/numaflow:latest
         imagePullPolicy: Always
         name: server-secrets-init


### PR DESCRIPTION
Stop initializing secrets for local user auth during UX server starts when auth is disabled, so that we don't always need to have secret read/write privileges for `numaflow-server-sa`. 

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
