### PR TITLE
chore: Refactor Sinks to Avoid Implementing Forwarder Interface

### DIFF
--- a/pkg/sinks/blackhole/blackhole_test.go
+++ b/pkg/sinks/blackhole/blackhole_test.go
@@ -24,14 +24,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
-	"github.com/numaproj/numaflow/pkg/isb/stores/simplebuffer"
 	"github.com/numaproj/numaflow/pkg/isb/testutils"
-	"github.com/numaproj/numaflow/pkg/watermark/generic"
-	"github.com/numaproj/numaflow/pkg/watermark/wmb"
 )
 
 func TestBlackhole_Start(t *testing.T) {
-	fromStep := simplebuffer.NewInMemoryBuffer("from", 25, 0)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
@@ -50,21 +46,13 @@ func TestBlackhole_Start(t *testing.T) {
 		Vertex:  vertex,
 		Replica: 0,
 	}
-	fetchWatermark, publishWatermark := generic.BuildNoOpWatermarkProgressorsFromBufferList([]string{vertex.Spec.Name})
-	idleManager, _ := wmb.NewIdleManager(1, 1)
-	s, err := NewBlackhole(vertexInstance, fromStep, fetchWatermark, publishWatermark[vertex.Spec.Name], idleManager)
+	s, err := NewBlackhole(ctx, vertexInstance)
 	assert.NoError(t, err)
 
-	stopped := s.Start()
-	// write some data
-	_, errs := fromStep.Write(ctx, writeMessages[0:5])
+	_, errs := s.Write(ctx, writeMessages[0:5])
 	assert.Equal(t, make([]error, 5), errs)
 
 	// write some data
-	_, errs = fromStep.Write(ctx, writeMessages[5:20])
+	_, errs = s.Write(ctx, writeMessages[5:20])
 	assert.Equal(t, make([]error, 15), errs)
-
-	s.Stop()
-
-	<-stopped
 }

--- a/pkg/sinks/kafka/kafka_test.go
+++ b/pkg/sinks/kafka/kafka_test.go
@@ -26,16 +26,11 @@ import (
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaflow/pkg/isb"
-	"github.com/numaproj/numaflow/pkg/isb/stores/simplebuffer"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
-	sinkforward "github.com/numaproj/numaflow/pkg/sinks/forward"
-	"github.com/numaproj/numaflow/pkg/watermark/generic"
-	"github.com/numaproj/numaflow/pkg/watermark/wmb"
 )
 
 func TestWriteSuccessToKafka(t *testing.T) {
 	var err error
-	fromStep := simplebuffer.NewInMemoryBuffer("toKafka", 25, 0)
 	toKafka := new(ToKafka)
 	vertex := &dfv1.Vertex{Spec: dfv1.VertexSpec{
 		PipelineName: "testPipeline",
@@ -46,13 +41,6 @@ func TestWriteSuccessToKafka(t *testing.T) {
 			},
 		},
 	}}
-	vertexInstance := &dfv1.VertexInstance{
-		Vertex:  vertex,
-		Replica: 0,
-	}
-	fetchWatermark, publishWatermark := generic.BuildNoOpWatermarkProgressorsFromBufferList([]string{vertex.Spec.Name})
-	idleManager, _ := wmb.NewIdleManager(1, 1)
-	toKafka.isdf, err = sinkforward.NewDataForward(vertexInstance, fromStep, toKafka, fetchWatermark, publishWatermark["testVertex"], idleManager)
 	assert.NoError(t, err)
 	toKafka.kafkaSink = vertex.Spec.Sink.Kafka
 	toKafka.name = "Test"
@@ -66,7 +54,6 @@ func TestWriteSuccessToKafka(t *testing.T) {
 	producer.ExpectInputAndSucceed()
 	toKafka.producer = producer
 	toKafka.connected = true
-	toKafka.Start()
 	msgs := []isb.Message{
 		{
 			Header: isb.Header{
@@ -87,30 +74,11 @@ func TestWriteSuccessToKafka(t *testing.T) {
 	for _, err := range errs {
 		assert.Nil(t, err)
 	}
-	toKafka.Stop()
 }
 
 func TestWriteFailureToKafka(t *testing.T) {
 	var err error
-	fromStep := simplebuffer.NewInMemoryBuffer("toKafka", 25, 0)
 	toKafka := new(ToKafka)
-	vertex := &dfv1.Vertex{Spec: dfv1.VertexSpec{
-		PipelineName: "testPipeline",
-		AbstractVertex: dfv1.AbstractVertex{
-			Name: "testVertex",
-			Sink: &dfv1.Sink{
-				Kafka: &dfv1.KafkaSink{},
-			},
-		},
-	}}
-	vertexInstance := &dfv1.VertexInstance{
-		Vertex:  vertex,
-		Replica: 0,
-	}
-	toSteps := map[string][]isb.BufferWriter{vertex.Spec.Name: {toKafka}}
-	fetchWatermark, publishWatermark := generic.BuildNoOpWatermarkProgressorsFromBufferMap(toSteps)
-	idleManager, _ := wmb.NewIdleManager(1, 1)
-	toKafka.isdf, err = sinkforward.NewDataForward(vertexInstance, fromStep, toKafka, fetchWatermark, publishWatermark["testVertex"], idleManager)
 	assert.NoError(t, err)
 	toKafka.name = "Test"
 	toKafka.topic = "topic-1"
@@ -123,7 +91,6 @@ func TestWriteFailureToKafka(t *testing.T) {
 	producer.ExpectInputAndFail(fmt.Errorf("test1"))
 	toKafka.producer = producer
 	toKafka.connected = true
-	toKafka.Start()
 	msgs := []isb.Message{
 		{
 			Header: isb.Header{
@@ -146,6 +113,5 @@ func TestWriteFailureToKafka(t *testing.T) {
 	}
 	assert.Equal(t, "test", errs[0].Error())
 	assert.Equal(t, "test1", errs[1].Error())
-	toKafka.Stop()
 
 }

--- a/pkg/sinks/logger/log.go
+++ b/pkg/sinks/logger/log.go
@@ -28,65 +28,22 @@ import (
 	"github.com/numaproj/numaflow/pkg/isb"
 	"github.com/numaproj/numaflow/pkg/metrics"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
-	sinkforward "github.com/numaproj/numaflow/pkg/sinks/forward"
-	"github.com/numaproj/numaflow/pkg/watermark/fetch"
-	"github.com/numaproj/numaflow/pkg/watermark/publish"
-	"github.com/numaproj/numaflow/pkg/watermark/wmb"
 )
 
 // ToLog prints the output to a log sinks.
 type ToLog struct {
 	name         string
 	pipelineName string
-	isdf         *sinkforward.DataForward
 	logger       *zap.SugaredLogger
 }
 
-type Option func(*ToLog) error
-
-func WithLogger(log *zap.SugaredLogger) Option {
-	return func(t *ToLog) error {
-		t.logger = log
-		return nil
-	}
-}
-
 // NewToLog returns ToLog type.
-func NewToLog(vertexInstance *dfv1.VertexInstance,
-	fromBuffer isb.BufferReader,
-	fetchWatermark fetch.Fetcher,
-	publishWatermark publish.Publisher,
-	idleManager wmb.IdleManager,
-	opts ...Option) (*ToLog, error) {
-
-	toLog := new(ToLog)
-	name := vertexInstance.Vertex.Spec.Name
-	toLog.name = name
-	toLog.pipelineName = vertexInstance.Vertex.Spec.PipelineName
-	// use opts in future for specifying logger format etc
-	for _, o := range opts {
-		if err := o(toLog); err != nil {
-			return nil, err
-		}
-	}
-	if toLog.logger == nil {
-		toLog.logger = logging.NewLogger()
-	}
-
-	forwardOpts := []sinkforward.Option{sinkforward.WithLogger(toLog.logger)}
-	if x := vertexInstance.Vertex.Spec.Limits; x != nil {
-		if x.ReadBatchSize != nil {
-			forwardOpts = append(forwardOpts, sinkforward.WithReadBatchSize(int64(*x.ReadBatchSize)))
-		}
-	}
-
-	isdf, err := sinkforward.NewDataForward(vertexInstance, fromBuffer, toLog, fetchWatermark, publishWatermark, idleManager, forwardOpts...)
-	if err != nil {
-		return nil, err
-	}
-	toLog.isdf = isdf
-
-	return toLog, nil
+func NewToLog(ctx context.Context, vertexInstance *dfv1.VertexInstance) (*ToLog, error) {
+	return &ToLog{
+		name:         vertexInstance.Vertex.Spec.Name,
+		pipelineName: vertexInstance.Vertex.Spec.PipelineName,
+		logger:       logging.FromContext(ctx),
+	}, nil
 }
 
 // GetName returns the name.
@@ -122,19 +79,4 @@ func (t *ToLog) Write(_ context.Context, messages []isb.Message) ([]isb.Offset, 
 
 func (t *ToLog) Close() error {
 	return nil
-}
-
-// Start starts sinking to Log.
-func (t *ToLog) Start() <-chan struct{} {
-	return t.isdf.Start()
-}
-
-// Stop stops sinking
-func (t *ToLog) Stop() {
-	t.isdf.Stop()
-}
-
-// ForceStop stops sinking
-func (t *ToLog) ForceStop() {
-	t.isdf.ForceStop()
 }

--- a/pkg/sinks/logger/log_test.go
+++ b/pkg/sinks/logger/log_test.go
@@ -24,20 +24,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
-	"github.com/numaproj/numaflow/pkg/isb"
-	"github.com/numaproj/numaflow/pkg/isb/stores/simplebuffer"
 	"github.com/numaproj/numaflow/pkg/isb/testutils"
-	sinkforward "github.com/numaproj/numaflow/pkg/sinks/forward"
-	"github.com/numaproj/numaflow/pkg/watermark/generic"
-	"github.com/numaproj/numaflow/pkg/watermark/wmb"
-)
-
-var (
-	testStartTime = time.Unix(1636470000, 0).UTC()
 )
 
 func TestToLog_Start(t *testing.T) {
-	fromStep := simplebuffer.NewInMemoryBuffer("from", 25, 0)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
@@ -56,88 +46,14 @@ func TestToLog_Start(t *testing.T) {
 		Vertex:  vertex,
 		Replica: 0,
 	}
-	fetchWatermark, publishWatermark := generic.BuildNoOpWatermarkProgressorsFromBufferList([]string{vertex.Spec.Name})
-	idleManager, _ := wmb.NewIdleManager(1, 1)
-	s, err := NewToLog(vertexInstance, fromStep, fetchWatermark, publishWatermark[vertex.Spec.Name], idleManager)
+	s, err := NewToLog(ctx, vertexInstance)
 	assert.NoError(t, err)
 
-	stopped := s.Start()
 	// write some data
-	_, errs := fromStep.Write(ctx, writeMessages[0:5])
+	_, errs := s.Write(ctx, writeMessages[0:5])
 	assert.Equal(t, make([]error, 5), errs)
 
 	// write some data
-	_, errs = fromStep.Write(ctx, writeMessages[5:20])
+	_, errs = s.Write(ctx, writeMessages[5:20])
 	assert.Equal(t, make([]error, 15), errs)
-
-	s.Stop()
-
-	<-stopped
-}
-
-// TestToLog_Forward writes to a vertex which has a logger sink
-func TestToLog_Forward(t *testing.T) {
-	tests := []struct {
-		name      string
-		batchSize int64
-	}{
-		{
-			name:      "batch_forward",
-			batchSize: 1,
-		},
-		{
-			name:      "batch_forward",
-			batchSize: 5,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			batchSize := tt.batchSize
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-			defer cancel()
-
-			fromStep := simplebuffer.NewInMemoryBuffer("from", 5*batchSize, 0)
-			to1 := simplebuffer.NewInMemoryBuffer("sinks.logger1", 5*batchSize, 0)
-
-			vertex1 := &dfv1.Vertex{Spec: dfv1.VertexSpec{
-				AbstractVertex: dfv1.AbstractVertex{
-					Name: "sinks.logger1",
-					Sink: &dfv1.Sink{
-						Log: &dfv1.Log{},
-					},
-				},
-			}}
-			vertexInstance1 := &dfv1.VertexInstance{
-				Vertex:  vertex1,
-				Replica: 0,
-			}
-
-			fetchWatermark1, publishWatermark1 := generic.BuildNoOpWatermarkProgressorsFromBufferList([]string{vertex1.Spec.Name})
-			idleManager0, _ := wmb.NewIdleManager(1, 1)
-			logger1, _ := NewToLog(vertexInstance1, to1, fetchWatermark1, publishWatermark1[vertex1.Spec.Name], idleManager0)
-			logger1Stopped := logger1.Start()
-
-			toSteps := map[string][]isb.BufferWriter{
-				"sinks.logger1": {to1},
-			}
-
-			writeMessages := testutils.BuildTestWriteMessages(int64(20), testStartTime, nil)
-
-			fetchWatermark, publishWatermark := generic.BuildNoOpWatermarkProgressorsFromBufferMap(toSteps)
-			idleManager1, _ := wmb.NewIdleManager(1, 1)
-			f, err := sinkforward.NewDataForward(vertexInstance1, fromStep, to1, fetchWatermark, publishWatermark["sinks.logger1"], idleManager1, sinkforward.WithReadBatchSize(batchSize))
-			assert.NoError(t, err)
-
-			stopped := f.Start()
-			// write some data
-			_, errs := fromStep.Write(ctx, writeMessages[0:batchSize])
-			assert.Equal(t, make([]error, batchSize), errs)
-			f.Stop()
-			<-stopped
-			// downstream should be stopped only after upstream is stopped
-			logger1.Stop()
-
-			<-logger1Stopped
-		})
-	}
 }

--- a/pkg/sinks/sinker.go
+++ b/pkg/sinks/sinker.go
@@ -17,12 +17,10 @@ limitations under the License.
 package sinks
 
 import (
-	"github.com/numaproj/numaflow/pkg/forwarder"
 	"github.com/numaproj/numaflow/pkg/isb"
 )
 
 // Sinker interface defines what a Sink should implement.
 type Sinker interface {
 	isb.BufferWriter
-	forwarder.StarterStopper
 }


### PR DESCRIPTION
Now that we have a separate forwarder for the sink, our sinks don't need to implement the forwarder interface.

