### PR TITLE
doc: add "nav" for fallback-sink

### DIFF
--- a/docs/user-guide/sinks/overview.md
+++ b/docs/user-guide/sinks/overview.md
@@ -22,3 +22,8 @@ supported by the platform's built-in sinks. As an example, once we have processe
 we can use Elasticsearch as a User defined sink to store the processed data and enable search and 
 analysis on the data.
 
+## Fallback Sink (DLQ)
+
+There is an explicit DLQ support for sinks using a concept called [fallback sink](fallback.md). For the rest of vertices,
+if you need DLQ, please use [conditional-forwarding](http://127.0.0.1:8000/user-guide/reference/conditional-forwarding/).
+Sink cannot not do conditional-forwarding since it is a terminal state and hence we have explicit fallback option. 

--- a/docs/user-guide/sinks/overview.md
+++ b/docs/user-guide/sinks/overview.md
@@ -25,5 +25,5 @@ analysis on the data.
 ## Fallback Sink (DLQ)
 
 There is an explicit DLQ support for sinks using a concept called [fallback sink](fallback.md). For the rest of vertices,
-if you need DLQ, please use [conditional-forwarding](http://127.0.0.1:8000/user-guide/reference/conditional-forwarding/).
+if you need DLQ, please use [conditional-forwarding](../reference/conditional-forwarding.md).
 Sink cannot not do conditional-forwarding since it is a terminal state and hence we have explicit fallback option. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
           - user-guide/sinks/log.md
           - user-guide/sinks/blackhole.md
           - User Defined Sinks: "user-guide/sinks/user-defined-sinks.md"
+          - Fallback Sink: "user-guide/sinks/fallback.md"
       - User Defined Functions:
           - Overview: "user-guide/user-defined-functions/user-defined-functions.md"
           - Map:


### PR DESCRIPTION
fix the following warning and make the doc accessible

```
INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
              - user-guide/sinks/fallback.md
```

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
