### PR TITLE
chore: UDS based multiproc server

### DIFF
--- a/pkg/sdkclient/const.go
+++ b/pkg/sdkclient/const.go
@@ -33,6 +33,7 @@ const (
 	FbSinkAddr            = "/var/run/numaflow/fb-sink.sock"
 	SourceAddr            = "/var/run/numaflow/source.sock"
 	SourceTransformerAddr = "/var/run/numaflow/sourcetransform.sock"
+	MultiProcAddr         = "/var/run/numaflow/multiproc"
 
 	// Server information file configs
 	MapServerInfoFile               = "/var/run/numaflow/mapper-server-info"

--- a/pkg/sdkclient/grpc/grpc_utils.go
+++ b/pkg/sdkclient/grpc/grpc_utils.go
@@ -33,8 +33,9 @@ func ConnectToServer(udsSockAddr string, serverInfo *info.ServerInfo, maxMessage
 	var err error
 	var sockAddr string
 
-	if serverInfo.Protocol == info.TCP {
-		// TCP connections are used for Multiprocessing server mode, here we have multiple servers forks
+	// Check if multiproc server is enabled
+	if serverInfo.MultiProcServer == true {
+		// In Multiprocessing server mode we have multiple servers forks
 		// and each server will listen on a different port.
 		// On the client side we will create a connection to each of these server instances.
 		// The client will use a custom resolver to resolve the server address.

--- a/pkg/sdkclient/grpc/grpc_utils.go
+++ b/pkg/sdkclient/grpc/grpc_utils.go
@@ -33,8 +33,8 @@ func ConnectToServer(udsSockAddr string, serverInfo *info.ServerInfo, maxMessage
 	var err error
 	var sockAddr string
 
-	// Check if multiproc server is enabled
-	if serverInfo.MultiProcServer == true {
+	// Check if Multiproc server mode is enabled
+	if _, ok := serverInfo.Metadata["MULTIPROC"]; ok {
 		// In Multiprocessing server mode we have multiple servers forks
 		// and each server will listen on a different port.
 		// On the client side we will create a connection to each of these server instances.

--- a/pkg/sdkclient/grpc_resolver/client_resolver.go
+++ b/pkg/sdkclient/grpc_resolver/client_resolver.go
@@ -101,7 +101,7 @@ func buildConnAddrs(numServers int) []string {
 // on multiprocessing TCP or UDS connection
 func RegMultiProcResolver(svrInfo *info.ServerInfo) error {
 	// Extract the server ports from the server info file and convert it to a list
-	numServers, _ := strconv.Atoi(svrInfo.Metadata["NUM_SERVERS"])
+	numServers, _ := strconv.Atoi(svrInfo.Metadata["MULTIPROC"])
 	log.Println("Multiprocessing Servers :", numServers)
 	conn := buildConnAddrs(numServers)
 	res := newMultiProcResolverBuilder(conn)

--- a/pkg/sdkclient/grpc_resolver/client_resolver.go
+++ b/pkg/sdkclient/grpc_resolver/client_resolver.go
@@ -84,7 +84,7 @@ func (*multiProcResolver) Resolve(target resolver.Target)          {}
 // buildConnAddrs Populate the connection list for the clients
 // Format (serverAddr, serverIdx) :
 // (unix:///var/run/numaflow/multiproc0.sock, 1),
-// (unix:///var/run/numaflow/multiproc2.sock, 2)
+// (unix:///var/run/numaflow/multiproc1.sock, 2)
 func buildConnAddrs(numServers int) []string {
 	var conn = make([]string, numServers)
 	for i := 0; i < numServers; i++ {

--- a/pkg/sdkclient/grpc_resolver/client_resolver.go
+++ b/pkg/sdkclient/grpc_resolver/client_resolver.go
@@ -83,8 +83,8 @@ func (*multiProcResolver) Resolve(target resolver.Target)          {}
 
 // buildConnAddrs Populate the connection list for the clients
 // Format (serverAddr, serverIdx) :
-// (unix:///var/run/numaflow/multiproc0.sock, 1),
-// (unix:///var/run/numaflow/multiproc1.sock, 2)
+// (unix:///var/run/numaflow/multiproc0.sock, 0),
+// (unix:///var/run/numaflow/multiproc1.sock, 1)
 func buildConnAddrs(numServers int) []string {
 	var conn = make([]string, numServers)
 	for i := 0; i < numServers; i++ {
@@ -92,7 +92,7 @@ func buildConnAddrs(numServers int) []string {
 		// unix:///var/run/numaflow/multiproc#serv_num.sock
 		serverAddr := ConnAddr + sdkclient.MultiProcAddr + strconv.Itoa(i) + ".sock"
 		// Format (serverAddr, serverIdx)
-		conn[i] = serverAddr + "," + strconv.Itoa(i+1)
+		conn[i] = serverAddr + "," + strconv.Itoa(i)
 	}
 	return conn
 }

--- a/pkg/sdkclient/grpc_resolver/client_resolver.go
+++ b/pkg/sdkclient/grpc_resolver/client_resolver.go
@@ -23,12 +23,14 @@ import (
 
 	"github.com/numaproj/numaflow-go/pkg/info"
 	"google.golang.org/grpc/resolver"
+
+	"github.com/numaproj/numaflow/pkg/sdkclient"
 )
 
 const (
 	CustScheme      = "udf"
 	CustServiceName = "numaflow.numaproj.io"
-	ConnAddr        = "0.0.0.0"
+	ConnAddr        = "unix://"
 )
 
 type MultiProcResolverBuilder struct {
@@ -80,14 +82,17 @@ func (*multiProcResolver) Close()                                  {}
 func (*multiProcResolver) Resolve(target resolver.Target)          {}
 
 // buildConnAddrs Populate the connection list for the clients
-// Format (serverAddr, serverIdx) : (0.0.0.0:5551, 1), (0.0.0.0:5552, 2)
-func buildConnAddrs(servPorts []string) []string {
-	var conn = make([]string, len(servPorts))
-	for i := 0; i < len(servPorts); i++ {
-		// Use the server ports from the server info file and assign to each client
-		addr, _ := strconv.Atoi(servPorts[i])
+// Format (serverAddr, serverIdx) :
+// (unix:///var/run/numaflow/multiproc0.sock, 1),
+// (unix:///var/run/numaflow/multiproc2.sock, 2)
+func buildConnAddrs(numServers int) []string {
+	var conn = make([]string, numServers)
+	for i := 0; i < numServers; i++ {
+		// Create a server port assign to each client
+		// unix:///var/run/numaflow/multiproc#serv_num.sock
+		serverAddr := ConnAddr + sdkclient.MultiProcAddr + strconv.Itoa(i) + ".sock"
 		// Format (serverAddr, serverIdx)
-		conn[i] = ConnAddr + ":" + strconv.Itoa(addr) + "," + strconv.Itoa(i+1)
+		conn[i] = serverAddr + "," + strconv.Itoa(i+1)
 	}
 	return conn
 }
@@ -96,9 +101,9 @@ func buildConnAddrs(servPorts []string) []string {
 // on multiprocessing TCP or UDS connection
 func RegMultiProcResolver(svrInfo *info.ServerInfo) error {
 	// Extract the server ports from the server info file and convert it to a list
-	servPorts := strings.Split(svrInfo.Metadata["SERV_PORTS"], ",")
-	log.Println("Multiprocessing TCP Server Ports:", servPorts)
-	conn := buildConnAddrs(servPorts)
+	numServers, _ := strconv.Atoi(svrInfo.Metadata["NUM_SERVERS"])
+	log.Println("Multiprocessing Servers :", numServers)
+	conn := buildConnAddrs(numServers)
 	res := newMultiProcResolverBuilder(conn)
 	resolver.Register(res)
 	return nil


### PR DESCRIPTION
This transitions the multiproc client to use a UDS socket instead of TCP.
We will receive the number of clients to start in the ServerInfo metadata 

And we will use UDS sockets in the format
```
unix:///var/run/numaflow/multiproc#serv_num.sock
```

Client side changes for [this](https://github.com/numaproj/numaflow-python/issues/161)
