### PR TITLE
feat: crate for retry with backoff strategy

### DIFF
--- a/serving/.rustfmt.toml
+++ b/serving/.rustfmt.toml
@@ -1,2 +1,1 @@
 edition = "2021"
-indent_style = "Block"

--- a/serving/Cargo.toml
+++ b/serving/Cargo.toml
@@ -1,4 +1,4 @@
-workspace = { members = ["extras/upstreams", "servesink"] }
+workspace = { members = [ "backoff","extras/upstreams", "servesink"] }
 [package]
 name = "serve"
 version = "0.1.0"

--- a/serving/backoff/Cargo.toml
+++ b/serving/backoff/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "backoff"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+pin-project = "1.1.5"
+tokio = { version = "1.38.0", features = ["full"] }

--- a/serving/backoff/src/lib.rs
+++ b/serving/backoff/src/lib.rs
@@ -1,0 +1,97 @@
+//! Retry with backoff for async Rust.
+//!
+//! Given a Future, we have to run the Future to completion. If the Future returns an error,
+//! we have retry the Future with a backoff [`strategy`]. Optionally, there are cases where retry is
+//! not useful, and we could break out of retries early; for such cases we have [`Condition`].
+//!
+//! ```rust
+//!
+//! use crate::backoff::strategy::fixed;
+//! use crate::backoff::retry::Retry;
+//!
+//! async fn some_work() -> Result<u64, ()> {
+//!     Ok(42)
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let interval = fixed::Interval::from_millis(1);
+//!     let fut = Retry::retry(interval, some_work, |_: &()| true);
+//!     let result = fut.await;
+//!     assert!(result.is_ok());
+//!     assert_eq!(result.unwrap(), 42);
+//! }
+//! ```
+
+use std::future::Future;
+
+/// strategy has all the different backoff strategies. It is an iterator with Item=Duration.
+/// The strategy decides what duration to return. Since it is an iterator, we can stop the
+/// iterator using [`take`](https://doc.rust-lang.org/std/iter/struct.Take.html).
+pub mod strategy;
+
+/// Conditional retry till we run out of backoff.
+pub mod retry;
+
+/// The retry condition depends on the result of [`Condition::can_retry`] function.
+/// [`Condition::can_retry`] should return `true` to continue retrying or `false` to stop..
+pub trait Condition<E> {
+    fn can_retry(&self, error: &E) -> bool;
+}
+
+/// we can have an implementation where a fn pointer (Fn) can be passed which
+/// can return bool based on the error
+impl<E, F> Condition<E> for F
+where
+    F: Fn(&E) -> bool,
+{
+    fn can_retry(&self, error: &E) -> bool {
+        self(error)
+    }
+}
+
+/// An `Operation` is anything that returns a Future when executed and that
+/// Future can be run to completion.
+pub trait Operation {
+    type Item;
+    type Error;
+    /// The [`Future`] returned when the Operation is called.
+    type Future: Future<Output=Result<Self::Item, Self::Error>>;
+
+    // a good example https://github.com/tower-rs/tower/blob/master/tower-service/src/lib.rs#L311
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    fn run(&mut self) -> Self::Future;
+}
+
+/// We can implement the [`Operation`] trait for [`FnMut`] that returns a [`Future`] whose output
+/// is a [`Result`].
+impl<T, E, R, F> Operation for F
+where
+    R: Future<Output=Result<T, E>>,
+    F: FnMut() -> R,
+{
+    type Item = T;
+    type Error = E;
+    type Future = R;
+
+    fn run(&mut self) -> Self::Future {
+        // run the FnMut
+        self()
+    }
+}
+
+// A NOTE on the [`Operation`] trait!
+// I tried without do without this Operation trait, but my generic exploded, something like the below:
+//
+// struct Retry<I, C, F, R, T, E>
+// where
+//     R: Future<Output = Result<T, E>>,
+//     F: FnMut() -> R
+//
+// I tried type alias, but then I ran into language issues https://github.com/rust-lang/rust/issues/21903
+// (NB: even to get the compiler to work, I had to do PhantomData.)
+//
+// An ideal type alias would be as follows:
+// type Operation<T, E, R: Future<Output = Result<T, E>>, F: FnMut() -> R> = F;
+// as of today, the above type alias is read by the compiler as follows
+// type Operation<T, E, R, F> = F; which is quite pointless.

--- a/serving/backoff/src/retry.rs
+++ b/serving/backoff/src/retry.rs
@@ -1,0 +1,231 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use pin_project::pin_project;
+use tokio::time::{Instant, Sleep, sleep_until};
+use crate::{Condition, Operation};
+
+/// To retry a Future with backoff, we will have to maintain 2 states. These states track whether
+/// the [`Operation`] is [`RetryState::Running`] or it is sleeping as prescribed by the [`crate::strategy`].
+/// The state-machine for retry flips between two states, (Operation or Sleeping):
+/// ```no_rust
+///      (Pending)
+///     /
+/// (op)            (Ok) -> [Return(Ok)]*
+///    \           /
+///     (Ready) ---       (Non-retriable) -> [Return(Err)]*
+///                \     /
+///                 (Err)                            (None) -> [Return(Err)]*
+///                      \                          /
+///                       (Retriable) ---> (Backoff)          (Pending)
+///                                                \        /
+///                                                  (Sleep)
+///                                                        \
+///                                                         (Ready) --> [START(op)]
+/// |------------------------------------|-------------------------|-----------------|
+///           Operation                          Backoff             Operation(start)
+///
+/// ```
+// We have to pin it because these are futures, and we want to do poll on these.
+#[pin_project(project = RetryStateProj)]
+enum RetryState<O>
+where
+    O: Operation,
+{
+    Running(#[pin] O::Future),
+    Sleeping(#[pin] Sleep),
+}
+
+/// Retry retries an operation based on the backoff strategy.
+#[pin_project]
+pub struct Retry<I, O, C>
+where
+    O: Operation,
+{
+    #[pin]
+    retry_state: RetryState<O>,
+    backoff: I,
+    operation: O,
+    condition: C,
+}
+
+impl<I, O, C> Retry<I, O, C>
+where
+    I: Iterator<Item=Duration>,
+    O: Operation,
+    C: Condition<O::Error>,
+{
+    pub fn retry<II: IntoIterator<IntoIter=I, Item=I::Item>>(
+        backoff: II,
+        mut operation: O,
+        condition: C,
+    ) -> Self {
+        Self {
+            retry_state: RetryState::Running(operation.run()),
+            backoff: backoff.into_iter(),
+            condition,
+            operation,
+        }
+    }
+
+    /// cools off before the next retry by doing a sleep on period determined by the backoff [`strategy`]
+    fn cool_off(mut self: Pin<&mut Self>, err: O::Error) -> Result<(), O::Error> {
+        match self.as_mut().project().backoff.next() {
+            // ran out of backoff, return the same error
+            None => Err(err),
+            Some(duration) => {
+                // set the state as sleeping
+                let till = sleep_until(Instant::now() + duration);
+                self.as_mut()
+                    .project()
+                    .retry_state
+                    .set(RetryState::Sleeping(till));
+                Ok(())
+            }
+        }
+    }
+
+    /// reattempts to run the [`Operation`] again.
+    fn reattempt(mut self: Pin<&mut Self>) {
+        let future = {
+            let this = self.as_mut().project();
+            this.operation.run()
+        };
+        self.as_mut()
+            .project()
+            .retry_state
+            .set(RetryState::Running(future));
+    }
+}
+
+
+impl<I, O, C> Future for Retry<I, O, C>
+where
+    I: Iterator<Item=Duration>,
+    O: Operation,
+    C: Condition<O::Error>,
+{
+    type Output = Result<O::Item, O::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.as_mut().project().retry_state.project() {
+            RetryStateProj::Running(op) => match op.poll(cx) {
+                Poll::Ready(output) => match output {
+                    Ok(item) => Poll::Ready(Ok(item)),
+                    Err(e) => {
+                        // if the error can be retried
+                        if self.as_mut().condition.can_retry(&e) {
+                            // before we can retry, we can to wait for a cool-off period (aka backoff)
+                            match self.as_mut().cool_off(e) {
+                                Ok(_) => self.as_mut().poll(cx),
+                                Err(e) => Poll::Ready(Err(e)),
+                            }
+                        } else {
+                            Poll::Ready(Err(e))
+                        }
+                    }
+                },
+                Poll::Pending => Poll::Pending,
+            },
+            RetryStateProj::Sleeping(sleep) => match sleep.poll(cx) {
+                Poll::Ready(_) => {
+                    self.as_mut().reattempt();
+                    self.poll(cx)
+                }
+                Poll::Pending => Poll::Pending,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::strategy::fixed;
+    use std::future;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    async fn always_successful() -> Result<u64, ()> {
+        Ok(42)
+    }
+
+    fn true_cond<E>(_: &E) -> bool {
+        true
+    }
+
+    fn false_cond<E>(_: &E) -> bool {
+        false
+    }
+
+    #[tokio::test]
+    async fn successful_first_attempt() {
+        let interval = fixed::Interval::from_millis(1);
+        let fut = Retry::retry(interval, always_successful, |_: &()| true);
+        let result = fut.await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 42);
+    }
+
+
+    #[tokio::test]
+    async fn non_retriable_failure() {
+        let interval = fixed::Interval::from_millis(1);
+
+        let fut = Retry::retry(
+            interval,
+            || future::ready(Err::<(), &str>("err")),
+            false_cond,
+        );
+        let result = fut.await;
+        assert!(result.is_err());
+        assert_eq!(result, Err("err"));
+    }
+
+    #[tokio::test]
+    async fn retry_till_condition() {
+        let interval = fixed::Interval::from_millis(1).take(10);
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let cloned_counter = counter.clone();
+
+        let fut = Retry::retry(
+            interval,
+            move || {
+                let previous = cloned_counter.fetch_add(1, Ordering::SeqCst);
+                future::ready(Err::<(), usize>(previous + 1))
+            },
+            |e: &usize| *e < 3,
+        );
+
+        let result = fut.await;
+        assert_eq!(result, Err(3));
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn retry_till_exhaustion() {
+        let attempts = 5;
+
+        let interval = fixed::Interval::from_millis(1).take(attempts);
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let cloned_counter = counter.clone();
+
+        let fut = Retry::retry(
+            interval,
+            move || {
+                let previous = cloned_counter.fetch_add(1, Ordering::SeqCst);
+                future::ready(Err::<(), usize>(previous + 1))
+            },
+            true_cond,
+        );
+
+        let result = fut.await;
+        // + 1 because take(n) are retries and the first run is not a retry
+        assert_eq!(result, Err(attempts + 1));
+        assert_eq!(counter.load(Ordering::SeqCst), attempts + 1);
+    }
+}

--- a/serving/backoff/src/strategy.rs
+++ b/serving/backoff/src/strategy.rs
@@ -1,0 +1,2 @@
+/// fixed interval backoff strategy.
+pub mod fixed;

--- a/serving/backoff/src/strategy/fixed.rs
+++ b/serving/backoff/src/strategy/fixed.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+
+pub struct Interval {
+    interval: Duration,
+}
+
+impl Interval {
+    // Build interval from Duration
+    pub fn new(interval: Duration) -> Self {
+        Self { interval }
+    }
+
+    // Build interval from millis
+    pub fn from_millis(millis: u64) -> Self {
+        Self {
+            interval: Duration::from_millis(millis),
+        }
+    }
+}
+
+impl Iterator for Interval {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(self.interval)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new() {
+        let mut interval = Interval::new(Duration::from_millis(1));
+        assert_eq!(interval.next(), Some(Duration::from_millis(1)));
+    }
+
+    #[test]
+    fn from_millis() {
+        let mut interval = Interval::from_millis(1);
+        assert_eq!(interval.next(), Some(Duration::from_millis(1)));
+        assert_eq!(interval.next(), Some(Duration::from_millis(1)));
+    }
+}


### PR DESCRIPTION
crate to do retries with different backoff strategies as an iterator for any async function.

