### PR TITLE
test: disable image registry creation in e2e test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,6 +193,7 @@ jobs:
           GOPATH: /home/runner/go
         run: |
           KUBECONFIG=~/.kube/numaflow-e2e-config VERSION=${{ github.sha }} make start
+          KUBECONFIG=~/.kube/numaflow-e2e-config kubectl -nnumaflow-system get po -o yaml | grep -i image
       - name: Run tests
         env:
           GOPATH: /home/runner/go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,18 +184,16 @@ jobs:
           key: ${{ runner.os }}-node-dep-v1-${{ hashFiles('**/yarn.lock') }}
       - name: Install k3d
         run: curl -sfL https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash &
-      - name: Create a registry and a cluster
+      - name: Create a cluster
         run: |
-          k3d registry create e2e-registry --port 5111
-          k3d cluster create e2e --registry-use k3d-e2e-registry:5111
+          k3d cluster create e2e
           k3d kubeconfig get e2e > ~/.kube/numaflow-e2e-config
-          echo '127.0.0.1 k3d-e2e-registry' | sudo tee -a /etc/hosts
       - name: Install Numaflow
         env:
           GOPATH: /home/runner/go
         run: |
-          KUBECONFIG=~/.kube/numaflow-e2e-config IMAGE_NAMESPACE=k3d-e2e-registry:5111 VERSION=${{ github.sha }} DOCKER_PUSH=false make start
+          KUBECONFIG=~/.kube/numaflow-e2e-config VERSION=${{ github.sha }} make start
       - name: Run tests
         env:
           GOPATH: /home/runner/go
-        run: KUBECONFIG=~/.kube/numaflow-e2e-config IMAGE_NAMESPACE=k3d-e2e-registry:5111 VERSION=${{ github.sha }} DOCKER_PUSH=false ISBSVC=${{matrix.driver}} make test-${{matrix.case}}
+        run: KUBECONFIG=~/.kube/numaflow-e2e-config VERSION=${{ github.sha }} ISBSVC=${{matrix.driver}} make test-${{matrix.case}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,7 +193,7 @@ jobs:
           GOPATH: /home/runner/go
         run: |
           KUBECONFIG=~/.kube/numaflow-e2e-config VERSION=${{ github.sha }} make start
-          KUBECONFIG=~/.kube/numaflow-e2e-config kubectl -nnumaflow-system get po -o yaml | grep -i image
+          KUBECONFIG=~/.kube/numaflow-e2e-config kubectl -nnumaflow-system get po -o yaml | grep -i quay.io
       - name: Run tests
         env:
           GOPATH: /home/runner/go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,7 +193,6 @@ jobs:
           GOPATH: /home/runner/go
         run: |
           KUBECONFIG=~/.kube/numaflow-e2e-config VERSION=${{ github.sha }} make start
-          KUBECONFIG=~/.kube/numaflow-e2e-config kubectl -nnumaflow-system get po -o yaml | grep -i quay.io
       - name: Run tests
         env:
           GOPATH: /home/runner/go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,8 +194,8 @@ jobs:
         env:
           GOPATH: /home/runner/go
         run: |
-          KUBECONFIG=~/.kube/numaflow-e2e-config IMAGE_NAMESPACE=k3d-e2e-registry:5111 VERSION=${{ github.sha }} DOCKER_PUSH=true make start
+          KUBECONFIG=~/.kube/numaflow-e2e-config IMAGE_NAMESPACE=k3d-e2e-registry:5111 VERSION=${{ github.sha }} DOCKER_PUSH=false make start
       - name: Run tests
         env:
           GOPATH: /home/runner/go
-        run: KUBECONFIG=~/.kube/numaflow-e2e-config IMAGE_NAMESPACE=k3d-e2e-registry:5111 VERSION=${{ github.sha }} DOCKER_PUSH=true ISBSVC=${{matrix.driver}} make test-${{matrix.case}}
+        run: KUBECONFIG=~/.kube/numaflow-e2e-config IMAGE_NAMESPACE=k3d-e2e-registry:5111 VERSION=${{ github.sha }} DOCKER_PUSH=false ISBSVC=${{matrix.driver}} make test-${{matrix.case}}


### PR DESCRIPTION
Image registry is actually not in-use during e2e tests - we use `make start` to install the manifests which set the image pull policy to `ifNotPresent`, and during image build, we always import the built image to the cluster.

Closes: https://github.com/numaproj/numaflow/issues/1802

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
