### PR TITLE
chore: move setting ObservedGeneration at the beginning of the reconciliation process

### DIFF
--- a/pkg/reconciler/isbsvc/controller.go
+++ b/pkg/reconciler/isbsvc/controller.go
@@ -101,6 +101,7 @@ func (r *interStepBufferServiceReconciler) reconcile(ctx context.Context, isbSvc
 	}
 
 	isbSvc.Status.InitConditions()
+	isbSvc.Status.SetObservedGeneration(isbSvc.Generation)
 	if err := ValidateInterStepBufferService(isbSvc); err != nil {
 		log.Errorw("Validation failed", zap.Error(err))
 		isbSvc.Status.MarkNotConfigured("InvalidSpec", err.Error())

--- a/pkg/reconciler/isbsvc/installer/installer.go
+++ b/pkg/reconciler/isbsvc/installer/installer.go
@@ -49,7 +49,6 @@ func Install(ctx context.Context, isbSvc *dfv1.InterStepBufferService, client cl
 		return err
 	}
 	isbSvc.Status.Config = *bufferConfig
-	isbSvc.Status.SetObservedGeneration(isbSvc.Generation)
 	return nil
 }
 

--- a/pkg/reconciler/pipeline/controller.go
+++ b/pkg/reconciler/pipeline/controller.go
@@ -129,6 +129,7 @@ func (r *pipelineReconciler) reconcile(ctx context.Context, pl *dfv1.Pipeline) (
 		return ctrl.Result{}, nil
 	}
 
+	pl.Status.SetObservedGeneration(pl.Generation)
 	// New, or reconciliation failed pipeline
 	if pl.Status.Phase == dfv1.PipelinePhaseUnknown || pl.Status.Phase == dfv1.PipelinePhaseFailed {
 		result, err := r.reconcileNonLifecycleChanges(ctx, pl)
@@ -334,7 +335,6 @@ func (r *pipelineReconciler) reconcileNonLifecycleChanges(ctx context.Context, p
 
 	pl.Status.MarkDeployed()
 	pl.Status.SetPhase(pl.Spec.Lifecycle.GetDesiredPhase(), "")
-	pl.Status.SetObservedGeneration(pl.Generation)
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
This PR moved setting `ObservedGeneration` at the beginning of the reconciliation process for pipeline and ISBService.  Currently, `ObservedGeneration` is setting at the end which can cause problems when we exit the reconciliation process early.

Explain what this PR does.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
