### PR TITLE
chore: use `kube_codegen.sh` instead in codegen.

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -17,8 +17,6 @@ cd "${FAKE_REPOPATH}"
 
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${FAKE_REPOPATH}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
-chmod +x ${CODEGEN_PKG}/*.sh
-
 subheader "running codegen"
 bash -x ${CODEGEN_PKG}/kube_codegen.sh "deepcopy" \
   github.com/numaproj/numaflow/pkg/client github.com/numaproj/numaflow/pkg/apis \

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -20,12 +20,12 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${FAKE_REPOPATH}"; ls -d -1 ./vendor/k8s.io/cod
 chmod +x ${CODEGEN_PKG}/*.sh
 
 subheader "running codegen"
-bash -x ${CODEGEN_PKG}/generate-groups.sh "deepcopy" \
+bash -x ${CODEGEN_PKG}/kube_codegen.sh "deepcopy" \
   github.com/numaproj/numaflow/pkg/client github.com/numaproj/numaflow/pkg/apis \
   "numaflow:v1alpha1" \
   --go-header-file hack/boilerplate/boilerplate.go.txt
 
-bash -x ${CODEGEN_PKG}/generate-groups.sh "client,informer,lister" \
+bash -x ${CODEGEN_PKG}/kube_codegen.sh "client,informer,lister" \
   github.com/numaproj/numaflow/pkg/client github.com/numaproj/numaflow/pkg/apis \
   "numaflow:v1alpha1" \
   --plural-exceptions="Vertex:Vertices,MonoVertex:MonoVertices" \


### PR DESCRIPTION
`make codegen` has the following warning,
```
WARNING: generate-internal-groups.sh is deprecated.
WARNING: Please use k8s.io/code-generator/kube_codegen.sh instead.

```
which can cause similar permission denied issue as https://github.com/numaproj/numaplane/pull/214
<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
