### PR TITLE
chore: reduce 5 second wait time every time redis sink check runs in e2e

### DIFF
--- a/test/fixtures/redis_check.go
+++ b/test/fixtures/redis_check.go
@@ -100,6 +100,9 @@ func runChecks(ctx context.Context, performChecks CheckFunc) bool {
 	ticker := time.NewTicker(retryInterval)
 	defer ticker.Stop()
 
+	if performChecks() {
+		return true
+	}
 	for {
 		select {
 		case <-ctx.Done():

--- a/test/reduce-two-e2e/reduce_two_test.go
+++ b/test/reduce-two-e2e/reduce_two_test.go
@@ -83,7 +83,7 @@ func (r *ReduceSuite) testReduceStream(lang string) {
 	// There should be no other values.
 	w.Expect().RedisSinkContains(pipelineName+"-sink", "102")
 	w.Expect().RedisSinkNotContains(pipelineName+"-sink", "99")
-	w.Expect().RedisSinkNotContains(pipelineName+"sink", "105")
+	w.Expect().RedisSinkNotContains(pipelineName+"-sink", "105")
 	done <- struct{}{}
 }
 


### PR DESCRIPTION
We use a 5s ticker to retry redis check in e2e, the check start with waiting for 5s before the first check, adding a lot of unnecessary wait time. Especially in test cases where we call multiple redis checks. This change immediately checks to reduce the 5 second wait.

Before the change:

```
--- PASS: TestDiamondSuite (482.58s)
    --- PASS: TestDiamondSuite/TestCycleBackward (119.63s)
    --- PASS: TestDiamondSuite/TestCycleToSelf (118.82s)
    --- PASS: TestDiamondSuite/TestJoinOnMapPipeline (69.46s)
    --- PASS: TestDiamondSuite/TestJoinOnReducePipeline (71.50s)
    --- PASS: TestDiamondSuite/TestJoinOnSinkVertex (69.61s)
```

After:

```
--- PASS: TestDiamondSuite (365.96s)
    --- PASS: TestDiamondSuite/TestCycleBackward (69.73s)
    --- PASS: TestDiamondSuite/TestCycleToSelf (68.09s)
    --- PASS: TestDiamondSuite/TestJoinOnMapPipeline (62.44s)
    --- PASS: TestDiamondSuite/TestJoinOnReducePipeline (68.53s)
    --- PASS: TestDiamondSuite/TestJoinOnSinkVertex (62.69s)
```
<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
