### PR TITLE
Fix: Use Merge patch rather than json patch for `pause-timestamp` annotation apply

### DIFF
--- a/pkg/reconciler/pipeline/controller.go
+++ b/pkg/reconciler/pipeline/controller.go
@@ -186,7 +186,6 @@ func (r *pipelineReconciler) reconcile(ctx context.Context, pl *dfv1.Pipeline) (
 		oldPhase := pl.Status.Phase
 		requeue, err := r.updateDesiredState(ctx, pl)
 		if err != nil {
-			fmt.Println("deletethis: got here 1")
 			logMsg := fmt.Sprintf("Updated desired pipeline phase failed: %v", zap.Error(err))
 			log.Error(logMsg)
 			r.recorder.Eventf(pl, corev1.EventTypeWarning, "ReconcilePipelineFailed", logMsg)
@@ -799,8 +798,6 @@ var sourceVertexFilter vertexFilterFunc = func(v dfv1.Vertex) bool { return v.Is
 func (r *pipelineReconciler) updateDesiredState(ctx context.Context, pl *dfv1.Pipeline) (bool, error) {
 	switch pl.Spec.Lifecycle.GetDesiredPhase() {
 	case dfv1.PipelinePhasePaused:
-
-		fmt.Println("deletethis: got here 2")
 		return r.pausePipeline(ctx, pl)
 	case dfv1.PipelinePhaseRunning, dfv1.PipelinePhaseUnknown:
 		return r.resumePipeline(ctx, pl)
@@ -834,34 +831,14 @@ func (r *pipelineReconciler) resumePipeline(ctx context.Context, pl *dfv1.Pipeli
 
 func (r *pipelineReconciler) pausePipeline(ctx context.Context, pl *dfv1.Pipeline) (bool, error) {
 	// check that annotations / pause timestamp annotation exist
-	/*if len(pl.GetAnnotations()) == 0 {
-		patchJson := `[{"op": "add", "path": "/metadata/annotations", "value": {}}]`
-		fmt.Printf("deletethis: first adding patchJson: %s, annotations=%+v\n", patchJson, pl.GetAnnotations())
-		if err := r.client.Patch(ctx, pl, client.RawPatch(types.JSONPatchType, []byte(patchJson))); err != nil && !apierrors.IsNotFound(err) {
-			return true, err
-		}
-	}*/
 	if pl.GetAnnotations() == nil || pl.GetAnnotations()[dfv1.KeyPauseTimestamp] == "" {
-		/*patchJson := `[{"op": "add", "path": "` + pauseTimestampPath + `", "value": "` + time.Now().Format(time.RFC3339) + `"}]`
-		fmt.Printf("deletethis: adding patchJson: %s, annotations=%+v\n", patchJson, pl.GetAnnotations())
-		if err := r.client.Patch(ctx, pl, client.RawPatch(types.JSONPatchType, []byte(patchJson))); err != nil && !apierrors.IsNotFound(err) {
-			fmt.Printf("deletethis: failed to add patchJson: %v\n", err)
-			return true, err
-		}*/
-		//path := strings.Replace(pauseTimestampPath, "~1", "/", -1)
-		//path = strings.Replace(path, "~0", "~", -1)
-		path := "numaflow.numaproj.io/pause-timestamp"
-		patchJson := `{"metadata":{"annotations":{"` + path + `":"` + time.Now().Format(time.RFC3339) + `"}}}`
-		fmt.Printf("deletethis: adding patchJson: %s, annotations=%+v\n", patchJson, pl.GetAnnotations())
+		patchJson := `{"metadata":{"annotations":{"` + dfv1.KeyPauseTimestamp + `":"` + time.Now().Format(time.RFC3339) + `"}}}`
 		if err := r.client.Patch(ctx, pl, client.RawPatch(types.MergePatchType, []byte(patchJson))); err != nil && !apierrors.IsNotFound(err) {
-			fmt.Printf("deletethis: failed to add patchJson: %v\n", err)
 			return true, err
 		}
 	}
 
-	fmt.Println("deletethis: got here 3")
 	pl.Status.MarkPhasePausing()
-	fmt.Println("deletethis: got here 4")
 	updated, err := r.scaleDownSourceVertices(ctx, pl)
 	if err != nil || updated {
 		// If there's an error, or scaling down happens, requeue the request

--- a/pkg/reconciler/pipeline/controller.go
+++ b/pkg/reconciler/pipeline/controller.go
@@ -88,7 +88,6 @@ func (r *pipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 	plCopy.Status.LastUpdated = metav1.Now()
 	if !equality.Semantic.DeepEqual(pl.Finalizers, plCopy.Finalizers) {
-		log.Debug("patching finalizer in")
 		patchYaml := "metadata:\n  finalizers: [" + strings.Join(plCopy.Finalizers, ",") + "]"
 		patchJson, _ := yaml.YAMLToJSON([]byte(patchYaml))
 		if err := r.client.Patch(ctx, pl, client.RawPatch(types.MergePatchType, []byte(patchJson))); err != nil {
@@ -915,10 +914,8 @@ func (r *pipelineReconciler) scaleVertex(ctx context.Context, pl *dfv1.Pipeline,
 				}
 			}
 			patchJson := fmt.Sprintf(`{"spec":{"replicas":%d}}`, scaleTo)
-			log.Infof("deletethis: patchJson=%q", patchJson)
 			err = r.client.Patch(ctx, &vertex, client.RawPatch(types.MergePatchType, []byte(patchJson)))
 			if err != nil && !apierrors.IsNotFound(err) {
-				log.Infof("deletethis: patching failed, error=%q", err)
 				return false, err
 			}
 			log.Infow("Scaled vertex", zap.Int32("from", origin), zap.Int32("to", scaleTo), zap.String("vertex", vertex.Name))


### PR DESCRIPTION
It seems if you create a Pipeline with no `metadata.annotations` set (at least if you are using minimized CRDs), then trying to do [this](https://github.com/numaproj/numaflow/blob/v1.3.1/pkg/reconciler/pipeline/controller.go#L827) json patch operation fails with the error "the server rejected our request due to an error in our request". 

This does not happen if a Merge Patch is used instead.

I tested this in the case of:

- an annotation already existed in the Pipeline when the Pipeline was created
- annotations not defined when the Pipeline was created

For both cases, I experimented with adding `lifecycle.desiredPhase: Paused` and also with removing it.

For both, I observed the proper annotation set:
```
metadata:
  annotations:
    numaflow.numaproj.io/pause-timestamp: "2024-09-20T20:31:47Z"
```
...and then later removed.


<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
