### PR TITLE
Debugging unit test timeout in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.22"
       - name: Add bins to PATH
         run: |
           echo /home/runner/go/bin >> $GITHUB_PATH
@@ -72,7 +72,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       nats:
-        image: 'bitnami/nats:latest'
+        image: "bitnami/nats:latest"
         ports:
           - 4222:4222
         env:
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.22"
         id: go
 
       - name: Check out code
@@ -94,11 +94,11 @@ jobs:
           key: ${{ runner.os }}-go-build-v1-${{ github.run_id }}
 
       - name: Get dependencies
-        run: go mod download
+        run: go mod download -x
 
       - name: Test Go
         run: make test-coverage-with-isb
-      
+
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -119,7 +119,7 @@ jobs:
       - name: Test Rust
         working-directory: ./rust
         run: |
-          CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='./target/debug/coverage/cargo-test-%p-%m.profraw' cargo test --all-features --workspace --all 
+          CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='./target/debug/coverage/cargo-test-%p-%m.profraw' cargo test --all-features --workspace --all
           grcov . -s ./target/debug/coverage/ --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/debug/coverage/lcov.info
 
       - name: Upload coverage reports to Codecov
@@ -140,7 +140,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.22"
       - name: Restore Go build cache
         uses: actions/cache@v4
         with:
@@ -160,7 +160,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
           cache-workspaces: rust -> target
-          rustflags: ''
+          rustflags: ""
       - name: Configure sccache
         run: |
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
@@ -187,13 +187,28 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [ build-rust-amd64 ]
+    needs: [build-rust-amd64]
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         driver: [jetstream]
-        case: [e2e, diamond-e2e, transformer-e2e, kafka-e2e, map-e2e, reduce-one-e2e, reduce-two-e2e, udsource-e2e, api-e2e, sideinputs-e2e, idle-source-e2e, monovertex-e2e, builtin-source-e2e]
+        case:
+          [
+            e2e,
+            diamond-e2e,
+            transformer-e2e,
+            kafka-e2e,
+            map-e2e,
+            reduce-one-e2e,
+            reduce-two-e2e,
+            udsource-e2e,
+            api-e2e,
+            sideinputs-e2e,
+            idle-source-e2e,
+            monovertex-e2e,
+            builtin-source-e2e,
+          ]
         include:
           - driver: redis
             case: e2e
@@ -213,7 +228,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.22"
       - name: Add bins to PATH
         run: |
           echo /home/runner/go/bin >> $GITHUB_PATH

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ test-coverage:
 
 .PHONY: test-coverage-with-isb
 test-coverage-with-isb:
-	go test -v -timeout 7m -covermode=atomic -coverprofile=test/profile.cov -tags=isb_redis $(shell go list ./... | grep -v /vendor/ | grep -v /numaflow/test/ | grep -v /pkg/client/ | grep -v /pkg/proto/ | grep -v /hack/))
+	go test -v -timeout 7m -covermode=atomic -coverprofile=test/profile.cov -tags=isb_redis $(shell go list ./... | grep -v /vendor/ | grep -v /numaflow/test/ | grep -v /pkg/client/ | grep -v /pkg/proto/ | grep -v /hack/)
 	go tool cover -func=test/profile.cov
 
 .PHONY: test-code

--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,7 @@ test-coverage:
 
 .PHONY: test-coverage-with-isb
 test-coverage-with-isb:
-	$(eval $@_START := $(shell date +%s))
-	$(eval $@_TEST_FILES := $(shell go list ./... | grep -v /vendor/ | grep -v /numaflow/test/ | grep -v /pkg/client/ | grep -v /pkg/proto/ | grep -v /hack/))
-	@echo "Discovered test files in $$(($$(date +%s)-$($@_START))) seconds"
-	go test -timeout 8m -covermode=atomic -coverprofile=test/profile.cov -tags=isb_redis $($@_TEST_FILES)
+	go test -v -timeout 7m -covermode=atomic -coverprofile=test/profile.cov -tags=isb_redis $(shell go list ./... | grep -v /vendor/ | grep -v /numaflow/test/ | grep -v /pkg/client/ | grep -v /pkg/proto/ | grep -v /hack/))
 	go tool cover -func=test/profile.cov
 
 .PHONY: test-code

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,10 @@ test-coverage:
 
 .PHONY: test-coverage-with-isb
 test-coverage-with-isb:
-	go test -covermode=atomic -coverprofile=test/profile.cov -tags=isb_redis $(shell go list ./... | grep -v /vendor/ | grep -v /numaflow/test/ | grep -v /pkg/client/ | grep -v /pkg/proto/ | grep -v /hack/)
+	$(eval $@_START := $(shell date +%s))
+	$(eval $@_TEST_FILES := $(shell go list ./... | grep -v /vendor/ | grep -v /numaflow/test/ | grep -v /pkg/client/ | grep -v /pkg/proto/ | grep -v /hack/))
+	@echo "Discovered test files in $$(($$(date +%s)-$($@_START))) seconds"
+	go test -timeout 8m -covermode=atomic -coverprofile=test/profile.cov -tags=isb_redis $($@_TEST_FILES)
 	go tool cover -func=test/profile.cov
 
 .PHONY: test-code


### PR DESCRIPTION
The Go unit tests are intermittently getting terminated due to the 10 minute timeout we set in Github CI. Tried setting 8 minute timeout with `go test -timeout 8m`. However, even before the Go's test runner timing out, Github timeout was reached. Github UI shows that the `go test` command ran for 9m35sec. https://github.com/numaproj/numaflow/actions/runs/11158574065/job/31015137527

When successful, the unit tests finishes in less than 4minutes. Since we are not able to recreate the issue consistently, this PR adds `-v -timeout 7m` to Go's test runner.

