### PR TITLE
feat: add keys into kafka header while producing

### DIFF
--- a/docs/user-guide/sinks/kafka.md
+++ b/docs/user-guide/sinks/kafka.md
@@ -2,6 +2,16 @@
 
 A `Kafka` sink is used to forward the messages to a Kafka topic. Kafka sink supports configuration overrides.
 
+## Kafka Headers
+
+We will insert `keys` into the Kafka header, but since `keys` is an array, we will add `keys` into the header in the
+following format.
+
+* `__keys_len` will have the number of `key` in the header. if `__keys_len` == `0`, means no `keys` are present.
+* `__keys_%d` will have the `key`, e.g., `__key_0` will be the first key, and so forth.
+
+## Example 
+
 ```yaml
 spec:
   vertices:


### PR DESCRIPTION
partially solves: #2142 

we will be adding `__key_len` in the header to indicate how many keys are going to be in the header. `__key_%d` will have the value at an index.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
