### PR TITLE
chore: Refactor - Rename Error variants

### DIFF
--- a/rust/numaflow-core/src/config.rs
+++ b/rust/numaflow-core/src/config.rs
@@ -1,11 +1,13 @@
-use crate::error::Error;
-use base64::prelude::BASE64_STANDARD;
-use base64::Engine;
-use bytes::Bytes;
-use numaflow_models::models::{Backoff, MonoVertex, RetryStrategy};
 use std::env;
 use std::fmt::Display;
 use std::sync::OnceLock;
+
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
+use bytes::Bytes;
+
+use crate::Error;
+use numaflow_models::models::{Backoff, MonoVertex, RetryStrategy};
 
 const DEFAULT_SOURCE_SOCKET: &str = "/var/run/numaflow/source.sock";
 const DEFAULT_SOURCE_SERVER_INFO_FILE: &str = "/var/run/numaflow/sourcer-server-info";

--- a/rust/numaflow-core/src/config.rs
+++ b/rust/numaflow-core/src/config.rs
@@ -218,13 +218,11 @@ impl Settings {
             let mono_vertex_spec = BASE64_STANDARD
                 .decode(mono_vertex_spec.as_bytes())
                 .map_err(|e| {
-                    Error::ConfigError(format!("Failed to decode mono vertex spec: {:?}", e))
+                    Error::Config(format!("Failed to decode mono vertex spec: {:?}", e))
                 })?;
 
-            let mono_vertex_obj: MonoVertex =
-                serde_json::from_slice(&mono_vertex_spec).map_err(|e| {
-                    Error::ConfigError(format!("Failed to parse mono vertex spec: {:?}", e))
-                })?;
+            let mono_vertex_obj: MonoVertex = serde_json::from_slice(&mono_vertex_spec)
+                .map_err(|e| Error::Config(format!("Failed to parse mono vertex spec: {:?}", e)))?;
 
             settings.batch_size = mono_vertex_obj
                 .spec
@@ -247,13 +245,13 @@ impl Settings {
             settings.mono_vertex_name = mono_vertex_obj
                 .metadata
                 .and_then(|metadata| metadata.name)
-                .ok_or_else(|| Error::ConfigError("Mono vertex name not found".to_string()))?;
+                .ok_or_else(|| Error::Config("Mono vertex name not found".to_string()))?;
 
             settings.transformer_config = match mono_vertex_obj
                 .spec
                 .source
                 .as_deref()
-                .ok_or(Error::ConfigError("Source not found".to_string()))?
+                .ok_or(Error::Config("Source not found".to_string()))?
                 .transformer
             {
                 Some(_) => Some(TransformerConfig::default()),
@@ -264,7 +262,7 @@ impl Settings {
                 .spec
                 .source
                 .as_deref()
-                .ok_or(Error::ConfigError("Source not found".to_string()))?
+                .ok_or(Error::Config("Source not found".to_string()))?
                 .udsource
             {
                 Some(_) => Some(UDSourceConfig::default()),
@@ -275,7 +273,7 @@ impl Settings {
                 .spec
                 .sink
                 .as_deref()
-                .ok_or(Error::ConfigError("Sink not found".to_string()))?
+                .ok_or(Error::Config("Sink not found".to_string()))?
                 .udsink
             {
                 Some(_) => Some(UDSinkConfig::default()),
@@ -286,7 +284,7 @@ impl Settings {
                 .spec
                 .sink
                 .as_deref()
-                .ok_or(Error::ConfigError("Sink not found".to_string()))?
+                .ok_or(Error::Config("Sink not found".to_string()))?
                 .fallback
             {
                 Some(_) => Some(UDSinkConfig::fallback_default()),
@@ -297,7 +295,7 @@ impl Settings {
                 .spec
                 .source
                 .as_deref()
-                .ok_or(Error::ConfigError("Source not found".to_string()))?
+                .ok_or(Error::Config("Source not found".to_string()))?
                 .generator
                 .as_deref()
             {
@@ -343,7 +341,7 @@ impl Settings {
 
                     // We do not allow 0 attempts to write to sink
                     if settings.sink_max_retry_attempts == 0 {
-                        return Err(Error::ConfigError(
+                        return Err(Error::Config(
                             "Retry Strategy given with 0 retry attempts".to_string(),
                         ));
                     }
@@ -361,7 +359,7 @@ impl Settings {
                 if settings.sink_retry_on_fail_strategy == OnFailureStrategy::Fallback
                     && settings.fallback_config.is_none()
                 {
-                    return Err(Error::ConfigError(
+                    return Err(Error::Config(
                         "Retry Strategy given as fallback but Fallback sink not configured"
                             .to_string(),
                     ));
@@ -372,7 +370,7 @@ impl Settings {
         settings.replica = env::var(ENV_POD_REPLICA)
             .unwrap_or_else(|_| "0".to_string())
             .parse()
-            .map_err(|e| Error::ConfigError(format!("Failed to parse pod replica: {:?}", e)))?;
+            .map_err(|e| Error::Config(format!("Failed to parse pod replica: {:?}", e)))?;
 
         Ok(settings)
     }

--- a/rust/numaflow-core/src/error.rs
+++ b/rust/numaflow-core/src/error.rs
@@ -5,35 +5,35 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Error, Debug, Clone)]
 pub enum Error {
     #[error("Metrics Error - {0}")]
-    MetricsError(String),
+    Metrics(String),
 
     #[error("Source Error - {0}")]
-    SourceError(String),
+    Source(String),
 
     #[error("Sink Error - {0}")]
-    SinkError(String),
+    Sink(String),
 
     #[error("Transformer Error - {0}")]
-    TransformerError(String),
+    Transformer(String),
 
     #[error("Forwarder Error - {0}")]
-    ForwarderError(String),
+    Forwarder(String),
 
     #[error("Connection Error - {0}")]
-    ConnectionError(String),
+    Connection(String),
 
     #[error("gRPC Error - {0}")]
-    GRPCError(String),
+    Grpc(String),
 
     #[error("Config Error - {0}")]
-    ConfigError(String),
+    Config(String),
 
     #[error("ServerInfoError Error - {0}")]
-    ServerInfoError(String),
+    ServerInfo(String),
 }
 
 impl From<tonic::Status> for Error {
     fn from(status: tonic::Status) -> Self {
-        Error::GRPCError(status.to_string())
+        Error::Grpc(status.to_string())
     }
 }

--- a/rust/numaflow-core/src/lib.rs
+++ b/rust/numaflow-core/src/lib.rs
@@ -2,8 +2,7 @@ use tracing::error;
 
 /// Custom Error handling.
 mod error;
-pub(crate) use crate::error::Error;
-pub(crate) use crate::error::Result;
+pub(crate) use crate::error::{Error, Result};
 
 /// MonoVertex is a simplified version of the [Pipeline] spec which is ideal for high TPS, low latency
 /// use-cases which do not require [ISB].

--- a/rust/numaflow-core/src/message.rs
+++ b/rust/numaflow-core/src/message.rs
@@ -5,8 +5,8 @@ use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
 use chrono::{DateTime, Utc};
 
-use crate::error::Error;
 use crate::shared::utils::{prost_timestamp_from_utc, utc_from_timestamp};
+use crate::Error;
 use numaflow_grpc::clients::sink::sink_request::Request;
 use numaflow_grpc::clients::sink::Status::{Failure, Fallback, Success};
 use numaflow_grpc::clients::sink::{sink_response, SinkRequest, SinkResponse};

--- a/rust/numaflow-core/src/message.rs
+++ b/rust/numaflow-core/src/message.rs
@@ -84,7 +84,7 @@ impl TryFrom<read_response::Result> for Message {
                 offset: BASE64_STANDARD.encode(o.offset),
                 partition_id: o.partition_id,
             },
-            None => return Err(Error::SourceError("Offset not found".to_string())),
+            None => return Err(Error::Source("Offset not found".to_string())),
         };
 
         Ok(Message {
@@ -161,7 +161,7 @@ impl TryFrom<SinkResponse> for ResponseFromSink {
     fn try_from(value: SinkResponse) -> Result<Self, Self::Error> {
         let value = value
             .result
-            .ok_or(Error::SinkError("result is empty".to_string()))?;
+            .ok_or(Error::Sink("result is empty".to_string()))?;
 
         let status = match value.status() {
             Success => ResponseStatusFromSink::Success,

--- a/rust/numaflow-core/src/monovertex.rs
+++ b/rust/numaflow-core/src/monovertex.rs
@@ -226,9 +226,7 @@ async fn fetch_source(
         )?;
         Ok(SourceType::Generator(source_read, source_ack, lag_reader))
     } else {
-        Err(Error::ConfigError(
-            "No valid source configuration found".into(),
-        ))
+        Err(Error::Config("No valid source configuration found".into()))
     }
 }
 
@@ -254,7 +252,7 @@ async fn fetch_sink(
         let log = SinkHandle::new(SinkClientType::Log).await?;
         return Ok((log, fb_sink));
     }
-    Err(Error::ConfigError(
+    Err(Error::Config(
         "No valid Sink configuration found".to_string(),
     ))
 }

--- a/rust/numaflow-core/src/monovertex/forwarder.rs
+++ b/rust/numaflow-core/src/monovertex/forwarder.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 
 use crate::config::{config, OnFailureStrategy};
 use crate::error;
-use crate::error::Error;
 use crate::message::{Message, Offset, ResponseStatusFromSink};
 use crate::monovertex::metrics;
 use crate::monovertex::metrics::forward_metrics;
 use crate::sink::SinkHandle;
+use crate::Error;
 use crate::{source::SourceHandle, transformer::user_defined::SourceTransformHandle};
 
 use chrono::Utc;

--- a/rust/numaflow-core/src/monovertex/metrics.rs
+++ b/rust/numaflow-core/src/monovertex/metrics.rs
@@ -275,18 +275,18 @@ pub(crate) async fn start_metrics_https_server(
 
     // Generate a self-signed certificate
     let CertifiedKey { cert, key_pair } = generate_simple_self_signed(vec!["localhost".into()])
-        .map_err(|e| Error::MetricsError(format!("Generating self-signed certificate: {}", e)))?;
+        .map_err(|e| Error::Metrics(format!("Generating self-signed certificate: {}", e)))?;
 
     let tls_config = RustlsConfig::from_pem(cert.pem().into(), key_pair.serialize_pem().into())
         .await
-        .map_err(|e| Error::MetricsError(format!("Creating tlsConfig from pem: {}", e)))?;
+        .map_err(|e| Error::Metrics(format!("Creating tlsConfig from pem: {}", e)))?;
 
     let metrics_app = metrics_router(metrics_state);
 
     axum_server::bind_rustls(addr, tls_config)
         .serve(metrics_app.into_make_service())
         .await
-        .map_err(|e| Error::MetricsError(format!("Starting web server for metrics: {}", e)))?;
+        .map_err(|e| Error::Metrics(format!("Starting web server for metrics: {}", e)))?;
 
     Ok(())
 }

--- a/rust/numaflow-core/src/monovertex/metrics.rs
+++ b/rust/numaflow-core/src/monovertex/metrics.rs
@@ -28,8 +28,8 @@ use numaflow_grpc::clients::source::source_client::SourceClient;
 use numaflow_grpc::clients::sourcetransformer::source_transform_client::SourceTransformClient;
 
 use crate::config::config;
-use crate::error::Error;
 use crate::source::SourceHandle;
+use crate::Error;
 
 // Define the labels for the metrics
 // Note: Please keep consistent with the definitions in MonoVertex daemon

--- a/rust/numaflow-core/src/shared/utils.rs
+++ b/rust/numaflow-core/src/shared/utils.rs
@@ -40,7 +40,7 @@ pub(crate) async fn check_compatibility(
             .await
             .map_err(|e| {
                 warn!("Error waiting for source server info file: {:?}", e);
-                Error::ForwarderError("Error waiting for server info file".to_string())
+                Error::Forwarder("Error waiting for server info file".to_string())
             })?;
     }
 
@@ -49,7 +49,7 @@ pub(crate) async fn check_compatibility(
             .await
             .map_err(|e| {
                 error!("Error waiting for sink server info file: {:?}", e);
-                Error::ForwarderError("Error waiting for server info file".to_string())
+                Error::Forwarder("Error waiting for server info file".to_string())
             })?;
     }
 
@@ -58,7 +58,7 @@ pub(crate) async fn check_compatibility(
             .await
             .map_err(|e| {
                 error!("Error waiting for transformer server info file: {:?}", e);
-                Error::ForwarderError("Error waiting for server info file".to_string())
+                Error::Forwarder("Error waiting for server info file".to_string())
             })?;
     }
 
@@ -67,7 +67,7 @@ pub(crate) async fn check_compatibility(
             .await
             .map_err(|e| {
                 warn!("Error waiting for fallback sink server info file: {:?}", e);
-                Error::ForwarderError("Error waiting for server info file".to_string())
+                Error::Forwarder("Error waiting for server info file".to_string())
             })?;
     }
     Ok(())
@@ -108,7 +108,7 @@ pub(crate) async fn wait_until_ready(
 ) -> error::Result<()> {
     loop {
         if cln_token.is_cancelled() {
-            return Err(Error::ForwarderError(
+            return Err(Error::Forwarder(
                 "Cancellation token is cancelled".to_string(),
             ));
         }
@@ -192,7 +192,7 @@ pub(crate) async fn create_rpc_channel(socket_path: PathBuf) -> crate::error::Re
 
 pub(crate) async fn connect_with_uds(uds_path: PathBuf) -> Result<Channel, Error> {
     let channel = Endpoint::try_from("http://[::]:50051")
-        .map_err(|e| Error::ConnectionError(format!("Failed to create endpoint: {:?}", e)))?
+        .map_err(|e| Error::Connection(format!("Failed to create endpoint: {:?}", e)))?
         .connect_with_connector(service_fn(move |_: Uri| {
             let uds_socket = uds_path.clone();
             async move {
@@ -202,7 +202,7 @@ pub(crate) async fn connect_with_uds(uds_path: PathBuf) -> Result<Channel, Error
             }
         }))
         .await
-        .map_err(|e| Error::ConnectionError(format!("Failed to connect: {:?}", e)))?;
+        .map_err(|e| Error::Connection(format!("Failed to connect: {:?}", e)))?;
     Ok(channel)
 }
 

--- a/rust/numaflow-core/src/shared/utils.rs
+++ b/rust/numaflow-core/src/shared/utils.rs
@@ -2,18 +2,6 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use crate::config::config;
-use crate::error;
-use crate::error::Error;
-use crate::monovertex::metrics::{
-    start_metrics_https_server, PendingReader, PendingReaderBuilder, UserDefinedContainerState,
-};
-use crate::shared::server_info;
-use crate::source::SourceHandle;
-use numaflow_grpc::clients::sink::sink_client::SinkClient;
-use numaflow_grpc::clients::source::source_client::SourceClient;
-use numaflow_grpc::clients::sourcetransformer::source_transform_client::SourceTransformClient;
-
 use axum::http::Uri;
 use backoff::retry::Retry;
 use backoff::strategy::fixed;
@@ -27,6 +15,18 @@ use tonic::transport::{Channel, Endpoint};
 use tonic::Request;
 use tower::service_fn;
 use tracing::{info, warn};
+
+use crate::config::config;
+use crate::error;
+use crate::monovertex::metrics::{
+    start_metrics_https_server, PendingReader, PendingReaderBuilder, UserDefinedContainerState,
+};
+use crate::shared::server_info;
+use crate::source::SourceHandle;
+use crate::Error;
+use numaflow_grpc::clients::sink::sink_client::SinkClient;
+use numaflow_grpc::clients::source::source_client::SourceClient;
+use numaflow_grpc::clients::sourcetransformer::source_transform_client::SourceTransformClient;
 
 pub(crate) async fn check_compatibility(
     cln_token: &CancellationToken,

--- a/rust/numaflow-core/src/sink/user_defined.rs
+++ b/rust/numaflow-core/src/sink/user_defined.rs
@@ -7,9 +7,9 @@ use numaflow_grpc::clients::sink::sink_client::SinkClient;
 use numaflow_grpc::clients::sink::{Handshake, SinkRequest, SinkResponse, TransmissionStatus};
 
 use crate::error;
-use crate::error::Error;
 use crate::message::{Message, ResponseFromSink};
 use crate::sink::Sink;
+use crate::Error;
 
 const DEFAULT_CHANNEL_SIZE: usize = 1000;
 

--- a/rust/numaflow-core/src/source/user_defined.rs
+++ b/rust/numaflow-core/src/source/user_defined.rs
@@ -10,11 +10,10 @@ use numaflow_grpc::clients::source::{
 };
 
 use crate::config::config;
-use crate::error;
-use crate::error::Error::SourceError;
 use crate::message::{Message, Offset};
 use crate::reader::LagReader;
 use crate::source::{SourceAcker, SourceReader};
+use crate::{Error, Result};
 
 /// User-Defined Source to operative on custom sources.
 #[derive(Debug)]
@@ -37,7 +36,7 @@ pub(crate) async fn new_source(
     client: SourceClient<Channel>,
     num_records: usize,
     timeout_in_ms: u16,
-) -> error::Result<(
+) -> Result<(
     UserDefinedSourceRead,
     UserDefinedSourceAck,
     UserDefinedSourceLagReader,
@@ -54,7 +53,7 @@ impl UserDefinedSourceRead {
         mut client: SourceClient<Channel>,
         num_records: usize,
         timeout_in_ms: u16,
-    ) -> error::Result<Self> {
+    ) -> Result<Self> {
         let (read_tx, resp_stream) = Self::create_reader(&mut client).await?;
 
         Ok(Self {
@@ -67,7 +66,7 @@ impl UserDefinedSourceRead {
 
     async fn create_reader(
         client: &mut SourceClient<Channel>,
-    ) -> error::Result<(mpsc::Sender<ReadRequest>, Streaming<ReadResponse>)> {
+    ) -> Result<(mpsc::Sender<ReadRequest>, Streaming<ReadResponse>)> {
         let (read_tx, read_rx) = mpsc::channel(config().batch_size as usize);
         let read_stream = ReceiverStream::new(read_rx);
 
@@ -79,7 +78,7 @@ impl UserDefinedSourceRead {
         read_tx
             .send(handshake_request)
             .await
-            .map_err(|e| SourceError(format!("failed to send handshake request: {}", e)))?;
+            .map_err(|e| Error::SourceError(format!("failed to send handshake request: {}", e)))?;
 
         let mut resp_stream = client
             .read_fn(Request::new(read_stream))
@@ -88,12 +87,12 @@ impl UserDefinedSourceRead {
 
         // first response from the server will be the handshake response. We need to check if the
         // server has accepted the handshake.
-        let handshake_response = resp_stream.message().await?.ok_or(SourceError(
+        let handshake_response = resp_stream.message().await?.ok_or(Error::SourceError(
             "failed to receive handshake response".to_string(),
         ))?;
         // handshake cannot to None during the initial phase and it has to set `sot` to true.
         if handshake_response.handshake.map_or(true, |h| !h.sot) {
-            return Err(SourceError("invalid handshake response".to_string()));
+            return Err(Error::SourceError("invalid handshake response".to_string()));
         }
 
         Ok((read_tx, resp_stream))
@@ -105,7 +104,7 @@ impl SourceReader for UserDefinedSourceRead {
         "user-defined-source"
     }
 
-    async fn read(&mut self) -> error::Result<Vec<Message>> {
+    async fn read(&mut self) -> Result<Vec<Message>> {
         let request = ReadRequest {
             request: Some(read_request::Request {
                 num_records: self.num_records as u64,
@@ -117,7 +116,7 @@ impl SourceReader for UserDefinedSourceRead {
         self.read_tx
             .send(request)
             .await
-            .map_err(|e| SourceError(e.to_string()))?;
+            .map_err(|e| Error::SourceError(e.to_string()))?;
 
         let mut messages = Vec::with_capacity(self.num_records);
 
@@ -128,7 +127,7 @@ impl SourceReader for UserDefinedSourceRead {
 
             let result = response
                 .result
-                .ok_or_else(|| SourceError("Empty message".to_string()))?;
+                .ok_or_else(|| Error::SourceError("Empty message".to_string()))?;
 
             messages.push(result.try_into()?);
         }
@@ -141,7 +140,7 @@ impl SourceReader for UserDefinedSourceRead {
 }
 
 impl UserDefinedSourceAck {
-    async fn new(mut client: SourceClient<Channel>) -> error::Result<Self> {
+    async fn new(mut client: SourceClient<Channel>) -> Result<Self> {
         let (ack_tx, ack_resp_stream) = Self::create_acker(&mut client).await?;
 
         Ok(Self {
@@ -152,7 +151,7 @@ impl UserDefinedSourceAck {
 
     async fn create_acker(
         client: &mut SourceClient<Channel>,
-    ) -> error::Result<(mpsc::Sender<AckRequest>, Streaming<AckResponse>)> {
+    ) -> Result<(mpsc::Sender<AckRequest>, Streaming<AckResponse>)> {
         let (ack_tx, ack_rx) = mpsc::channel(config().batch_size as usize);
         let ack_stream = ReceiverStream::new(ack_rx);
 
@@ -161,21 +160,22 @@ impl UserDefinedSourceAck {
             request: None,
             handshake: Some(source::Handshake { sot: true }),
         };
-        ack_tx
-            .send(ack_handshake_request)
-            .await
-            .map_err(|e| SourceError(format!("failed to send ack handshake request: {}", e)))?;
+        ack_tx.send(ack_handshake_request).await.map_err(|e| {
+            Error::SourceError(format!("failed to send ack handshake request: {}", e))
+        })?;
 
         let mut ack_resp_stream = client.ack_fn(Request::new(ack_stream)).await?.into_inner();
 
         // first response from the server will be the handshake response. We need to check if the
         // server has accepted the handshake.
-        let ack_handshake_response = ack_resp_stream.message().await?.ok_or(SourceError(
+        let ack_handshake_response = ack_resp_stream.message().await?.ok_or(Error::SourceError(
             "failed to receive ack handshake response".to_string(),
         ))?;
         // handshake cannot to None during the initial phase and it has to set `sot` to true.
         if ack_handshake_response.handshake.map_or(true, |h| !h.sot) {
-            return Err(SourceError("invalid ack handshake response".to_string()));
+            return Err(Error::SourceError(
+                "invalid ack handshake response".to_string(),
+            ));
         }
 
         Ok((ack_tx, ack_resp_stream))
@@ -183,7 +183,7 @@ impl UserDefinedSourceAck {
 }
 
 impl SourceAcker for UserDefinedSourceAck {
-    async fn ack(&mut self, offsets: Vec<Offset>) -> error::Result<()> {
+    async fn ack(&mut self, offsets: Vec<Offset>) -> Result<()> {
         let n = offsets.len();
 
         // send n ack requests
@@ -192,7 +192,7 @@ impl SourceAcker for UserDefinedSourceAck {
             self.ack_tx
                 .send(request)
                 .await
-                .map_err(|e| SourceError(e.to_string()))?;
+                .map_err(|e| Error::SourceError(e.to_string()))?;
         }
 
         // make sure we get n responses for the n requests.
@@ -201,7 +201,9 @@ impl SourceAcker for UserDefinedSourceAck {
                 .ack_resp_stream
                 .message()
                 .await?
-                .ok_or(SourceError("failed to receive ack response".to_string()))?;
+                .ok_or(Error::SourceError(
+                    "failed to receive ack response".to_string(),
+                ))?;
         }
 
         Ok(())
@@ -220,7 +222,7 @@ impl UserDefinedSourceLagReader {
 }
 
 impl LagReader for UserDefinedSourceLagReader {
-    async fn pending(&mut self) -> error::Result<Option<usize>> {
+    async fn pending(&mut self) -> Result<Option<usize>> {
         Ok(self
             .source_client
             .pending_fn(Request::new(()))


### PR DESCRIPTION
Fixes the `clippy` warnings for all the variants of the `Error` enum.
```sh
➜  cd rust/numaflow-core
➜  cargo clippy -- --no-deps
warning: variant name ends with the enum's name
 --> numaflow-core/src/error.rs:8:5
  |
8 |     MetricsError(String),
  |     ^^^^^^^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names
  = note: `#[warn(clippy::enum_variant_names)]` on by default
```