### PR TITLE
feat: check if the buffer is full before writing to ISB

### DIFF
--- a/rust/numaflow-core/src/config.rs
+++ b/rust/numaflow-core/src/config.rs
@@ -9,6 +9,7 @@ use bytes::Bytes;
 use crate::Error;
 use numaflow_models::models::{Backoff, MonoVertex, RetryStrategy};
 
+// TODO move constants to a separate module, separate consts for different components
 const DEFAULT_SOURCE_SOCKET: &str = "/var/run/numaflow/source.sock";
 const DEFAULT_SOURCE_SERVER_INFO_FILE: &str = "/var/run/numaflow/sourcer-server-info";
 const DEFAULT_SINK_SOCKET: &str = "/var/run/numaflow/sink.sock";
@@ -30,6 +31,60 @@ const DEFAULT_TIMEOUT_IN_MS: u32 = 1000;
 const DEFAULT_MAX_SINK_RETRY_ATTEMPTS: u16 = u16::MAX;
 const DEFAULT_SINK_RETRY_INTERVAL_IN_MS: u32 = 1;
 const DEFAULT_SINK_RETRY_ON_FAIL_STRATEGY: OnFailureStrategy = OnFailureStrategy::Retry;
+
+/// Jetstream ISB related configurations.
+pub mod jetstream {
+    use std::fmt;
+    use std::time::Duration;
+
+    // jetstream related constants
+    const DEFAULT_PARTITION_IDX: u16 = 0;
+    const DEFAULT_MAX_LENGTH: usize = 30000;
+    const DEFAULT_USAGE_LIMIT: f64 = 0.8;
+    const DEFAULT_REFRESH_INTERVAL_SECS: u64 = 1;
+    const DEFAULT_BUFFER_FULL_STRATEGY: BufferFullStrategy = BufferFullStrategy::RetryUntilSuccess;
+    const DEFAULT_RETRY_TIMEOUT_MILLIS: u64 = 10;
+
+    #[derive(Debug, Clone)]
+    pub(crate) struct StreamWriterConfig {
+        pub name: String,
+        pub partition_idx: u16,
+        pub max_length: usize,
+        pub refresh_interval: Duration,
+        pub usage_limit: f64,
+        pub buffer_full_strategy: BufferFullStrategy,
+        pub retry_timeout: Duration,
+    }
+
+    impl Default for StreamWriterConfig {
+        fn default() -> Self {
+            StreamWriterConfig {
+                name: "default".to_string(),
+                partition_idx: DEFAULT_PARTITION_IDX,
+                max_length: DEFAULT_MAX_LENGTH,
+                usage_limit: DEFAULT_USAGE_LIMIT,
+                refresh_interval: Duration::from_secs(DEFAULT_REFRESH_INTERVAL_SECS),
+                buffer_full_strategy: DEFAULT_BUFFER_FULL_STRATEGY,
+                retry_timeout: Duration::from_millis(DEFAULT_RETRY_TIMEOUT_MILLIS),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Eq, PartialEq)]
+    pub(crate) enum BufferFullStrategy {
+        RetryUntilSuccess,
+        DiscardLatest,
+    }
+
+    impl fmt::Display for BufferFullStrategy {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                BufferFullStrategy::RetryUntilSuccess => write!(f, "retryUntilSuccess"),
+                BufferFullStrategy::DiscardLatest => write!(f, "discardLatest"),
+            }
+        }
+    }
+}
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum OnFailureStrategy {

--- a/rust/numaflow-core/src/pipeline/isb/jetstream.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream.rs
@@ -7,8 +7,11 @@ use tokio::sync::mpsc::Receiver;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
-/// Jetstream Writer is responsible for writing messages to Jetstream ISB.
-/// it exposes both sync and async methods to write messages.
+/// JetStream Writer is responsible for writing messages to JetStream ISB.
+/// it exposes both sync and async methods to write messages. It has gates
+/// to prevent writing into the buffer if the buffer is full. After successful
+/// writes, it will let the callee know the status (or return a non-retryable
+/// exception).
 pub(super) mod writer;
 
 /// ISB Writer accepts an Actor pattern based messages.

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/writer.rs
@@ -1,7 +1,10 @@
+use crate::config::jetstream::StreamWriterConfig;
 use crate::error::Error;
 use crate::Result;
+use async_nats::jetstream::consumer::PullConsumer;
 use async_nats::jetstream::context::PublishAckFuture;
 use async_nats::jetstream::publish::PublishAck;
+use async_nats::jetstream::stream::RetentionPolicy::Limits;
 use async_nats::jetstream::Context;
 use bytes::Bytes;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -18,6 +21,7 @@ use tracing::{debug, warn};
 /// Writes to JetStream ISB. Exposes both write and blocking methods to write messages.
 /// It accepts a cancellation token to stop infinite retries during shutdown.
 pub(super) struct JetstreamWriter {
+    config: StreamWriterConfig,
     js_ctx: Context,
     is_full: Arc<AtomicBool>,
     paf_resolver_tx: mpsc::Sender<ResolveAndPublishResult>,
@@ -27,11 +31,17 @@ pub(super) struct JetstreamWriter {
 impl JetstreamWriter {
     /// Creates a JetStream Writer and a background task to make sure the Write futures (PAFs) are
     /// successful. Batch Size determines the maximum pending futures.
-    pub(super) fn new(js_ctx: Context, batch_size: usize, cancel_token: CancellationToken) -> Self {
+    pub(super) fn new(
+        config: StreamWriterConfig,
+        js_ctx: Context,
+        batch_size: usize,
+        cancel_token: CancellationToken,
+    ) -> Self {
         let (paf_resolver_tx, paf_resolver_rx) =
             mpsc::channel::<ResolveAndPublishResult>(batch_size);
 
         let this = Self {
+            config,
             js_ctx,
             is_full: Arc::new(AtomicBool::new(false)),
             paf_resolver_tx,
@@ -39,11 +49,10 @@ impl JetstreamWriter {
         };
 
         // spawn a task for checking whether buffer is_full
-
         tokio::task::spawn({
             let mut this = this.clone();
             async move {
-                this.get_stream_stats().await;
+                this.check_stream_status().await;
             }
         });
 
@@ -56,19 +65,93 @@ impl JetstreamWriter {
         this
     }
 
-    async fn get_stream_stats(&mut self) {
-        self.is_full.store(true, Ordering::Relaxed);
+    /*
+     * Checks the buffer usage metrics (soft and solid usage) for a given stream.
+     * If the usage is greater than the bufferUsageLimit, it sets the is_full flag to true.
+     */
+    async fn check_stream_status(&mut self) {
+        let mut interval = tokio::time::interval(self.config.refresh_interval);
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    match Self::fetch_buffer_usage(self.js_ctx.clone(), self.config.name.as_str(), self.config.max_length).await {
+                        Ok((soft_usage, solid_usage)) => {
+                            if solid_usage >= self.config.usage_limit && soft_usage >= self.config.usage_limit {
+                                self.is_full.store(true, Ordering::Relaxed);
+                            } else {
+                                self.is_full.store(false, Ordering::Relaxed);
+                            }
+                        }
+                        Err(e) => {
+                            error!(?e, "Failed to fetch buffer usage, updating isFull to true");
+                            self.is_full.store(true, Ordering::Relaxed);
+                        }
+                    }
+                }
+                _ = self.cancel_token.cancelled() => {
+                    return;
+                }
+            }
+        }
+    }
+
+    /*
+     * Fetches the buffer usage metrics (soft and solid usage) for a given stream.
+     *
+     * Soft Usage:
+     * Formula: (NumPending + NumAckPending) / maxLength
+     * - NumPending: The number of pending messages.
+     * - NumAckPending: The number of messages that are in processing state(yet to be acked).
+     * - maxLength: The maximum length of the buffer.
+     *
+     * Solid Usage:
+     * Formula:
+     * - If the stream's retention policy is LimitsPolicy: solidUsage = softUsage
+     * - Otherwise: solidUsage = State.Msgs / maxLength
+     * - State.Msgs: The total number of messages in the stream.
+     * - maxLength: The maximum length of the buffer.
+     *
+     */
+    async fn fetch_buffer_usage(
+        js_ctx: Context,
+        stream_name: &str,
+        max_length: usize,
+    ) -> Result<(f64, f64)> {
+        let mut stream = js_ctx
+            .get_stream(stream_name)
+            .await
+            .map_err(|_| Error::ISB("Failed to get stream".to_string()))?;
+
+        let stream_info = stream
+            .info()
+            .await
+            .map_err(|e| Error::ISB(format!("Failed to get the stream info {:?}", e)))?;
+
+        let mut consumer: PullConsumer = js_ctx
+            .get_consumer_from_stream(stream_name, stream_name)
+            .await
+            .map_err(|e| Error::ISB(format!("Failed to get the consumer {:?}", e)))?;
+
+        let consumer_info = consumer
+            .info()
+            .await
+            .map_err(|e| Error::ISB(format!("Failed to get the consumer info {:?}", e)))?;
+
+        let soft_usage = (consumer_info.num_pending as f64 + consumer_info.num_ack_pending as f64)
+            / max_length as f64;
+        let solid_usage = if stream_info.config.retention == Limits {
+            soft_usage
+        } else {
+            stream_info.state.messages as f64 / max_length as f64
+        };
+
+        Ok((soft_usage, solid_usage))
     }
 
     /// Writes the message to the JetStream ISB and returns a future which can be
     /// awaited to get the PublishAck. It will do infinite retries until the message
     /// gets published successfully. If it returns an error it means it is fatal error
-    pub(super) async fn write(
-        &self,
-        stream: &'static str,
-        payload: Vec<u8>,
-        callee_tx: oneshot::Sender<Result<u64>>,
-    ) {
+    pub(super) async fn write(&self, payload: Vec<u8>, callee_tx: oneshot::Sender<Result<u64>>) {
         let js_ctx = self.js_ctx.clone();
 
         // loop till we get a PAF, there could be other reasons why PAFs cannot be created.
@@ -77,9 +160,12 @@ impl JetstreamWriter {
             match self.is_full.load(Ordering::Relaxed) {
                 true => {
                     // FIXME: add metrics
-                    debug!(%stream, "buffer is full");
+                    debug!(%self.config.name, "buffer is full");
                 }
-                false => match js_ctx.publish(stream, Bytes::from(payload.clone())).await {
+                false => match js_ctx
+                    .publish(self.config.name.clone(), Bytes::from(payload.clone()))
+                    .await
+                {
                     Ok(paf) => {
                         break paf;
                     }
@@ -106,7 +192,6 @@ impl JetstreamWriter {
         self.paf_resolver_tx
             .send(ResolveAndPublishResult {
                 paf,
-                stream,
                 payload,
                 callee_tx,
             })
@@ -117,15 +202,14 @@ impl JetstreamWriter {
     /// Writes the message to the JetStream ISB and returns the PublishAck. It will do
     /// infinite retries until the message gets published successfully. If it returns
     /// an error it means it is fatal non-retryable error.
-    pub(super) async fn blocking_write(
-        &self,
-        stream: &'static str,
-        payload: Vec<u8>,
-    ) -> Result<PublishAck> {
+    pub(super) async fn blocking_write(&self, payload: Vec<u8>) -> Result<PublishAck> {
         let js_ctx = self.js_ctx.clone();
 
         loop {
-            match js_ctx.publish(stream, Bytes::from(payload.clone())).await {
+            match js_ctx
+                .publish(self.config.name.clone(), Bytes::from(payload.clone()))
+                .await
+            {
                 Ok(paf) => match paf.await {
                     Ok(ack) => {
                         if ack.duplicate {
@@ -137,12 +221,12 @@ impl JetstreamWriter {
                         return Ok(ack);
                     }
                     Err(e) => {
-                        error!("awaiting publish ack failed, retrying: {}", e);
+                        error!(?e, "awaiting publish ack failed, retrying");
                         sleep(Duration::from_millis(10)).await;
                     }
                 },
                 Err(e) => {
-                    error!("publishing failed, retrying: {}", e);
+                    error!(?e, "publishing failed, retrying");
                     sleep(Duration::from_millis(10)).await;
                 }
             }
@@ -159,7 +243,6 @@ impl JetstreamWriter {
 #[derive(Debug)]
 pub(super) struct ResolveAndPublishResult {
     paf: PublishAckFuture,
-    stream: &'static str,
     payload: Vec<u8>,
     callee_tx: oneshot::Sender<Result<u64>>,
 }
@@ -188,11 +271,7 @@ impl PafResolverActor {
             Ok(ack) => result.callee_tx.send(Ok(ack.sequence)).unwrap(),
             Err(e) => {
                 error!(?e, "Failed to resolve the future, trying blocking write");
-                match self
-                    .js_writer
-                    .blocking_write(result.stream, result.payload.clone())
-                    .await
-                {
+                match self.js_writer.blocking_write(result.payload.clone()).await {
                     Ok(ack) => result.callee_tx.send(Ok(ack.sequence)).unwrap(),
                     Err(e) => result.callee_tx.send(Err(e)).unwrap(),
                 }
@@ -235,7 +314,12 @@ mod tests {
             .await
             .unwrap();
 
-        let writer = JetstreamWriter::new(context.clone(), 500, cln_token.clone());
+        let config = StreamWriterConfig {
+            name: stream_name.into(),
+            ..Default::default()
+        };
+
+        let writer = JetstreamWriter::new(config, context.clone(), 500, cln_token.clone());
 
         let message = Message {
             keys: vec!["key_0".to_string()],
@@ -254,9 +338,7 @@ mod tests {
         };
 
         let (success_tx, success_rx) = oneshot::channel::<Result<u64>>();
-        writer
-            .write(stream_name, message.try_into().unwrap(), success_tx)
-            .await;
+        writer.write(message.try_into().unwrap(), success_tx).await;
         assert!(success_rx.await.is_ok());
 
         context.delete_stream(stream_name).await.unwrap();
@@ -281,7 +363,12 @@ mod tests {
             .await
             .unwrap();
 
-        let writer = JetstreamWriter::new(context.clone(), 500, cln_token.clone());
+        let config = StreamWriterConfig {
+            name: stream_name.into(),
+            ..Default::default()
+        };
+
+        let writer = JetstreamWriter::new(config, context.clone(), 500, cln_token.clone());
 
         let message = Message {
             keys: vec!["key_0".to_string()],
@@ -299,9 +386,7 @@ mod tests {
             headers: HashMap::new(),
         };
 
-        let result = writer
-            .blocking_write(stream_name, message.try_into().unwrap())
-            .await;
+        let result = writer.blocking_write(message.try_into().unwrap()).await;
         assert!(result.is_ok());
 
         let publish_ack = result.unwrap();
@@ -329,8 +414,13 @@ mod tests {
             .await
             .unwrap();
 
+        let config = StreamWriterConfig {
+            name: stream_name.into(),
+            ..Default::default()
+        };
+
         let cancel_token = CancellationToken::new();
-        let writer = JetstreamWriter::new(context.clone(), 500, cancel_token.clone());
+        let writer = JetstreamWriter::new(config, context.clone(), 500, cancel_token.clone());
 
         let mut result_receivers = Vec::new();
         // Publish 10 messages successfully
@@ -351,9 +441,7 @@ mod tests {
                 headers: HashMap::new(),
             };
             let (success_tx, success_rx) = oneshot::channel::<Result<u64>>();
-            writer
-                .write(stream_name, message.try_into().unwrap(), success_tx)
-                .await;
+            writer.write(message.try_into().unwrap(), success_tx).await;
             result_receivers.push(success_rx);
         }
 
@@ -375,9 +463,7 @@ mod tests {
             headers: HashMap::new(),
         };
         let (success_tx, success_rx) = oneshot::channel::<Result<u64>>();
-        writer
-            .write(stream_name, message.try_into().unwrap(), success_tx)
-            .await;
+        writer.write(message.try_into().unwrap(), success_tx).await;
         result_receivers.push(success_rx);
 
         // Cancel the token to exit the retry loop


### PR DESCRIPTION
* Introduced stream writer configuration.
* Made the writer a one-to-one mapping with the stream, as it spawns a task to check if the buffer is full, and this task checks for a specific stream.
* Added support to check if the buffer is full before invoking writes to the ISB.

TODO: 
* unit tests