### PR TITLE
fix: refine vertex/mvtx pod clean up logic

### DIFF
--- a/pkg/reconciler/monovertex/controller.go
+++ b/pkg/reconciler/monovertex/controller.go
@@ -204,7 +204,7 @@ func (mr *monoVertexReconciler) orchestratePods(ctx context.Context, monoVtx *df
 
 	// Manually or automatically scaled down, in this case, we need to clean up extra pods if there's any
 	if err := mr.cleanUpPodsFromTo(ctx, monoVtx, desiredReplicas, math.MaxInt); err != nil {
-		return fmt.Errorf("failed to clean up mono vertex pods [%v, ): %w", desiredReplicas, err)
+		return fmt.Errorf("failed to clean up mono vertex pods [%v, ∞): %w", desiredReplicas, err)
 	}
 	if currentReplicas := int(monoVtx.Status.Replicas); currentReplicas > desiredReplicas {
 		monoVtx.Status.Replicas = uint32(desiredReplicas)

--- a/pkg/reconciler/vertex/controller.go
+++ b/pkg/reconciler/vertex/controller.go
@@ -218,7 +218,7 @@ func (r *vertexReconciler) orchestratePods(ctx context.Context, vertex *dfv1.Ver
 
 	// Manually or automatically scaled down, in this case, we need to clean up extra pods if there's any
 	if err := r.cleanUpPodsFromTo(ctx, vertex, desiredReplicas, math.MaxInt); err != nil {
-		return fmt.Errorf("failed to clean up vertex pods [%v, ): %w", desiredReplicas, err)
+		return fmt.Errorf("failed to clean up vertex pods [%v, ∞): %w", desiredReplicas, err)
 	}
 	if currentReplicas := int(vertex.Status.Replicas); currentReplicas > desiredReplicas {
 		vertex.Status.Replicas = uint32(desiredReplicas)


### PR DESCRIPTION
In some edged cases, e.g. the scaling operations on vertex/mvtx are too frequent (multiple times in 1 second, not caused by human, but some other issue like [this](https://github.com/numaproj/numaplane/issues/353)), the controller can not catch up with each change, and then it can end up with uncleaned up pods running (e.g. the mvtx only has 1 replica, but there are extra pods 3 and 4 running).

This PR fixes the problem.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
