### PR TITLE
fix(docs): use manifests from main branch in quick-start

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -28,8 +28,8 @@ Once you have completed all the prerequisites, run the following command lines t
 
 ```shell
 kubectl create ns numaflow-system
-kubectl apply -n numaflow-system -f https://raw.githubusercontent.com/numaproj/numaflow/stable/config/install.yaml
-kubectl apply -f https://raw.githubusercontent.com/numaproj/numaflow/stable/examples/0-isbsvc-jetstream.yaml
+kubectl apply -n numaflow-system -f https://raw.githubusercontent.com/numaproj/numaflow/main/config/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/numaproj/numaflow/main/examples/0-isbsvc-jetstream.yaml
 ```
 
 ## Creating a simple pipeline
@@ -39,7 +39,7 @@ As an example, we will create a `simple pipeline` that contains a source vertex 
 Run the command below to create a simple pipeline.
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/numaproj/numaflow/stable/examples/1-simple-pipeline.yaml
+kubectl apply -f https://raw.githubusercontent.com/numaproj/numaflow/main/examples/1-simple-pipeline.yaml
 ```
 
 To view a list of pipelines you've created, run:
@@ -92,14 +92,13 @@ This should generate an output like the sample below:
 2022/08/25 23:59:39 (out) {"Data":"jk4nN/a7Dhc=","Createdts":1661471978707963534}
 ```
 
-
 Numaflow also comes with a built-in user interface.
 
-**NOTE**: Please install the metrics server if your local Kubernetes cluster does not bring it by default (e.g., Kind). 
+**NOTE**: Please install the metrics server if your local Kubernetes cluster does not bring it by default (e.g., Kind).
 You can install it by running the below command.
 
 ```shell
-kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml 
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 kubectl patch -n kube-system deployment metrics-server --type=json -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
 ```
 
@@ -117,7 +116,7 @@ This renders the following UI on https://localhost:8443/.
 The pipeline can be deleted by issuing the following command:
 
 ```shell
-kubectl delete -f https://raw.githubusercontent.com/numaproj/numaflow/stable/examples/1-simple-pipeline.yaml
+kubectl delete -f https://raw.githubusercontent.com/numaproj/numaflow/main/examples/1-simple-pipeline.yaml
 ```
 
 ## Creating an advanced pipeline


### PR DESCRIPTION
`even-odd` example in quick-start is broken due to the gRPC protocol change.

Switch to using `main` branch manifests for installation and quick-start examples, which should be always working.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
