### PR TITLE
chore: Load docker image from buildx runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ build-rust-in-docker:
 	mkdir -p dist
 	-$(DOCKER) container ls --all --filter=ancestor='$(IMAGE_NAMESPACE)/$(BINARY_NAME)-rust-builder:$(VERSION)' --format "{{.ID}}" | xargs $(DOCKER) rm
 	-$(DOCKER) image rm $(IMAGE_NAMESPACE)/$(BINARY_NAME)-rust-builder:$(VERSION)
-	DOCKER_BUILDKIT=1 $(DOCKER) build --build-arg "BASE_IMAGE=$(DEV_BASE_IMAGE)" $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAMESPACE)/$(BINARY_NAME)-rust-builder:$(VERSION) --target rust-builder -f $(DOCKERFILE) .
+	DOCKER_BUILDKIT=1 $(DOCKER) build --build-arg "BASE_IMAGE=$(DEV_BASE_IMAGE)" $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAMESPACE)/$(BINARY_NAME)-rust-builder:$(VERSION) --target rust-builder -f $(DOCKERFILE) . --load
 	export CTR=$$($(DOCKER) create $(IMAGE_NAMESPACE)/$(BINARY_NAME)-rust-builder:$(VERSION)) && $(DOCKER) cp $$CTR:/root/numaflow dist/numaflow-rs-linux-$(HOST_ARCH) && $(DOCKER) rm $$CTR && $(DOCKER) image rm $(IMAGE_NAMESPACE)/$(BINARY_NAME)-rust-builder:$(VERSION)
 
 .PHONY: build-rust-in-docker-multi


### PR DESCRIPTION
To build multi-platform images, developers may have enabled parallel multi-platform builder using buildx on their laptop. In such cases, the `build-rust-in-docker` stage that is part of the `make start` fails. The `build-rust-in-docker` tries to create a container to copy the binary from the image to host machine. Since the image was built inside the buildx runner, this container creation fails. The `--load` flag should load the image from buildx runner so that container creation will not fail. Also, this flag is ignored if the image build happens natively (without multi-platform buildx runner).
