### PR TITLE
fix: honor lookbackSeconds for mvtx

### DIFF
--- a/pkg/apis/numaflow/v1alpha1/mono_vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/mono_vertex_types.go
@@ -318,7 +318,7 @@ func (mv MonoVertex) simpleCopy() MonoVertex {
 
 func (mv MonoVertex) GetPodSpec(req GetMonoVertexPodSpecReq) (*corev1.PodSpec, error) {
 	copiedSpec := mv.simpleCopy()
-	copiedSpec.Spec.Scale = Scale{}
+	copiedSpec.Spec.Scale = Scale{LookbackSeconds: mv.Spec.Scale.LookbackSeconds}
 	monoVtxBytes, err := json.Marshal(copiedSpec)
 	if err != nil {
 		return nil, errors.New("failed to marshal mono vertex spec")

--- a/rust/numaflow-core/src/config.rs
+++ b/rust/numaflow-core/src/config.rs
@@ -45,7 +45,6 @@ pub(crate) struct Settings {
 /// LookbackStruct is a struct to hold the lookback window map for the monovertex/pipeline.
 #[derive(Default)]
 pub(crate) struct LookbackStruct {
-    // It is okay to use std mutex because we register each metric only one time.
     window_map: parking_lot::Mutex<[(&'static str, i64); 4]>,
 }
 

--- a/rust/numaflow-core/src/config.rs
+++ b/rust/numaflow-core/src/config.rs
@@ -1,14 +1,9 @@
-use futures::future::Lazy;
-use log::info;
-use monovertex::MonovertexConfig;
-use parking_lot::lock_api::MutexGuard;
-use parking_lot::RawMutex;
-use prometheus_client::registry::Registry;
 use std::env;
-use std::sync::{Mutex, OnceLock};
+use std::sync::OnceLock;
+
+use monovertex::MonovertexConfig;
 
 use crate::config::pipeline::PipelineConfig;
-use crate::metrics::GlobalMetrics;
 use crate::Error;
 use crate::Result;
 

--- a/rust/numaflow-core/src/config/monovertex.rs
+++ b/rust/numaflow-core/src/config/monovertex.rs
@@ -1,18 +1,18 @@
 use std::time::Duration;
 
-use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
 use serde_json::from_slice;
 
 use numaflow_models::models::MonoVertex;
 
-use crate::config::components::{sink, source};
 use crate::config::components::metrics::MetricsConfig;
 use crate::config::components::sink::SinkConfig;
 use crate::config::components::source::{GeneratorConfig, SourceConfig};
 use crate::config::components::transformer::{
     TransformerConfig, TransformerType, UserDefinedConfig,
 };
+use crate::config::components::{sink, source};
 use crate::error::Error;
 use crate::message::get_vertex_replica;
 use crate::Result;
@@ -155,8 +155,8 @@ impl MonovertexConfig {
 
 #[cfg(test)]
 mod tests {
-    use base64::Engine;
     use base64::prelude::BASE64_STANDARD;
+    use base64::Engine;
 
     use crate::config::components::sink::SinkType;
     use crate::config::components::source::SourceType;

--- a/rust/numaflow-core/src/config/monovertex.rs
+++ b/rust/numaflow-core/src/config/monovertex.rs
@@ -1,20 +1,21 @@
 use std::time::Duration;
 
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
+use serde_json::from_slice;
+
+use numaflow_models::models::MonoVertex;
+
+use crate::config::components::{sink, source};
 use crate::config::components::metrics::MetricsConfig;
 use crate::config::components::sink::SinkConfig;
 use crate::config::components::source::{GeneratorConfig, SourceConfig};
 use crate::config::components::transformer::{
     TransformerConfig, TransformerType, UserDefinedConfig,
 };
-use crate::config::components::{sink, source};
 use crate::error::Error;
 use crate::message::get_vertex_replica;
 use crate::Result;
-use base64::prelude::BASE64_STANDARD;
-use base64::Engine;
-use numaflow_models::models::MonoVertex;
-use serde_json::from_slice;
-use tracing::info;
 
 const DEFAULT_BATCH_SIZE: u64 = 500;
 const DEFAULT_TIMEOUT_IN_MS: u32 = 1000;
@@ -130,15 +131,12 @@ impl MonovertexConfig {
             None
         };
 
-        info!("MONOBERT: {:?}", mono_vertex_obj);
-
         let look_back_window = mono_vertex_obj
             .spec
             .scale
             .as_ref()
             .and_then(|scale| scale.lookback_seconds.map(|x| x as i64))
             .unwrap_or(DEFAULT_LOOKBACK_SECONDS);
-        info!("Lookback window: {:?}", look_back_window);
 
         Ok(MonovertexConfig {
             name: mono_vertex_name,
@@ -157,14 +155,15 @@ impl MonovertexConfig {
 
 #[cfg(test)]
 mod tests {
-    use base64::prelude::BASE64_STANDARD;
     use base64::Engine;
+    use base64::prelude::BASE64_STANDARD;
 
     use crate::config::components::sink::SinkType;
     use crate::config::components::source::SourceType;
     use crate::config::components::transformer::TransformerType;
     use crate::config::monovertex::MonovertexConfig;
     use crate::error::Error;
+
     #[test]
     fn test_load_valid_config() {
         let valid_config = r#"

--- a/rust/numaflow-core/src/metrics.rs
+++ b/rust/numaflow-core/src/metrics.rs
@@ -759,7 +759,6 @@ async fn expose_pending_metrics(
                     .get_or_create(&metric_labels)
                     .set(pending);
             }
-            info!("MYDEBUG LOOKBACK {} {}", label, seconds);
         }
         // skip for those the pending is not implemented
         if !pending_info.is_empty() {

--- a/rust/numaflow-core/src/metrics.rs
+++ b/rust/numaflow-core/src/metrics.rs
@@ -4,18 +4,12 @@ use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-use crate::config::{config, lookback_window_map};
-use crate::source::SourceHandle;
-use crate::Error;
 use axum::body::Body;
 use axum::extract::State;
 use axum::http::{Response, StatusCode};
 use axum::response::IntoResponse;
 use axum::{routing::get, Router};
 use axum_server::tls_rustls::RustlsConfig;
-use numaflow_pb::clients::sink::sink_client::SinkClient;
-use numaflow_pb::clients::source::source_client::SourceClient;
-use numaflow_pb::clients::sourcetransformer::source_transform_client::SourceTransformClient;
 use prometheus_client::encoding::text::encode;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
@@ -29,6 +23,14 @@ use tokio::time;
 use tonic::transport::Channel;
 use tonic::Request;
 use tracing::{debug, error, info};
+
+use numaflow_pb::clients::sink::sink_client::SinkClient;
+use numaflow_pb::clients::source::source_client::SourceClient;
+use numaflow_pb::clients::sourcetransformer::source_transform_client::SourceTransformClient;
+
+use crate::config::lookback_window_map;
+use crate::source::SourceHandle;
+use crate::Error;
 
 pub const COMPONENT_MVTX: &str = "mono-vertex";
 
@@ -800,12 +802,13 @@ mod tests {
     use std::net::SocketAddr;
     use std::time::Instant;
 
-    use super::*;
-    use crate::config::LookbackStruct;
-    use crate::shared::utils::create_rpc_channel;
     use numaflow::source::{Message, Offset, SourceReadRequest};
     use numaflow::{sink, source, sourcetransform};
     use tokio::sync::mpsc::Sender;
+
+    use crate::shared::utils::create_rpc_channel;
+
+    use super::*;
 
     struct SimpleSource;
     #[tonic::async_trait]

--- a/rust/numaflow-core/src/pipeline.rs
+++ b/rust/numaflow-core/src/pipeline.rs
@@ -430,6 +430,7 @@ mod tests {
                 lag_check_interval_in_secs: 5,
                 lag_refresh_interval_in_secs: 3,
             },
+            lookback_seconds: 120,
         };
 
         let cancellation_token = tokio_util::sync::CancellationToken::new();
@@ -585,6 +586,7 @@ mod tests {
                 lag_check_interval_in_secs: 5,
                 lag_refresh_interval_in_secs: 3,
             },
+            lookback_seconds: 120,
         };
 
         let cancellation_token = tokio_util::sync::CancellationToken::new();


### PR DESCRIPTION
Currently for monovertex if the lookbackSeconds is specified in the spec, the metric lag reader does not honor that value and keeps using default 
```
metadata:
  name: simple-mono-vertex
spec:
  scale:
    lookbackSeconds: 100
```

```
2024-11-20T23:39:37.561609Z  INFO numaflow_core::monovertex::forwarder: Forwarded 26200 messages at time 2024-11-20 23:39:37.561606851 UTC
2024-11-20T23:39:38.568245Z  INFO numaflow_core::monovertex::forwarder: Forwarded 25600 messages at time 2024-11-20 23:39:38.568242351 UTC
2024-11-20T23:39:39.535464Z  INFO numaflow_core::metrics: MYDEBUG LOOKBACK 1m 60
2024-11-20T23:39:39.535513Z  INFO numaflow_core::metrics: MYDEBUG LOOKBACK default 120
```


With this fix it should update the value based on the config 

```
"uds", language: "rust", minimum_numaflow_version: "1.3.1-z", version: "0.1.1", metadata: Some({}) }
2024-11-20T23:12:56.429612Z  INFO numaflow_core::shared::server_info: Server info file: ServerInfo { protocol: "uds", language: "rust", minimum_numaflow_version: "1.3.1-z", version: "0.1.1", metadata: Some({}) }
2024-11-20T23:12:56.469090Z  INFO numaflow_core::metrics: MYDEBUG LOOKBACK 1m 60
2024-11-20T23:12:56.469104Z  INFO numaflow_core::metrics: MYDEBUG LOOKBACK default 100
```