### PR TITLE
feat: counter metrics visualizer for pipeline

### DIFF
--- a/config/advanced-install/namespaced-numaflow-server.yaml
+++ b/config/advanced-install/namespaced-numaflow-server.yaml
@@ -137,7 +137,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  config.yaml: |
+  config.yaml: |-
     # url is a required field, it should be the url of the service to which the metrics proxy will connect
     # url: service_name + "." + service_namespace + ".svc.cluster.local" + ":" + port
     # example for local prometheus service
@@ -186,6 +186,32 @@ data:
         #          required: false
         #    - name: mono-vertex
         #      #expr: optional
+    - name: pipeline_counter_metrics
+      object: vertex
+      title: Rate of Change of metrics
+      description: This pattern is to calculate rate of change of counter metrics
+      expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
+      params:
+        - name: duration
+          required: true
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: forwarder_data_read_total
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+            - name: pod
+              filters:
+                - name: pod
+                  required: false
 kind: ConfigMap
 metadata:
   name: numaflow-server-metrics-proxy-config

--- a/config/advanced-install/namespaced-numaflow-server.yaml
+++ b/config/advanced-install/namespaced-numaflow-server.yaml
@@ -186,10 +186,10 @@ data:
         #          required: false
         #    - name: mono-vertex
         #      #expr: optional
-    - name: pipeline_counter_metrics
+    - name: vertex_throughput
       object: vertex
-      title: Rate of Change of metrics
-      description: This pattern is to calculate rate of change of counter metrics
+      title: Vertex Throughput and Message Rates
+      description: This pattern measures the throughput of a vertex in messages per second across different dimensions
       expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
       params:
         - name: duration

--- a/config/advanced-install/numaflow-server.yaml
+++ b/config/advanced-install/numaflow-server.yaml
@@ -144,7 +144,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  config.yaml: |
+  config.yaml: |-
     # url is a required field, it should be the url of the service to which the metrics proxy will connect
     # url: service_name + "." + service_namespace + ".svc.cluster.local" + ":" + port
     # example for local prometheus service
@@ -193,6 +193,32 @@ data:
         #          required: false
         #    - name: mono-vertex
         #      #expr: optional
+    - name: pipeline_counter_metrics
+      object: vertex
+      title: Rate of Change of metrics
+      description: This pattern is to calculate rate of change of counter metrics
+      expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
+      params:
+        - name: duration
+          required: true
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: forwarder_data_read_total
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+            - name: pod
+              filters:
+                - name: pod
+                  required: false
 kind: ConfigMap
 metadata:
   name: numaflow-server-metrics-proxy-config

--- a/config/advanced-install/numaflow-server.yaml
+++ b/config/advanced-install/numaflow-server.yaml
@@ -193,10 +193,10 @@ data:
         #          required: false
         #    - name: mono-vertex
         #      #expr: optional
-    - name: pipeline_counter_metrics
+    - name: vertex_throughput
       object: vertex
-      title: Rate of Change of metrics
-      description: This pattern is to calculate rate of change of counter metrics
+      title: Vertex Throughput and Message Rates
+      description: This pattern measures the throughput of a vertex in messages per second across different dimensions
       expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
       params:
         - name: duration

--- a/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
+++ b/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
@@ -52,10 +52,10 @@ data:
         #          required: false
         #    - name: mono-vertex
         #      #expr: optional
-    - name: pipeline_counter_metrics
+    - name: vertex_throughput
       object: vertex
-      title: Rate of Change of metrics
-      description: This pattern is to calculate rate of change of counter metrics
+      title: Vertex Throughput and Message Rates
+      description: This pattern measures the throughput of a vertex in messages per second across different dimensions
       expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
       params:
         - name: duration

--- a/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
+++ b/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
@@ -52,3 +52,29 @@ data:
         #          required: false
         #    - name: mono-vertex
         #      #expr: optional
+    - name: pipeline_counter_metrics
+      object: vertex
+      title: Rate of Change of metrics
+      description: This pattern is to calculate rate of change of counter metrics
+      expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
+      params:
+        - name: duration
+          required: true
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: forwarder_data_read_total
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+            - name: pod
+              filters:
+                - name: pod
+                  required: false

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -28501,10 +28501,10 @@ data:
         #          required: false
         #    - name: mono-vertex
         #      #expr: optional
-    - name: pipeline_counter_metrics
+    - name: vertex_throughput
       object: vertex
-      title: Rate of Change of metrics
-      description: This pattern is to calculate rate of change of counter metrics
+      title: Vertex Throughput and Message Rates
+      description: This pattern measures the throughput of a vertex in messages per second across different dimensions
       expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
       params:
         - name: duration

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -28452,7 +28452,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  config.yaml: |
+  config.yaml: |-
     # url is a required field, it should be the url of the service to which the metrics proxy will connect
     # url: service_name + "." + service_namespace + ".svc.cluster.local" + ":" + port
     # example for local prometheus service
@@ -28501,6 +28501,32 @@ data:
         #          required: false
         #    - name: mono-vertex
         #      #expr: optional
+    - name: pipeline_counter_metrics
+      object: vertex
+      title: Rate of Change of metrics
+      description: This pattern is to calculate rate of change of counter metrics
+      expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
+      params:
+        - name: duration
+          required: true
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: forwarder_data_read_total
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+            - name: pod
+              filters:
+                - name: pod
+                  required: false
 kind: ConfigMap
 metadata:
   name: numaflow-server-metrics-proxy-config

--- a/config/namespace-install.yaml
+++ b/config/namespace-install.yaml
@@ -28340,7 +28340,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  config.yaml: |
+  config.yaml: |-
     # url is a required field, it should be the url of the service to which the metrics proxy will connect
     # url: service_name + "." + service_namespace + ".svc.cluster.local" + ":" + port
     # example for local prometheus service
@@ -28389,6 +28389,32 @@ data:
         #          required: false
         #    - name: mono-vertex
         #      #expr: optional
+    - name: pipeline_counter_metrics
+      object: vertex
+      title: Rate of Change of metrics
+      description: This pattern is to calculate rate of change of counter metrics
+      expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
+      params:
+        - name: duration
+          required: true
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: forwarder_data_read_total
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+            - name: pod
+              filters:
+                - name: pod
+                  required: false
 kind: ConfigMap
 metadata:
   name: numaflow-server-metrics-proxy-config

--- a/config/namespace-install.yaml
+++ b/config/namespace-install.yaml
@@ -28389,10 +28389,10 @@ data:
         #          required: false
         #    - name: mono-vertex
         #      #expr: optional
-    - name: pipeline_counter_metrics
+    - name: vertex_throughput
       object: vertex
-      title: Rate of Change of metrics
-      description: This pattern is to calculate rate of change of counter metrics
+      title: Vertex Throughput and Message Rates
+      description: This pattern measures the throughput of a vertex in messages per second across different dimensions
       expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
       params:
         - name: duration

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/index.tsx
@@ -201,6 +201,7 @@ export function Pods(props: PodsProps) {
           containerName={selectedContainer}
           pod={selectedPod}
           podDetails={selectedPodDetails}
+          vertexId={vertexId}
         />
       </Box>
     );

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/index.tsx
@@ -26,6 +26,7 @@ export function PodDetail({
   type,
   containerName,
   pod,
+  vertexId
 }: PodDetailProps) {
   if (!pod) return null;
 
@@ -59,7 +60,7 @@ export function PodDetail({
           label="Logs"
           data-testid="logs-tab"
         />
-        {!disableMetricsCharts && type === "monoVertex" && (
+        {!disableMetricsCharts && (
           <Tab
             className={
               selectedTab === METRICS_TAB_INDEX
@@ -94,7 +95,7 @@ export function PodDetail({
           </Box>
         )}
       </div>
-      {!disableMetricsCharts && type === "monoVertex" && (
+      {!disableMetricsCharts && (
         <div
           className="vertex-details-tab-panel"
           role="tabpanel"
@@ -112,6 +113,7 @@ export function PodDetail({
                 namespaceId={namespaceId}
                 pipelineId={pipelineId}
                 type={type}
+                vertexId={vertexId}
               />
             </Box>
           )}

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/index.tsx
@@ -17,7 +17,7 @@ export interface MetricsProps {
   vertexId?: string;
 }
 
-export function Metrics({ namespaceId, pipelineId, type }: MetricsProps) {
+export function Metrics({ namespaceId, pipelineId, type, vertexId }: MetricsProps) {
   const {
     metricsDiscoveryData: discoveredMetrics,
     error: discoveredMetricsError,
@@ -88,6 +88,7 @@ export function Metrics({ namespaceId, pipelineId, type }: MetricsProps) {
                   pipelineId={pipelineId}
                   type={type}
                   metric={metric}
+                  vertexId={vertexId}
                 />
               )}
             </AccordionDetails>

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
@@ -28,6 +28,7 @@ const LineChartComponent = ({ namespaceId, pipelineId, type, metric, vertexId }:
   // store all filters for each selected dimension
   const [filtersList, setFiltersList] = useState<any[]>([]);
   const [filters, setFilters] = useState<any>({});
+  const [previousDimension, setPreviousDimension] = useState(metricsReq?.dimension);
 
   const getRandomColor = useCallback((index: number) => {
     const hue = (index * 137.508) % 360;
@@ -75,9 +76,11 @@ const LineChartComponent = ({ namespaceId, pipelineId, type, metric, vertexId }:
     setFilters(newFilters);
   }, [filtersList, getFilterValue, setFilters]);
 
+  //update filters only when dimension changes in metricsReq
   useEffect(() => {
-    if (metricsReq?.dimension) {
+    if (metricsReq?.dimension !== previousDimension) {
       updateFilterList(metricsReq.dimension);
+      setPreviousDimension(metricsReq?.dimension);
     }
   }, [metricsReq, updateFilterList]);
 

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
@@ -18,7 +18,7 @@ import EmptyChart from "../EmptyChart";
 import { useMetricsFetch } from "../../../../../../../../../../../../../../../utils/fetchWrappers/metricsFetch";
 
 // TODO have a check for metricReq against metric object to ensure required fields are passed
-const LineChartComponent = ({ namespaceId, pipelineId, type, metric }: any) => {
+const LineChartComponent = ({ namespaceId, pipelineId, type, metric, vertexId }: any) => {
   const [transformedData, setTransformedData] = useState<any[]>([]);
   const [chartLabels, setChartLabels] = useState<any[]>([]);
   const [metricsReq, setMetricsReq] = useState<any>({
@@ -42,6 +42,8 @@ const LineChartComponent = ({ namespaceId, pipelineId, type, metric }: any) => {
         case "mvtx_name":
         case "pipeline":
           return pipelineId;
+        case "vertex":
+          return vertexId;
         default:
           return "";
       }
@@ -91,7 +93,7 @@ const LineChartComponent = ({ namespaceId, pipelineId, type, metric }: any) => {
         name: param?.Name,
         required: param?.Required,
       })) || [];
-
+    
     setParamsList([...initParams, ...newParams]);
   }, [metric, setParamsList]);
 
@@ -214,6 +216,7 @@ const LineChartComponent = ({ namespaceId, pipelineId, type, metric }: any) => {
             namespaceId={namespaceId}
             pipelineId={pipelineId}
             type={type}
+            vertexId={vertexId}
             setFilters={setFilters}
           />
         </Box>

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/common/FiltersDropdown/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/common/FiltersDropdown/index.tsx
@@ -25,6 +25,7 @@ export interface FiltersDropdownProps {
   namespaceId: string;
   pipelineId: string;
   type: string;
+  vertexId?: string;
   setFilters: any;
 }
 
@@ -33,6 +34,7 @@ const FiltersDropdown = ({
   namespaceId,
   pipelineId,
   type,
+  vertexId,
   setFilters,
 }: FiltersDropdownProps) => {
   const { host } = useContext<AppContextProps>(AppContext);
@@ -62,8 +64,8 @@ const FiltersDropdown = ({
         try {
           const response = await fetch(
             `${host}${getBaseHref()}/api/v1/namespaces/${namespaceId}/${
-              type === "monoVertex" ? "mono-vertices" : "pipeline"
-            }/${pipelineId}/pods`
+              type === "monoVertex" ? `mono-vertices/${pipelineId}/pods` : `pipelines/${pipelineId}/vertices/${vertexId}/pods`
+            }`
           );
           if (!response.ok) {
             callback(null);

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants.ts
@@ -19,10 +19,14 @@ export const dimensionMap: { [p: string]: string } = {
   "mono-vertex": "MonoVertex",
   pod: "Pod",
   pipeline: "Pipeline",
+  vertex: "Vertex"
 };
 
 export const dimensionReverseMap: { [p: string]: string } = {
   monoVertex: "mono-vertex",
+  source: "vertex",
+  udf: "vertex",
+  sink: "vertex",
   pipeline: "pipeline",
   pod: "pod",
 };
@@ -34,4 +38,6 @@ export const metricNameMap: { [p: string]: string } = {
     "Mono Vertex Processing Time Latency (in micro seconds)",
   monovtx_sink_time_bucket:
     "Mono Vertex Sink Write Time Latency (in micro seconds)",
+  forwarder_data_read_total:
+    "Vertex Read Processing Rate"
 };

--- a/ui/src/types/declarations/pods.d.ts
+++ b/ui/src/types/declarations/pods.d.ts
@@ -98,6 +98,7 @@ export interface PodDetailProps {
   containerName: string;
   pod: Pod;
   podDetails: PodDetail;
+  vertexId: string;
 }
 export interface ContainerInfoProps {
   state: string;


### PR DESCRIPTION
Changes in the UI to support visualisation of counter metrics for a pipeline.

1. Metrics added in the config: **forwarder_data_read_total** [ read processing rates ]
2. Placement: **Metrics** tab adjacent to **Logs**. [going forward, placement can be adjusted based on context to enhance debugging experience]
<img width="836" alt="Screenshot 2024-11-29 at 5 57 06 PM" src="https://github.com/user-attachments/assets/ea5dabe5-0895-4517-89c9-163c89997f89">
