### PR TITLE
mono-vertex read processing rate metric

### DIFF
--- a/config/advanced-install/namespaced-numaflow-server.yaml
+++ b/config/advanced-install/namespaced-numaflow-server.yaml
@@ -164,28 +164,28 @@ data:
             - namespace
             - mvtx_name
           dimensions:
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
             - name: pod
               # expr: optional expression for prometheus query
               # overrides the default expression
               filters:
                 - name: pod
                   required: false
+        - metric_name: monovtx_sink_time_bucket
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
+              #expr: optional
+            - name: pod
+              #expr: optional
+              filters:
+                - name: pod
+                  required: false
         # Add histogram metrics similar to the pattern above
-        #- metric_name: monovtx_sink_time_bucket
-        #  required_filters:
-        #    - namespace
-        #    - mvtx_name
-        #  dimensions:
-        #    - name: pod
-        #      #expr: optional
-        #      filters:
-        #        - name: pod
-        #          required: false
-        #    - name: mono-vertex
-        #      #expr: optional
     - name: vertex_throughput
       object: vertex
       title: Vertex Throughput and Message Rates
@@ -209,6 +209,33 @@ data:
               # expr: optional expression for prometheus query
               # overrides the default expression
             - name: pod
+              filters:
+                - name: pod
+                  required: false
+    - name: mono_vertex_throughput
+      object: mono-vertex
+      title: Mono-Vertex Throughput and Message Rates
+      description: This pattern measures the throughput of a mono-vertex in messages per second across different dimensions
+      expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
+      params:
+        - name: duration
+          required: true
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: monovtx_read_total
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
               filters:
                 - name: pod
                   required: false

--- a/config/advanced-install/numaflow-server.yaml
+++ b/config/advanced-install/numaflow-server.yaml
@@ -171,28 +171,28 @@ data:
             - namespace
             - mvtx_name
           dimensions:
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
             - name: pod
               # expr: optional expression for prometheus query
               # overrides the default expression
               filters:
                 - name: pod
                   required: false
+        - metric_name: monovtx_sink_time_bucket
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
+              #expr: optional
+            - name: pod
+              #expr: optional
+              filters:
+                - name: pod
+                  required: false
         # Add histogram metrics similar to the pattern above
-        #- metric_name: monovtx_sink_time_bucket
-        #  required_filters:
-        #    - namespace
-        #    - mvtx_name
-        #  dimensions:
-        #    - name: pod
-        #      #expr: optional
-        #      filters:
-        #        - name: pod
-        #          required: false
-        #    - name: mono-vertex
-        #      #expr: optional
     - name: vertex_throughput
       object: vertex
       title: Vertex Throughput and Message Rates
@@ -216,6 +216,33 @@ data:
               # expr: optional expression for prometheus query
               # overrides the default expression
             - name: pod
+              filters:
+                - name: pod
+                  required: false
+    - name: mono_vertex_throughput
+      object: mono-vertex
+      title: Mono-Vertex Throughput and Message Rates
+      description: This pattern measures the throughput of a mono-vertex in messages per second across different dimensions
+      expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
+      params:
+        - name: duration
+          required: true
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: monovtx_read_total
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
               filters:
                 - name: pod
                   required: false

--- a/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
+++ b/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
@@ -30,28 +30,28 @@ data:
             - namespace
             - mvtx_name
           dimensions:
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
             - name: pod
               # expr: optional expression for prometheus query
               # overrides the default expression
               filters:
                 - name: pod
                   required: false
+        - metric_name: monovtx_sink_time_bucket
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
+              #expr: optional
+            - name: pod
+              #expr: optional
+              filters:
+                - name: pod
+                  required: false
         # Add histogram metrics similar to the pattern above
-        #- metric_name: monovtx_sink_time_bucket
-        #  required_filters:
-        #    - namespace
-        #    - mvtx_name
-        #  dimensions:
-        #    - name: pod
-        #      #expr: optional
-        #      filters:
-        #        - name: pod
-        #          required: false
-        #    - name: mono-vertex
-        #      #expr: optional
     - name: vertex_throughput
       object: vertex
       title: Vertex Throughput and Message Rates
@@ -75,6 +75,33 @@ data:
               # expr: optional expression for prometheus query
               # overrides the default expression
             - name: pod
+              filters:
+                - name: pod
+                  required: false
+    - name: mono_vertex_throughput
+      object: mono-vertex
+      title: Mono-Vertex Throughput and Message Rates
+      description: This pattern measures the throughput of a mono-vertex in messages per second across different dimensions
+      expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
+      params:
+        - name: duration
+          required: true
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: monovtx_read_total
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
               filters:
                 - name: pod
                   required: false

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -28584,28 +28584,28 @@ data:
             - namespace
             - mvtx_name
           dimensions:
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
             - name: pod
               # expr: optional expression for prometheus query
               # overrides the default expression
               filters:
                 - name: pod
                   required: false
+        - metric_name: monovtx_sink_time_bucket
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
+              #expr: optional
+            - name: pod
+              #expr: optional
+              filters:
+                - name: pod
+                  required: false
         # Add histogram metrics similar to the pattern above
-        #- metric_name: monovtx_sink_time_bucket
-        #  required_filters:
-        #    - namespace
-        #    - mvtx_name
-        #  dimensions:
-        #    - name: pod
-        #      #expr: optional
-        #      filters:
-        #        - name: pod
-        #          required: false
-        #    - name: mono-vertex
-        #      #expr: optional
     - name: vertex_throughput
       object: vertex
       title: Vertex Throughput and Message Rates
@@ -28629,6 +28629,33 @@ data:
               # expr: optional expression for prometheus query
               # overrides the default expression
             - name: pod
+              filters:
+                - name: pod
+                  required: false
+    - name: mono_vertex_throughput
+      object: mono-vertex
+      title: Mono-Vertex Throughput and Message Rates
+      description: This pattern measures the throughput of a mono-vertex in messages per second across different dimensions
+      expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
+      params:
+        - name: duration
+          required: true
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: monovtx_read_total
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
               filters:
                 - name: pod
                   required: false

--- a/config/namespace-install.yaml
+++ b/config/namespace-install.yaml
@@ -28472,28 +28472,28 @@ data:
             - namespace
             - mvtx_name
           dimensions:
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
             - name: pod
               # expr: optional expression for prometheus query
               # overrides the default expression
               filters:
                 - name: pod
                   required: false
+        - metric_name: monovtx_sink_time_bucket
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
+              #expr: optional
+            - name: pod
+              #expr: optional
+              filters:
+                - name: pod
+                  required: false
         # Add histogram metrics similar to the pattern above
-        #- metric_name: monovtx_sink_time_bucket
-        #  required_filters:
-        #    - namespace
-        #    - mvtx_name
-        #  dimensions:
-        #    - name: pod
-        #      #expr: optional
-        #      filters:
-        #        - name: pod
-        #          required: false
-        #    - name: mono-vertex
-        #      #expr: optional
     - name: vertex_throughput
       object: vertex
       title: Vertex Throughput and Message Rates
@@ -28517,6 +28517,33 @@ data:
               # expr: optional expression for prometheus query
               # overrides the default expression
             - name: pod
+              filters:
+                - name: pod
+                  required: false
+    - name: mono_vertex_throughput
+      object: mono-vertex
+      title: Mono-Vertex Throughput and Message Rates
+      description: This pattern measures the throughput of a mono-vertex in messages per second across different dimensions
+      expr: sum(rate($metric_name{$filters}[$duration])) by ($dimension)
+      params:
+        - name: duration
+          required: true
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: monovtx_read_total
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
               filters:
                 - name: pod
                   required: false

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/index.tsx
@@ -77,7 +77,7 @@ export function Metrics({ namespaceId, pipelineId, type, vertexId }: MetricsProp
               aria-controls={`${metric?.metric_name}-content`}
               id={`${metric?.metric_name}-header`}
             >
-              <Box sx={{ textTransform: "capitalize" }}>
+              <Box>
                 {metricNameMap[metric?.metric_name] || metric?.metric_name}
               </Box>
             </AccordionSummary>

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants.ts
@@ -39,5 +39,7 @@ export const metricNameMap: { [p: string]: string } = {
   monovtx_sink_time_bucket:
     "Mono Vertex Sink Write Time Latency (in micro seconds)",
   forwarder_data_read_total:
-    "Vertex Read Processing Rate"
+    "Vertex Read Processing Rate (messages per second)",
+  monovtx_read_total:
+    "Mono Vertex Read Processing Rate (messages per second)"
 };


### PR DESCRIPTION
Adds mono-vertex read processing rate metric ([monovtx_read_total](https://github.com/numaproj/numaflow/blob/05df88691d8c9a787c5d4b84e5a97bf4d9d39a4e/rust/numaflow-core/src/metrics.rs#L181))
