### PR TITLE
fix: honor lookbackSeconds in monovertex and rust pipeline

### DIFF
--- a/pkg/apis/numaflow/v1alpha1/mono_vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/mono_vertex_types.go
@@ -318,7 +318,7 @@ func (mv MonoVertex) simpleCopy() MonoVertex {
 
 func (mv MonoVertex) GetPodSpec(req GetMonoVertexPodSpecReq) (*corev1.PodSpec, error) {
 	copiedSpec := mv.simpleCopy()
-	copiedSpec.Spec.Scale = Scale{}
+	copiedSpec.Spec.Scale = Scale{LookbackSeconds: mv.Spec.Scale.LookbackSeconds}
 	monoVtxBytes, err := json.Marshal(copiedSpec)
 	if err != nil {
 		return nil, errors.New("failed to marshal mono vertex spec")

--- a/rust/numaflow-core/src/config/components.rs
+++ b/rust/numaflow-core/src/config/components.rs
@@ -398,12 +398,14 @@ pub(crate) mod metrics {
     const DEFAULT_METRICS_PORT: u16 = 2469;
     const DEFAULT_LAG_CHECK_INTERVAL_IN_SECS: u16 = 5;
     const DEFAULT_LAG_REFRESH_INTERVAL_IN_SECS: u16 = 3;
+    const DEFAULT_LOOKBACK_WINDOW_IN_SECS: i64 = 120;
 
     #[derive(Debug, Clone, PartialEq)]
     pub(crate) struct MetricsConfig {
         pub metrics_server_listen_port: u16,
         pub lag_check_interval_in_secs: u16,
         pub lag_refresh_interval_in_secs: u16,
+        pub lookback_window_in_secs: i64,
     }
 
     impl Default for MetricsConfig {
@@ -412,7 +414,16 @@ pub(crate) mod metrics {
                 metrics_server_listen_port: DEFAULT_METRICS_PORT,
                 lag_check_interval_in_secs: DEFAULT_LAG_CHECK_INTERVAL_IN_SECS,
                 lag_refresh_interval_in_secs: DEFAULT_LAG_REFRESH_INTERVAL_IN_SECS,
+                lookback_window_in_secs: DEFAULT_LOOKBACK_WINDOW_IN_SECS,
             }
+        }
+    }
+
+    impl MetricsConfig {
+        pub(crate) fn with_lookback_window_in_secs(lookback_window_in_secs: i64) -> Self {
+            let mut default_config = Self::default();
+            default_config.lookback_window_in_secs = lookback_window_in_secs;
+            default_config
         }
     }
 }

--- a/rust/numaflow-core/src/config/components.rs
+++ b/rust/numaflow-core/src/config/components.rs
@@ -398,14 +398,14 @@ pub(crate) mod metrics {
     const DEFAULT_METRICS_PORT: u16 = 2469;
     const DEFAULT_LAG_CHECK_INTERVAL_IN_SECS: u16 = 5;
     const DEFAULT_LAG_REFRESH_INTERVAL_IN_SECS: u16 = 3;
-    const DEFAULT_LOOKBACK_WINDOW_IN_SECS: i64 = 120;
+    const DEFAULT_LOOKBACK_WINDOW_IN_SECS: u16 = 120;
 
     #[derive(Debug, Clone, PartialEq)]
     pub(crate) struct MetricsConfig {
         pub metrics_server_listen_port: u16,
         pub lag_check_interval_in_secs: u16,
         pub lag_refresh_interval_in_secs: u16,
-        pub lookback_window_in_secs: i64,
+        pub lookback_window_in_secs: u16,
     }
 
     impl Default for MetricsConfig {
@@ -420,7 +420,7 @@ pub(crate) mod metrics {
     }
 
     impl MetricsConfig {
-        pub(crate) fn with_lookback_window_in_secs(lookback_window_in_secs: i64) -> Self {
+        pub(crate) fn with_lookback_window_in_secs(lookback_window_in_secs: u16) -> Self {
             let mut default_config = Self::default();
             default_config.lookback_window_in_secs = lookback_window_in_secs;
             default_config

--- a/rust/numaflow-core/src/config/monovertex.rs
+++ b/rust/numaflow-core/src/config/monovertex.rs
@@ -1,5 +1,10 @@
 use std::time::Duration;
 
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
+use numaflow_models::models::MonoVertex;
+use serde_json::from_slice;
+
 use crate::config::components::metrics::MetricsConfig;
 use crate::config::components::sink::SinkConfig;
 use crate::config::components::source::{GeneratorConfig, SourceConfig};
@@ -10,10 +15,6 @@ use crate::config::components::{sink, source};
 use crate::config::get_vertex_replica;
 use crate::error::Error;
 use crate::Result;
-use base64::prelude::BASE64_STANDARD;
-use base64::Engine;
-use numaflow_models::models::MonoVertex;
-use serde_json::from_slice;
 
 const DEFAULT_BATCH_SIZE: u64 = 500;
 const DEFAULT_TIMEOUT_IN_MS: u32 = 1000;

--- a/rust/numaflow-core/src/config/monovertex.rs
+++ b/rust/numaflow-core/src/config/monovertex.rs
@@ -1,11 +1,5 @@
 use std::time::Duration;
 
-use base64::prelude::BASE64_STANDARD;
-use base64::Engine;
-use serde_json::from_slice;
-
-use numaflow_models::models::MonoVertex;
-
 use crate::config::components::metrics::MetricsConfig;
 use crate::config::components::sink::SinkConfig;
 use crate::config::components::source::{GeneratorConfig, SourceConfig};
@@ -16,6 +10,10 @@ use crate::config::components::{sink, source};
 use crate::config::get_vertex_replica;
 use crate::error::Error;
 use crate::Result;
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
+use numaflow_models::models::MonoVertex;
+use serde_json::from_slice;
 
 const DEFAULT_BATCH_SIZE: u64 = 500;
 const DEFAULT_TIMEOUT_IN_MS: u32 = 1000;

--- a/rust/numaflow-core/src/config/monovertex.rs
+++ b/rust/numaflow-core/src/config/monovertex.rs
@@ -2,8 +2,9 @@ use std::time::Duration;
 
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
-use numaflow_models::models::MonoVertex;
 use serde_json::from_slice;
+
+use numaflow_models::models::MonoVertex;
 
 use crate::config::components::metrics::MetricsConfig;
 use crate::config::components::sink::SinkConfig;
@@ -18,6 +19,7 @@ use crate::Result;
 
 const DEFAULT_BATCH_SIZE: u64 = 500;
 const DEFAULT_TIMEOUT_IN_MS: u32 = 1000;
+const DEFAULT_LOOKBACK_WINDOW_IN_SECS: i64 = 120;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct MonovertexConfig {
@@ -128,12 +130,19 @@ impl MonovertexConfig {
             None
         };
 
+        let look_back_window = mono_vertex_obj
+            .spec
+            .scale
+            .as_ref()
+            .and_then(|scale| scale.lookback_seconds.map(|x| x))
+            .unwrap_or(DEFAULT_LOOKBACK_WINDOW_IN_SECS);
+
         Ok(MonovertexConfig {
             name: mono_vertex_name,
             replica: *get_vertex_replica(),
             batch_size: batch_size as usize,
             read_timeout: Duration::from_millis(timeout_in_ms as u64),
-            metrics_config: MetricsConfig::default(),
+            metrics_config: MetricsConfig::with_lookback_window_in_secs(look_back_window),
             source_config,
             sink_config,
             transformer_config,
@@ -152,6 +161,7 @@ mod tests {
     use crate::config::components::transformer::TransformerType;
     use crate::config::monovertex::MonovertexConfig;
     use crate::error::Error;
+
     #[test]
     fn test_load_valid_config() {
         let valid_config = r#"

--- a/rust/numaflow-core/src/config/monovertex.rs
+++ b/rust/numaflow-core/src/config/monovertex.rs
@@ -18,7 +18,7 @@ use crate::Result;
 
 const DEFAULT_BATCH_SIZE: u64 = 500;
 const DEFAULT_TIMEOUT_IN_MS: u32 = 1000;
-const DEFAULT_LOOKBACK_WINDOW_IN_SECS: i64 = 120;
+const DEFAULT_LOOKBACK_WINDOW_IN_SECS: u16 = 120;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct MonovertexConfig {
@@ -133,7 +133,7 @@ impl MonovertexConfig {
             .spec
             .scale
             .as_ref()
-            .and_then(|scale| scale.lookback_seconds.map(|x| x))
+            .and_then(|scale| scale.lookback_seconds.map(|x| x as u16))
             .unwrap_or(DEFAULT_LOOKBACK_WINDOW_IN_SECS);
 
         Ok(MonovertexConfig {

--- a/rust/numaflow-core/src/config/pipeline.rs
+++ b/rust/numaflow-core/src/config/pipeline.rs
@@ -18,7 +18,7 @@ use crate::Result;
 
 const DEFAULT_BATCH_SIZE: u64 = 500;
 const DEFAULT_TIMEOUT_IN_MS: u32 = 1000;
-const DEFAULT_LOOKBACK_WINDOW_IN_SECS: i64 = 120;
+const DEFAULT_LOOKBACK_WINDOW_IN_SECS: u16 = 120;
 const ENV_NUMAFLOW_SERVING_JETSTREAM_URL: &str = "NUMAFLOW_ISBSVC_JETSTREAM_URL";
 const ENV_NUMAFLOW_SERVING_JETSTREAM_USER: &str = "NUMAFLOW_ISBSVC_JETSTREAM_USER";
 const ENV_NUMAFLOW_SERVING_JETSTREAM_PASSWORD: &str = "NUMAFLOW_ISBSVC_JETSTREAM_PASSWORD";
@@ -273,7 +273,7 @@ impl PipelineConfig {
             .spec
             .scale
             .as_ref()
-            .and_then(|scale| scale.lookback_seconds.map(|x| x))
+            .and_then(|scale| scale.lookback_seconds.map(|x| x as u16))
             .unwrap_or(DEFAULT_LOOKBACK_WINDOW_IN_SECS);
 
         Ok(PipelineConfig {

--- a/rust/numaflow-core/src/config/pipeline.rs
+++ b/rust/numaflow-core/src/config/pipeline.rs
@@ -18,6 +18,7 @@ use crate::Result;
 
 const DEFAULT_BATCH_SIZE: u64 = 500;
 const DEFAULT_TIMEOUT_IN_MS: u32 = 1000;
+const DEFAULT_LOOKBACK_WINDOW_IN_SECS: i64 = 120;
 const ENV_NUMAFLOW_SERVING_JETSTREAM_URL: &str = "NUMAFLOW_ISBSVC_JETSTREAM_URL";
 const ENV_NUMAFLOW_SERVING_JETSTREAM_USER: &str = "NUMAFLOW_ISBSVC_JETSTREAM_USER";
 const ENV_NUMAFLOW_SERVING_JETSTREAM_PASSWORD: &str = "NUMAFLOW_ISBSVC_JETSTREAM_PASSWORD";
@@ -268,6 +269,13 @@ impl PipelineConfig {
             });
         }
 
+        let look_back_window = vertex_obj
+            .spec
+            .scale
+            .as_ref()
+            .and_then(|scale| scale.lookback_seconds.map(|x| x))
+            .unwrap_or(DEFAULT_LOOKBACK_WINDOW_IN_SECS);
+
         Ok(PipelineConfig {
             batch_size: batch_size as usize,
             paf_concurrency: env::var("PAF_BATCH_SIZE")
@@ -282,7 +290,7 @@ impl PipelineConfig {
             from_vertex_config,
             to_vertex_config,
             vertex_config: vertex,
-            metrics_config: Default::default(),
+            metrics_config: MetricsConfig::with_lookback_window_in_secs(look_back_window),
         })
     }
 }
@@ -376,6 +384,7 @@ mod tests {
                 metrics_server_listen_port: 2469,
                 lag_check_interval_in_secs: 5,
                 lag_refresh_interval_in_secs: 3,
+                lookback_window_in_secs: 120,
             },
         };
         assert_eq!(pipeline_config, expected);

--- a/rust/numaflow-core/src/pipeline.rs
+++ b/rust/numaflow-core/src/pipeline.rs
@@ -330,6 +330,7 @@ mod tests {
                 metrics_server_listen_port: 2469,
                 lag_check_interval_in_secs: 5,
                 lag_refresh_interval_in_secs: 3,
+                lookback_window_in_secs: 120,
             },
         };
 
@@ -486,6 +487,7 @@ mod tests {
                 metrics_server_listen_port: 2469,
                 lag_check_interval_in_secs: 5,
                 lag_refresh_interval_in_secs: 3,
+                lookback_window_in_secs: 120,
             },
         };
 

--- a/rust/numaflow-core/src/shared/metrics.rs
+++ b/rust/numaflow-core/src/shared/metrics.rs
@@ -40,5 +40,6 @@ pub(crate) async fn create_pending_reader(
         .refresh_interval(Duration::from_secs(
             metrics_config.lag_refresh_interval_in_secs.into(),
         ))
+        .lookback_seconds(metrics_config.lookback_window_in_secs.into())
         .build()
 }


### PR DESCRIPTION
Currently  if the lookbackSeconds is specified in the spec, the metric lag reader does not honor that value and keeps using default 

```
apiVersion: numaflow.numaproj.io/v1alpha1
kind: MonoVertex
metadata:
  name: simple-mono-vertex
spec:
  scale:
    lookbackSeconds: 90
```

Before change

```
skohli@macos-JQWR9T560R numaflow % kubectl logs simple-mono-vertex-mv-0-fovym -f | grep MYDEBUG
2024-12-05T01:01:55.057650Z  INFO numaflow_core::metrics: MYDEBUG LABEL "default" 120
2024-12-05T01:02:04.057950Z  INFO numaflow_core::metrics: MYDEBUG LABEL "default" 120
```

After
```

skohli@macos-JQWR9T560R numaflow % kubectl logs simple-mono-vertex-mv-0-pfevp -f | grep MYDEBUG
2024-12-05T01:02:55.514563Z  INFO numaflow_core::metrics: MYDEBUG LABEL "default" 90
2024-12-05T01:02:58.514440Z  INFO numaflow_core::metrics: MYDEBUG LABEL "default" 90
```