### PR TITLE
feat: pipeline gauge metrics

### DIFF
--- a/config/advanced-install/namespaced-numaflow-server.yaml
+++ b/config/advanced-install/namespaced-numaflow-server.yaml
@@ -143,33 +143,71 @@ data:
     # example for local prometheus service
     # url: http://prometheus-operated.monitoring.svc.cluster.local:9090
     patterns:
-    - name: mono_vertex_gauge
-      object: mono-vertex
-      title: Pending Messages Lag
-      description: This query is the total number of pending messages for the mono vertex
+    - name: vertex_gauge
+      object: vertex
+      title: Vertex Pending Messages
+      description: This query is the total number of pending messages for the vertex
       expr: |
-        $metric_name{$filters}
+        sum($metric_name{$filters}) by ($dimension, period)
       params:
         - name: start_time
           required: false
         - name: end_time
           required: false
       metrics:
-      - metric_name: monovtx_pending
-        required_filters:
-          - namespace
-          - mvtx_name
-        dimensions:
-          - name: pod
-            filters:
-              - name: pod
-                required: false
-              - name: period
-                required: false
-          - name: mono-vertex
-            filters:
-              - name: period
-                required: false
+        - metric_name: vertex_pending_messages
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: pod
+                  required: false
+                - name: period
+                  required: false
+            - name: vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: period
+                  required: false
+
+    - name: mono_vertex_gauge
+      object: mono-vertex
+      title: Pending Messages Lag
+      description: This query is the total number of pending messages for the mono vertex
+      expr: |
+        sum($metric_name{$filters}) by ($dimension, period)
+      params:
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: monovtx_pending
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: pod
+                  required: false
+                - name: period
+                  required: false
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: period
+                  required: false
+
     - name: mono_vertex_histogram
       object: mono-vertex
       title: Processing Time Latency
@@ -192,11 +230,7 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false
@@ -206,15 +240,11 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false
-        # Add histogram metrics similar to the pattern above
+
     - name: vertex_throughput
       object: vertex
       title: Vertex Throughput and Message Rates
@@ -235,12 +265,11 @@ data:
             - vertex
           dimensions:
             - name: vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
               filters:
                 - name: pod
                   required: false
+
     - name: mono_vertex_throughput
       object: mono-vertex
       title: Mono-Vertex Throughput and Message Rates
@@ -260,11 +289,7 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false

--- a/config/advanced-install/numaflow-server.yaml
+++ b/config/advanced-install/numaflow-server.yaml
@@ -150,33 +150,71 @@ data:
     # example for local prometheus service
     # url: http://prometheus-operated.monitoring.svc.cluster.local:9090
     patterns:
-    - name: mono_vertex_gauge
-      object: mono-vertex
-      title: Pending Messages Lag
-      description: This query is the total number of pending messages for the mono vertex
+    - name: vertex_gauge
+      object: vertex
+      title: Vertex Pending Messages
+      description: This query is the total number of pending messages for the vertex
       expr: |
-        $metric_name{$filters}
+        sum($metric_name{$filters}) by ($dimension, period)
       params:
         - name: start_time
           required: false
         - name: end_time
           required: false
       metrics:
-      - metric_name: monovtx_pending
-        required_filters:
-          - namespace
-          - mvtx_name
-        dimensions:
-          - name: pod
-            filters:
-              - name: pod
-                required: false
-              - name: period
-                required: false
-          - name: mono-vertex
-            filters:
-              - name: period
-                required: false
+        - metric_name: vertex_pending_messages
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: pod
+                  required: false
+                - name: period
+                  required: false
+            - name: vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: period
+                  required: false
+
+    - name: mono_vertex_gauge
+      object: mono-vertex
+      title: Pending Messages Lag
+      description: This query is the total number of pending messages for the mono vertex
+      expr: |
+        sum($metric_name{$filters}) by ($dimension, period)
+      params:
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: monovtx_pending
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: pod
+                  required: false
+                - name: period
+                  required: false
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: period
+                  required: false
+
     - name: mono_vertex_histogram
       object: mono-vertex
       title: Processing Time Latency
@@ -199,11 +237,7 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false
@@ -213,15 +247,11 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false
-        # Add histogram metrics similar to the pattern above
+
     - name: vertex_throughput
       object: vertex
       title: Vertex Throughput and Message Rates
@@ -242,12 +272,11 @@ data:
             - vertex
           dimensions:
             - name: vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
               filters:
                 - name: pod
                   required: false
+
     - name: mono_vertex_throughput
       object: mono-vertex
       title: Mono-Vertex Throughput and Message Rates
@@ -267,11 +296,7 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false

--- a/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
+++ b/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
@@ -9,33 +9,71 @@ data:
     # example for local prometheus service
     # url: http://prometheus-operated.monitoring.svc.cluster.local:9090
     patterns:
-    - name: mono_vertex_gauge
-      object: mono-vertex
-      title: Pending Messages Lag
-      description: This query is the total number of pending messages for the mono vertex
+    - name: vertex_gauge
+      object: vertex
+      title: Vertex Pending Messages
+      description: This query is the total number of pending messages for the vertex
       expr: |
-        $metric_name{$filters}
+        sum($metric_name{$filters}) by ($dimension, period)
       params:
         - name: start_time
           required: false
         - name: end_time
           required: false
       metrics:
-      - metric_name: monovtx_pending
-        required_filters:
-          - namespace
-          - mvtx_name
-        dimensions:
-          - name: pod
-            filters:
-              - name: pod
-                required: false
-              - name: period
-                required: false
-          - name: mono-vertex
-            filters:
-              - name: period
-                required: false
+        - metric_name: vertex_pending_messages
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: pod
+                  required: false
+                - name: period
+                  required: false
+            - name: vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: period
+                  required: false
+    
+    - name: mono_vertex_gauge
+      object: mono-vertex
+      title: Pending Messages Lag
+      description: This query is the total number of pending messages for the mono vertex
+      expr: |
+        sum($metric_name{$filters}) by ($dimension, period)
+      params:
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: monovtx_pending
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: pod
+                  required: false
+                - name: period
+                  required: false
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: period
+                  required: false
+
     - name: mono_vertex_histogram
       object: mono-vertex
       title: Processing Time Latency
@@ -58,11 +96,7 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false
@@ -72,15 +106,11 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false
-        # Add histogram metrics similar to the pattern above
+
     - name: vertex_throughput
       object: vertex
       title: Vertex Throughput and Message Rates
@@ -101,12 +131,11 @@ data:
             - vertex
           dimensions:
             - name: vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
               filters:
                 - name: pod
                   required: false
+
     - name: mono_vertex_throughput
       object: mono-vertex
       title: Mono-Vertex Throughput and Message Rates
@@ -126,11 +155,7 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -28563,33 +28563,71 @@ data:
     # example for local prometheus service
     # url: http://prometheus-operated.monitoring.svc.cluster.local:9090
     patterns:
-    - name: mono_vertex_gauge
-      object: mono-vertex
-      title: Pending Messages Lag
-      description: This query is the total number of pending messages for the mono vertex
+    - name: vertex_gauge
+      object: vertex
+      title: Vertex Pending Messages
+      description: This query is the total number of pending messages for the vertex
       expr: |
-        $metric_name{$filters}
+        sum($metric_name{$filters}) by ($dimension, period)
       params:
         - name: start_time
           required: false
         - name: end_time
           required: false
       metrics:
-      - metric_name: monovtx_pending
-        required_filters:
-          - namespace
-          - mvtx_name
-        dimensions:
-          - name: pod
-            filters:
-              - name: pod
-                required: false
-              - name: period
-                required: false
-          - name: mono-vertex
-            filters:
-              - name: period
-                required: false
+        - metric_name: vertex_pending_messages
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: pod
+                  required: false
+                - name: period
+                  required: false
+            - name: vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: period
+                  required: false
+
+    - name: mono_vertex_gauge
+      object: mono-vertex
+      title: Pending Messages Lag
+      description: This query is the total number of pending messages for the mono vertex
+      expr: |
+        sum($metric_name{$filters}) by ($dimension, period)
+      params:
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: monovtx_pending
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: pod
+                  required: false
+                - name: period
+                  required: false
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: period
+                  required: false
+
     - name: mono_vertex_histogram
       object: mono-vertex
       title: Processing Time Latency
@@ -28612,11 +28650,7 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false
@@ -28626,15 +28660,11 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false
-        # Add histogram metrics similar to the pattern above
+
     - name: vertex_throughput
       object: vertex
       title: Vertex Throughput and Message Rates
@@ -28655,12 +28685,11 @@ data:
             - vertex
           dimensions:
             - name: vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
               filters:
                 - name: pod
                   required: false
+
     - name: mono_vertex_throughput
       object: mono-vertex
       title: Mono-Vertex Throughput and Message Rates
@@ -28680,11 +28709,7 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false

--- a/config/namespace-install.yaml
+++ b/config/namespace-install.yaml
@@ -28451,33 +28451,71 @@ data:
     # example for local prometheus service
     # url: http://prometheus-operated.monitoring.svc.cluster.local:9090
     patterns:
-    - name: mono_vertex_gauge
-      object: mono-vertex
-      title: Pending Messages Lag
-      description: This query is the total number of pending messages for the mono vertex
+    - name: vertex_gauge
+      object: vertex
+      title: Vertex Pending Messages
+      description: This query is the total number of pending messages for the vertex
       expr: |
-        $metric_name{$filters}
+        sum($metric_name{$filters}) by ($dimension, period)
       params:
         - name: start_time
           required: false
         - name: end_time
           required: false
       metrics:
-      - metric_name: monovtx_pending
-        required_filters:
-          - namespace
-          - mvtx_name
-        dimensions:
-          - name: pod
-            filters:
-              - name: pod
-                required: false
-              - name: period
-                required: false
-          - name: mono-vertex
-            filters:
-              - name: period
-                required: false
+        - metric_name: vertex_pending_messages
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: pod
+                  required: false
+                - name: period
+                  required: false
+            - name: vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: period
+                  required: false
+
+    - name: mono_vertex_gauge
+      object: mono-vertex
+      title: Pending Messages Lag
+      description: This query is the total number of pending messages for the mono vertex
+      expr: |
+        sum($metric_name{$filters}) by ($dimension, period)
+      params:
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: monovtx_pending
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
+            - name: pod
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: pod
+                  required: false
+                - name: period
+                  required: false
+            - name: mono-vertex
+              # expr: optional expression for prometheus query
+              # overrides the default expression
+              filters:
+                - name: period
+                  required: false
+
     - name: mono_vertex_histogram
       object: mono-vertex
       title: Processing Time Latency
@@ -28500,11 +28538,7 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false
@@ -28514,15 +28548,11 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false
-        # Add histogram metrics similar to the pattern above
+
     - name: vertex_throughput
       object: vertex
       title: Vertex Throughput and Message Rates
@@ -28543,12 +28573,11 @@ data:
             - vertex
           dimensions:
             - name: vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
               filters:
                 - name: pod
                   required: false
+
     - name: mono_vertex_throughput
       object: mono-vertex
       title: Mono-Vertex Throughput and Message Rates
@@ -28568,11 +28597,7 @@ data:
             - mvtx_name
           dimensions:
             - name: mono-vertex
-              # expr: optional expression for prometheus query
-              # overrides the default expression
             - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
               filters:
                 - name: pod
                   required: false

--- a/server/apis/v1/promql_service_test.go
+++ b/server/apis/v1/promql_service_test.go
@@ -459,7 +459,7 @@ func Test_QueryPrometheus(t *testing.T) {
 				Api: mockAPI,
 			},
 		}
-		query := `sum(monovtx_pending{namespace="default", mvtx_name="test-mvtx", pending="5m"}) by (mvtx_name, period)`
+		query := `sum(monovtx_pending{namespace="default", mvtx_name="test-mvtx", period="5m"}) by (mvtx_name, period)`
 		startTime := time.Now().Add(-30 * time.Minute)
 		endTime := time.Now()
 
@@ -482,7 +482,7 @@ func Test_QueryPrometheus(t *testing.T) {
 				Api: mockAPI,
 			},
 		}
-		query := `sum(vertex_pending_messages{namespace="default", pipeline="test-pipeline", vertex="test-vertex", pending="5m"}) by (vertex, period)`
+		query := `sum(vertex_pending_messages{namespace="default", pipeline="test-pipeline", vertex="test-vertex", period="5m"}) by (vertex, period)`
 		startTime := time.Now().Add(-30 * time.Minute)
 		endTime := time.Now()
 

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/index.tsx
@@ -65,6 +65,11 @@ export function Metrics({ namespaceId, pipelineId, type, vertexId }: MetricsProp
   return (
     <Box sx={{ height: "100%" }}>
       {discoveredMetrics?.data?.map((metric: any) => {
+        if (
+          type === "source" &&
+          metric?.metric_name === "vertex_pending_messages"
+        )
+          return null;
         const panelId = `${metric?.metric_name}-panel`;
         return (
           <Accordion

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
@@ -121,14 +121,15 @@ const LineChartComponent = ({
   const groupByLabel = useCallback((dimension: string, metricName: string) => {
     switch (metricName) {
       case "monovtx_pending":
-        return "period";
+      case "vertex_pending_messages":
+        return dimension === "pod" ? ["pod", "period"] : ["period"];
     }
 
     switch (dimension) {
       case "mono-vertex":
-        return "mvtx_name";
+        return ["mvtx_name"];
       default:
-        return dimension;
+        return [dimension];
     }
   }, []);
 
@@ -141,7 +142,18 @@ const LineChartComponent = ({
         metricsReq?.metric_name
       );
       chartData?.forEach((item) => {
-        const labelVal = item?.metric?.[label];
+        let labelVal = "";
+        label?.forEach((eachLabel: string) => {
+          if (item?.metric?.[eachLabel] !== undefined) {
+            labelVal += (labelVal ? "-" : "") + item.metric[eachLabel];
+          }
+        });
+
+        // Remove initial hyphen if labelVal is not empty
+        if (labelVal.startsWith("-") && labelVal.length > 1) {
+          labelVal = labelVal.substring(1);
+        }
+
         labels.push(labelVal);
         item?.values?.forEach(([timestamp, value]: [number, string]) => {
           const date = new Date(timestamp * 1000);

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants.ts
@@ -40,7 +40,7 @@ export const metricNameMap: { [p: string]: string } = {
     "Mono Vertex Sink Write Time Latency (in micro seconds)",
   forwarder_data_read_total:
     "Vertex Read Processing Rate (messages per second)",
-  monovtx_read_total:
-    "Mono Vertex Read Processing Rate (messages per second)",
-  monovtx_pending: "Mono Vertex Pending",
+  monovtx_read_total: "Mono Vertex Read Processing Rate (messages per second)",
+  monovtx_pending: "Mono Vertex Pending Messages",
+  vertex_pending_messages: "Vertex Pending Messages",
 };


### PR DESCRIPTION
Fixes #2243 
- Updates gauge pattern for mono-vertices
- Enhances labels for gauge metrics
- Adds pending lag metrics for pipeline vertices
<img width="1689" alt="image" src="https://github.com/user-attachments/assets/cbce7a13-9a2e-41ac-a8f2-d528930852c2" />
