### PR TITLE
chore: add container type to server info log

### DIFF
--- a/rust/numaflow-core/src/shared/server_info.rs
+++ b/rust/numaflow-core/src/shared/server_info.rs
@@ -97,14 +97,17 @@ pub(crate) async fn sdk_server_info(
     // Read the server info file
     let server_info = read_server_info(&file_path, cln_token).await?;
 
+    // Get the container type from the server info file
+    let container_type = get_container_type(&file_path).unwrap_or(ContainerType::Unknown);
+
     // Log the server info
-    info!("Server info file: {:?}", server_info);
+    info!("{:?} Server info file: {:?}", container_type, server_info);
 
     // Extract relevant fields from server info
     let sdk_version = &server_info.version;
     let min_numaflow_version = &server_info.minimum_numaflow_version;
     let sdk_language = &server_info.language;
-    let container_type = get_container_type(&file_path).unwrap_or(ContainerType::Unknown);
+
     // Get version information
     let version_info = version::get_version_info();
     let numaflow_version = &version_info.version;
@@ -508,8 +511,8 @@ mod version {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Read, Write};
     use std::{collections::HashMap, fs::File};
+    use std::io::{Read, Write};
 
     use serde_json::json;
     use tempfile::tempdir;

--- a/rust/numaflow-core/src/shared/server_info.rs
+++ b/rust/numaflow-core/src/shared/server_info.rs
@@ -101,7 +101,7 @@ pub(crate) async fn sdk_server_info(
     let container_type = get_container_type(&file_path).unwrap_or(ContainerType::Unknown);
 
     // Log the server info
-    info!("{:?} Server info file: {:?}", container_type, server_info);
+    info!(?container_type, "Server info file: {:?}", server_info);
 
     // Extract relevant fields from server info
     let sdk_version = &server_info.version;
@@ -511,8 +511,8 @@ mod version {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, fs::File};
     use std::io::{Read, Write};
+    use std::{collections::HashMap, fs::File};
 
     use serde_json::json;
     use tempfile::tempdir;

--- a/rust/numaflow-core/src/shared/server_info.rs
+++ b/rust/numaflow-core/src/shared/server_info.rs
@@ -101,7 +101,7 @@ pub(crate) async fn sdk_server_info(
     let container_type = get_container_type(&file_path).unwrap_or(ContainerType::Unknown);
 
     // Log the server info
-    info!(?container_type, "Server info file: {:?}", server_info);
+    info!(?container_type, ?server_info, "Server info file");
 
     // Extract relevant fields from server info
     let sdk_version = &server_info.version;


### PR DESCRIPTION
Currently our ServerInfo log doesnt show which container is it corresponding to
```
skohli@macos-JQWR9T560R numaflow % kubectl logs simple-mono-vertex-mv-0-oq2s8 -f
2024-12-13T18:25:01.707148Z  INFO numaflow_core: Starting monovertex forwarder with config: MonovertexConfig { name: "simple-mono-vertex", batch_size: 500, read_timeout: 1s, replica: 0, source_config: SourceConfig { source_type: UserDefined(UserDefinedConfig { grpc_max_message_size: 67108864, socket_path: "/var/run/numaflow/source.sock", server_info_path: "/var/run/numaflow/sourcer-server-info" }) }, sink_config: SinkConfig { sink_type: UserDefined(UserDefinedConfig { grpc_max_message_size: 67108864, socket_path: "/var/run/numaflow/sink.sock", server_info_path: "/var/run/numaflow/sinker-server-info" }), retry_config: Some(RetryConfig { sink_max_retry_attempts: 65535, sink_retry_interval_in_ms: 1, sink_retry_on_fail_strategy: Retry, sink_default_retry_strategy: RetryStrategy { backoff: Some(Backoff { interval: Some(1ms), steps: Some(65535) }), on_failure: Some("retry") } }) }, transformer_config: Some(TransformerConfig { concurrency: 500, transformer_type: UserDefined(UserDefinedConfig { grpc_max_message_size: 67108864, socket_path: "/var/run/numaflow/sourcetransform.sock", server_info_path: "/var/run/numaflow/sourcetransformer-server-info" }) }), fb_sink_config: None, metrics_config: MetricsConfig { metrics_server_listen_port: 2469, lag_check_interval_in_secs: 5, lag_refresh_interval_in_secs: 3, lookback_window_in_secs: 120 } }
2024-12-13T18:25:01.708185Z  INFO numaflow_core::shared::server_info: Server info file: ServerInfo { protocol: "uds", language: "rust", minimum_numaflow_version: "1.4.0-z", version: "0.2.1", metadata: Some({}) }
2024-12-13T18:25:01.709734Z  INFO numaflow_core::shared::grpc: Waiting for source client to be ready...
2024-12-13T18:25:01.743069Z  INFO numaflow_core::shared::server_info: Server info file: ServerInfo { protocol: "uds", language: "rust", minimum_numaflow_version: "1.4.0-z", version: "0.2.1", metadata: Some({}) }
2024-12-13T18:25:01.774156Z  INFO numaflow_core::shared::server_info: Server info file: ServerInfo { protocol: "uds", language: "rust", minimum_numaflow_version: "1.4.0-z", version: "0.2.1", metadata: Some({}) }
2024-12-13T18:25:01.806412Z  INFO numaflow_core::monovertex: Forwarder is starting...
2024-12-13T18:25:01.806433Z  INFO numaflow_core::source: Started streaming source with batch size: 500
2024-12-13T18:25:02.806635Z  INFO numaflow_core::source: Processed 22000 messages in Instant { tv_sec: 1642, tv_nsec: 914323365 }
2024-12-13T18:25:02.816079Z  INFO numaflow_core::sink: Processed 22000 messages at Instant { tv_sec: 1642, tv_nsec: 923767823 }
```

Updated to show container type along with it

```
skohli@macos-JQWR9T560R numaflow % kubectl logs simple-mono-vertex-mv-0-1cxlf -f
2024-12-13T19:07:38.745299Z  INFO numaflow_core: Starting monovertex forwarder with config: MonovertexConfig { name: "simple-mono-vertex", batch_size: 500, read_timeout: 1s, replica: 0, source_config: SourceConfig { source_type: UserDefined(UserDefinedConfig { grpc_max_message_size: 67108864, socket_path: "/var/run/numaflow/source.sock", server_info_path: "/var/run/numaflow/sourcer-server-info" }) }, sink_config: SinkConfig { sink_type: UserDefined(UserDefinedConfig { grpc_max_message_size: 67108864, socket_path: "/var/run/numaflow/sink.sock", server_info_path: "/var/run/numaflow/sinker-server-info" }), retry_config: Some(RetryConfig { sink_max_retry_attempts: 65535, sink_retry_interval_in_ms: 1, sink_retry_on_fail_strategy: Retry, sink_default_retry_strategy: RetryStrategy { backoff: Some(Backoff { interval: Some(1ms), steps: Some(65535) }), on_failure: Some("retry") } }) }, transformer_config: Some(TransformerConfig { concurrency: 500, transformer_type: UserDefined(UserDefinedConfig { grpc_max_message_size: 67108864, socket_path: "/var/run/numaflow/sourcetransform.sock", server_info_path: "/var/run/numaflow/sourcetransformer-server-info" }) }), fb_sink_config: None, metrics_config: MetricsConfig { metrics_server_listen_port: 2469, lag_check_interval_in_secs: 5, lag_refresh_interval_in_secs: 3, lookback_window_in_secs: 120 } }
2024-12-13T19:07:38.746408Z  INFO numaflow_core::shared::server_info: Sourcer Server info file: ServerInfo { protocol: "uds", language: "rust", minimum_numaflow_version: "1.4.0-z", version: "0.2.1", metadata: Some({}) }
2024-12-13T19:07:38.747823Z  INFO numaflow_core::shared::grpc: Waiting for source client to be ready...
2024-12-13T19:07:38.779540Z  INFO numaflow_core::shared::server_info: SourceTransformer Server info file: ServerInfo { protocol: "uds", language: "rust", minimum_numaflow_version: "1.4.0-z", version: "0.2.1", metadata: Some({}) }
2024-12-13T19:07:38.810449Z  INFO numaflow_core::shared::server_info: Sinker Server info file: ServerInfo { protocol: "uds", language: "rust", minimum_numaflow_version: "1.4.0-z", version: "0.2.1", metadata: Some({}) }
2024-12-13T19:07:38.842175Z  INFO numaflow_core::monovertex: Forwarder is starting...

2024-12-13T19:11:54.323687Z  INFO numaflow_core: Starting monovertex forwarder with config: MonovertexConfig { name: "simple-mono-vertex", batch_size: 500, read_timeout: 1s, replica: 0, source_config: SourceConfig { source_type: UserDefined(UserDefinedConfig { grpc_max_message_size: 67108864, socket_path: "/var/run/numaflow/source.sock", server_info_path: "/var/run/numaflow/sourcer-server-info" }) }, sink_config: SinkConfig { sink_type: UserDefined(UserDefinedConfig { grpc_max_message_size: 67108864, socket_path: "/var/run/numaflow/sink.sock", server_info_path: "/var/run/numaflow/sinker-server-info" }), retry_config: Some(RetryConfig { sink_max_retry_attempts: 65535, sink_retry_interval_in_ms: 1, sink_retry_on_fail_strategy: Retry, sink_default_retry_strategy: RetryStrategy { backoff: Some(Backoff { interval: Some(1ms), steps: Some(65535) }), on_failure: Some("retry") } }) }, transformer_config: Some(TransformerConfig { concurrency: 500, transformer_type: UserDefined(UserDefinedConfig { grpc_max_message_size: 67108864, socket_path: "/var/run/numaflow/sourcetransform.sock", server_info_path: "/var/run/numaflow/sourcetransformer-server-info" }) }), fb_sink_config: Some(SinkConfig { sink_type: UserDefined(UserDefinedConfig { grpc_max_message_size: 67108864, socket_path: "/var/run/numaflow/fb-sink.sock", server_info_path: "/var/run/numaflow/fb-sinker-server-info" }), retry_config: None }), metrics_config: MetricsConfig { metrics_server_listen_port: 2469, lag_check_interval_in_secs: 5, lag_refresh_interval_in_secs: 3, lookback_window_in_secs: 120 } }
2024-12-13T19:11:54.324048Z  INFO numaflow_core::shared::server_info: Sourcer Server info file: ServerInfo { protocol: "uds", language: "rust", minimum_numaflow_version: "1.4.0-z", version: "0.2.1", metadata: Some({}) }
2024-12-13T19:11:54.324546Z  INFO numaflow_core::shared::grpc: Waiting for source client to be ready...
2024-12-13T19:11:54.358961Z  INFO numaflow_core::shared::server_info: SourceTransformer Server info file: ServerInfo { protocol: "uds", language: "rust", minimum_numaflow_version: "1.4.0-z", version: "0.2.1", metadata: Some({}) }
2024-12-13T19:11:54.388207Z  INFO numaflow_core::shared::server_info: Sinker Server info file: ServerInfo { protocol: "uds", language: "rust", minimum_numaflow_version: "1.4.0-z", version: "0.2.1", metadata: Some({}) }
2024-12-13T19:11:54.413235Z  INFO numaflow_core::shared::server_info: FbSinker Server info file: ServerInfo { protocol: "uds", language: "rust", minimum_numaflow_version: "1.4.0-z", version: "0.2.1", metadata: Some({}) }
2024-12-13T19:11:54.448584Z  INFO numaflow_core::monovertex: Forwarder is starting...
2024-12-13T19:11:54.448691Z  INFO numaflow_core::source: Started streaming source with batch size: 500
2024-12-13T19:11:55.451615Z  INFO numaflow_core::source: Processed 22500 messages in Instant { tv_sec: 4046, tv_nsec: 562307261 }

```
