### PR TITLE
chore: use same metric to expose binary build info

### DIFF
--- a/pkg/daemon/server/daemon_server.go
+++ b/pkg/daemon/server/daemon_server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/numaproj/numaflow/pkg/daemon/server/service"
 	server "github.com/numaproj/numaflow/pkg/daemon/server/service/rater"
 	"github.com/numaproj/numaflow/pkg/isbsvc"
+	"github.com/numaproj/numaflow/pkg/metrics"
 	jsclient "github.com/numaproj/numaflow/pkg/shared/clients/nats"
 	redisclient "github.com/numaproj/numaflow/pkg/shared/clients/redis"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
@@ -156,7 +157,9 @@ func (ds *daemonServer) Run(ctx context.Context) error {
 	go ds.exposeMetrics(ctx)
 
 	version := numaflow.GetVersion()
-	pipeline_info.WithLabelValues(version.Version, version.Platform, ds.pipeline.Name).Set(1)
+	// TODO: clean it up in v1.6
+	deprecatedPipelineInfo.WithLabelValues(version.Version, version.Platform, ds.pipeline.Name).Set(1)
+	metrics.BuildInfo.WithLabelValues(v1alpha1.ComponentDaemon, ds.pipeline.Name, version.Version, version.Platform).Set(1)
 
 	log.Infof("Daemon server started successfully on %s", address)
 	<-ctx.Done()

--- a/pkg/daemon/server/metrics.go
+++ b/pkg/daemon/server/metrics.go
@@ -23,10 +23,11 @@ import (
 )
 
 var (
-	pipeline_info = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	// Deprecated: Use pkg/metrics.BuildInfo instead.
+	deprecatedPipelineInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: "pipeline",
 		Name:      "build_info",
-		Help:      "A metric with a constant value '1', labeled by Numaflow binary version and platform, as well as the pipeline name",
+		Help:      "A metric with a constant value '1', labeled by Numaflow binary version and platform, as well as the pipeline name. Deprecated: Use build_info instead",
 	}, []string{metrics.LabelVersion, metrics.LabelPlatform, metrics.LabelPipeline})
 
 	// Pipeline processing lag, max(watermark) - min(watermark)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -41,6 +41,11 @@ const (
 )
 
 var (
+	BuildInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "build_info",
+		Help: "A metric with a constant value '1', labeled by Numaflow binary version, platform, and other information",
+	}, []string{LabelComponent, LabelComponentName, LabelVersion, LabelPlatform})
+
 	SDKInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "sdk_info",
 		Help: "A metric with a constant value '1', labeled by SDK information such as version, language, and type",

--- a/pkg/mvtxdaemon/server/daemon_server.go
+++ b/pkg/mvtxdaemon/server/daemon_server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/numaproj/numaflow"
 	"github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaflow/pkg/apis/proto/mvtxdaemon"
+	"github.com/numaproj/numaflow/pkg/metrics"
 	"github.com/numaproj/numaflow/pkg/mvtxdaemon/server/service"
 	rateServer "github.com/numaproj/numaflow/pkg/mvtxdaemon/server/service/rater"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
@@ -108,7 +109,9 @@ func (ds *daemonServer) Run(ctx context.Context) error {
 	}()
 
 	version := numaflow.GetVersion()
-	monoVertexInfo.WithLabelValues(version.Version, version.Platform, ds.monoVtx.Name).Set(1)
+	// Todo: clean it up in v1.6
+	deprecatedMonoVertexInfo.WithLabelValues(version.Version, version.Platform, ds.monoVtx.Name).Set(1)
+	metrics.BuildInfo.WithLabelValues(v1alpha1.ComponentMonoVertexDaemon, ds.monoVtx.Name, version.Version, version.Platform).Set(1)
 
 	log.Infof("MonoVertex daemon server started successfully on %s", address)
 	<-ctx.Done()

--- a/pkg/mvtxdaemon/server/metrics.go
+++ b/pkg/mvtxdaemon/server/metrics.go
@@ -24,9 +24,10 @@ import (
 )
 
 var (
-	monoVertexInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	// Deprecated: Use pkg/metrics.BuildInfo instead.
+	deprecatedMonoVertexInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: "monovtx",
 		Name:      "build_info",
-		Help:      "A metric with a constant value '1', labeled by Numaflow binary version and platform, as well as the mono vertex name",
+		Help:      "A metric with a constant value '1', labeled by Numaflow binary version and platform, as well as the mono vertex name.  Deprecated: Use build_info instead",
 	}, []string{metrics.LabelVersion, metrics.LabelPlatform, metrics.LabelMonoVertexName})
 )


### PR DESCRIPTION


```
# HELP build_info A metric with a constant value '1', labeled by Numaflow binary version, platform, and other information
# TYPE build_info gauge
build_info{component="daemon",component_name="simple-pipeline",platform="linux/arm64",version="latest+7450e16.dirty"} 1

# HELP pipeline_build_info A metric with a constant value '1', labeled by Numaflow binary version and platform, as well as the pipeline name. Deprecated: Use build_info instead
# TYPE pipeline_build_info gauge
pipeline_build_info{pipeline="simple-pipeline",platform="linux/arm64",version="latest+7450e16.dirty"} 1
```

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
