### PR TITLE
chore: make transformer sub component of source

### DIFF
--- a/rust/numaflow-core/src/monovertex.rs
+++ b/rust/numaflow-core/src/monovertex.rs
@@ -1,4 +1,3 @@
-use forwarder::ForwarderBuilder;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -10,7 +9,6 @@ use crate::shared::create_components;
 use crate::sink::SinkWriter;
 use crate::source::Source;
 use crate::tracker::TrackerHandle;
-use crate::transformer::Transformer;
 use crate::{metrics, shared};
 
 /// [forwarder] orchestrates data movement from the Source to the Sink via the optional SourceTransformer.
@@ -26,19 +24,20 @@ pub(crate) async fn start_forwarder(
     config: &MonovertexConfig,
 ) -> error::Result<()> {
     let tracker_handle = TrackerHandle::new();
-    let (source, source_grpc_client) = create_components::create_source(
+    let (transformer, transformer_grpc_client) = create_components::create_transformer(
         config.batch_size,
-        config.read_timeout,
-        &config.source_config,
+        config.transformer_config.clone(),
         tracker_handle.clone(),
         cln_token.clone(),
     )
     .await?;
 
-    let (transformer, transformer_grpc_client) = create_components::create_transformer(
+    let (source, source_grpc_client) = create_components::create_source(
         config.batch_size,
-        config.transformer_config.clone(),
+        config.read_timeout,
+        &config.source_config,
         tracker_handle.clone(),
+        transformer,
         cln_token.clone(),
     )
     .await?;
@@ -69,7 +68,7 @@ pub(crate) async fn start_forwarder(
     // FIXME: what to do with the handle
     shared::metrics::start_metrics_server(config.metrics_config.clone(), metrics_state).await;
 
-    start(config.clone(), source, sink_writer, transformer, cln_token).await?;
+    start(config.clone(), source, sink_writer, cln_token).await?;
 
     Ok(())
 }
@@ -78,7 +77,6 @@ async fn start(
     mvtx_config: MonovertexConfig,
     source: Source,
     sink: SinkWriter,
-    transformer: Option<Transformer>,
     cln_token: CancellationToken,
 ) -> error::Result<()> {
     // start the pending reader to publish pending metrics
@@ -89,18 +87,9 @@ async fn start(
     .await;
     let _pending_reader_handle = pending_reader.start(is_mono_vertex()).await;
 
-    let mut forwarder_builder = ForwarderBuilder::new(source, sink, cln_token);
-
-    // add transformer if exists
-    if let Some(transformer_client) = transformer {
-        forwarder_builder = forwarder_builder.transformer(transformer_client);
-    }
-
-    // build the final forwarder
-    let forwarder = forwarder_builder.build();
+    let forwarder = forwarder::Forwarder::new(source, sink, cln_token);
 
     info!("Forwarder is starting...");
-
     // start the forwarder, it will return only on Signal
     forwarder.start().await?;
 

--- a/rust/numaflow-core/src/monovertex/forwarder.rs
+++ b/rust/numaflow-core/src/monovertex/forwarder.rs
@@ -33,7 +33,6 @@ use tokio_util::sync::CancellationToken;
 use crate::error;
 use crate::sink::SinkWriter;
 use crate::source::Source;
-use crate::transformer::Transformer;
 use crate::Error;
 
 /// Forwarder is responsible for reading messages from the source, applying transformation if
@@ -41,78 +40,34 @@ use crate::Error;
 /// back to the source.
 pub(crate) struct Forwarder {
     source: Source,
-    transformer: Option<Transformer>,
     sink_writer: SinkWriter,
     cln_token: CancellationToken,
-}
-
-pub(crate) struct ForwarderBuilder {
-    source: Source,
-    sink_writer: SinkWriter,
-    cln_token: CancellationToken,
-    transformer: Option<Transformer>,
-}
-
-impl ForwarderBuilder {
-    /// Create a new builder with mandatory fields
-    pub(crate) fn new(
-        streaming_source: Source,
-        streaming_sink: SinkWriter,
-        cln_token: CancellationToken,
-    ) -> Self {
-        Self {
-            source: streaming_source,
-            sink_writer: streaming_sink,
-            cln_token,
-            transformer: None,
-        }
-    }
-
-    /// Set the optional transformer client
-    pub(crate) fn transformer(mut self, transformer: Transformer) -> Self {
-        self.transformer = Some(transformer);
-        self
-    }
-
-    /// Build the StreamingForwarder instance
-    #[must_use]
-    pub(crate) fn build(self) -> Forwarder {
-        Forwarder {
-            source: self.source,
-            sink_writer: self.sink_writer,
-            transformer: self.transformer,
-            cln_token: self.cln_token,
-        }
-    }
 }
 
 impl Forwarder {
+    pub(crate) fn new(
+        source: Source,
+        sink_writer: SinkWriter,
+        cln_token: CancellationToken,
+    ) -> Self {
+        Self {
+            source,
+            sink_writer,
+            cln_token,
+        }
+    }
     pub(crate) async fn start(&self) -> error::Result<()> {
         let (messages_stream, reader_handle) =
             self.source.streaming_read(self.cln_token.clone())?;
 
-        let (transformed_messages_stream, transformer_handle) =
-            if let Some(transformer) = &self.transformer {
-                let (transformed_messages_rx, transformer_handle) =
-                    transformer.transform_stream(messages_stream)?;
-                (transformed_messages_rx, Some(transformer_handle))
-            } else {
-                (messages_stream, None)
-            };
-
         let sink_writer_handle = self
             .sink_writer
-            .streaming_write(transformed_messages_stream, self.cln_token.clone())
+            .streaming_write(messages_stream, self.cln_token.clone())
             .await?;
 
-        match tokio::try_join!(
-            reader_handle,
-            transformer_handle.unwrap_or_else(|| tokio::spawn(async { Ok(()) })),
-            sink_writer_handle,
-        ) {
-            Ok((reader_result, transformer_result, sink_writer_result)) => {
+        match tokio::try_join!(reader_handle, sink_writer_handle,) {
+            Ok((reader_result, sink_writer_result)) => {
                 sink_writer_result?;
-                transformer_result?;
                 reader_result?;
                 Ok(())
             }
@@ -141,7 +96,7 @@ mod tests {
     use tokio::task::JoinHandle;
     use tokio_util::sync::CancellationToken;
 
-    use crate::monovertex::forwarder::ForwarderBuilder;
+    use crate::monovertex::forwarder::Forwarder;
     use crate::shared::grpc::create_rpc_channel;
     use crate::sink::{SinkClientType, SinkWriterBuilder};
     use crate::source::user_defined::new_source;
@@ -233,8 +188,35 @@ mod tests {
 
     #[tokio::test]
     async fn test_forwarder() {
+        let tracker_handle = TrackerHandle::new();
+
         // create the source which produces x number of messages
         let cln_token = CancellationToken::new();
+
+        // create a transformer
+        let (st_shutdown_tx, st_shutdown_rx) = oneshot::channel();
+        let tmp_dir = TempDir::new().unwrap();
+        let sock_file = tmp_dir.path().join("sourcetransform.sock");
+        let server_info_file = tmp_dir.path().join("sourcetransformer-server-info");
+
+        let server_info = server_info_file.clone();
+        let server_socket = sock_file.clone();
+        let transformer_handle = tokio::spawn(async move {
+            sourcetransform::Server::new(SimpleTransformer)
+                .with_socket_file(server_socket)
+                .with_server_info_file(server_info)
+                .start_with_shutdown(st_shutdown_rx)
+                .await
+                .expect("server failed");
+        });
+
+        // wait for the server to start
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let client = SourceTransformClient::new(create_rpc_channel(sock_file).await.unwrap());
+        let transformer = Transformer::new(10, 10, client, tracker_handle.clone())
+            .await
+            .unwrap();
 
         let (src_shutdown_tx, src_shutdown_rx) = oneshot::channel();
         let tmp_dir = TempDir::new().unwrap();
@@ -263,38 +245,13 @@ mod tests {
             .await
             .map_err(|e| panic!("failed to create source reader: {:?}", e))
             .unwrap();
-        let tracker_handle = TrackerHandle::new();
         let source = Source::new(
             5,
             SourceType::UserDefinedSource(src_read, src_ack, lag_reader),
             tracker_handle.clone(),
             true,
+            Some(transformer),
         );
-
-        // create a transformer
-        let (st_shutdown_tx, st_shutdown_rx) = oneshot::channel();
-        let tmp_dir = TempDir::new().unwrap();
-        let sock_file = tmp_dir.path().join("sourcetransform.sock");
-        let server_info_file = tmp_dir.path().join("sourcetransformer-server-info");
-
-        let server_info = server_info_file.clone();
-        let server_socket = sock_file.clone();
-        let transformer_handle = tokio::spawn(async move {
-            sourcetransform::Server::new(SimpleTransformer)
-                .with_socket_file(server_socket)
-                .with_server_info_file(server_info)
-                .start_with_shutdown(st_shutdown_rx)
-                .await
-                .expect("server failed");
-        });
-
-        // wait for the server to start
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        let client = SourceTransformClient::new(create_rpc_channel(sock_file).await.unwrap());
-        let transformer = Transformer::new(10, 10, client, tracker_handle.clone())
-            .await
-            .unwrap();
 
         let sink_writer = SinkWriterBuilder::new(
             10,
@@ -307,9 +264,7 @@ mod tests {
         .unwrap();
 
         // create the forwarder with the source, transformer, and writer
-        let forwarder = ForwarderBuilder::new(source.clone(), sink_writer, cln_token.clone())
-            .transformer(transformer)
-            .build();
+        let forwarder = Forwarder::new(source.clone(), sink_writer, cln_token.clone());
 
         let forwarder_handle: JoinHandle<Result<()>> = tokio::spawn(async move {
             forwarder.start().await?;
@@ -366,6 +321,31 @@ mod tests {
         // create the source which produces x number of messages
         let cln_token = CancellationToken::new();
 
+        // create a transformer
+        let (st_shutdown_tx, st_shutdown_rx) = oneshot::channel();
+        let tmp_dir = TempDir::new().unwrap();
+        let sock_file = tmp_dir.path().join("sourcetransform.sock");
+        let server_info_file = tmp_dir.path().join("sourcetransformer-server-info");
+
+        let server_info = server_info_file.clone();
+        let server_socket = sock_file.clone();
+        let transformer_handle = tokio::spawn(async move {
+            sourcetransform::Server::new(FlatMapTransformer)
+                .with_socket_file(server_socket)
+                .with_server_info_file(server_info)
+                .start_with_shutdown(st_shutdown_rx)
+                .await
+                .expect("server failed");
+        });
+
+        // wait for the server to start
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let client = SourceTransformClient::new(create_rpc_channel(sock_file).await.unwrap());
+        let transformer = Transformer::new(10, 10, client, tracker_handle.clone())
+            .await
+            .unwrap();
+
         let (src_shutdown_tx, src_shutdown_rx) = oneshot::channel();
         let tmp_dir = TempDir::new().unwrap();
         let sock_file = tmp_dir.path().join("source.sock");
@@ -399,32 +379,8 @@ mod tests {
             SourceType::UserDefinedSource(src_read, src_ack, lag_reader),
             tracker_handle.clone(),
             true,
+            Some(transformer),
         );
-
-        // create a transformer
-        let (st_shutdown_tx, st_shutdown_rx) = oneshot::channel();
-        let tmp_dir = TempDir::new().unwrap();
-        let sock_file = tmp_dir.path().join("sourcetransform.sock");
-        let server_info_file = tmp_dir.path().join("sourcetransformer-server-info");
-
-        let server_info = server_info_file.clone();
-        let server_socket = sock_file.clone();
-        let transformer_handle = tokio::spawn(async move {
-            sourcetransform::Server::new(FlatMapTransformer)
-                .with_socket_file(server_socket)
-                .with_server_info_file(server_info)
-                .start_with_shutdown(st_shutdown_rx)
-                .await
-                .expect("server failed");
-        });
-
-        // wait for the server to start
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        let client = SourceTransformClient::new(create_rpc_channel(sock_file).await.unwrap());
-        let transformer = Transformer::new(10, 10, client, tracker_handle.clone())
-            .await
-            .unwrap();
 
         let sink_writer = SinkWriterBuilder::new(
             10,
@@ -437,9 +393,7 @@ mod tests {
         .unwrap();
 
         // create the forwarder with the source, transformer, and writer
-        let forwarder = ForwarderBuilder::new(source.clone(), sink_writer, cln_token.clone())
-            .transformer(transformer)
-            .build();
+        let forwarder = Forwarder::new(source.clone(), sink_writer, cln_token.clone());
 
         let forwarder_handle: JoinHandle<Result<()>> = tokio::spawn(async move {
             forwarder.start().await?;

--- a/rust/numaflow-core/src/pipeline/forwarder/source_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/source_forwarder.rs
@@ -4,90 +4,45 @@ use crate::error;
 use crate::error::Error;
 use crate::pipeline::isb::jetstream::writer::JetstreamWriter;
 use crate::source::Source;
-use crate::transformer::Transformer;
 
 /// Source forwarder is the orchestrator which starts streaming source, a transformer, and an isb writer
 /// and manages the lifecycle of these components.
 pub(crate) struct SourceForwarder {
     source: Source,
-    transformer: Option<Transformer>,
     writer: JetstreamWriter,
     cln_token: CancellationToken,
 }
 
-/// ForwarderBuilder is a builder for Forwarder.
-pub(crate) struct SourceForwarderBuilder {
-    streaming_source: Source,
-    transformer: Option<Transformer>,
-    writer: JetstreamWriter,
-    cln_token: CancellationToken,
-}
-
-impl SourceForwarderBuilder {
+impl SourceForwarder {
     pub(crate) fn new(
-        streaming_source: Source,
+        source: Source,
         writer: JetstreamWriter,
         cln_token: CancellationToken,
     ) -> Self {
         Self {
-            streaming_source,
-            transformer: None,
+            source,
             writer,
             cln_token,
         }
     }
 
-    pub(crate) fn with_transformer(mut self, transformer: Transformer) -> Self {
-        self.transformer = Some(transformer);
-        self
-    }
-
-    pub(crate) fn build(self) -> SourceForwarder {
-        SourceForwarder {
-            source: self.streaming_source,
-            transformer: self.transformer,
-            writer: self.writer,
-            cln_token: self.cln_token,
-        }
-    }
-}
-
-impl SourceForwarder {
     /// Start the forwarder by starting the streaming source, transformer, and writer.
     pub(crate) async fn start(&self) -> error::Result<()> {
         // RETHINK: only source should stop when the token is cancelled, transformer and writer should drain the streams
         // and then stop.
-        let (read_messages_stream, reader_handle) =
+        let (messages_stream, reader_handle) =
             self.source.streaming_read(self.cln_token.clone())?;
 
-        // start the transformer if it is present
-        let (transformed_messages_stream, transformer_handle) =
-            if let Some(transformer) = &self.transformer {
-                let (transformed_messages_stream, transformer_handle) =
-                    transformer.transform_stream(read_messages_stream)?;
-                (transformed_messages_stream, Some(transformer_handle))
-            } else {
-                (read_messages_stream, None)
-            };
+        let writer_handle = self.writer.streaming_write(messages_stream).await?;
 
-        let writer_handle = self
-            .writer
-            .streaming_write(transformed_messages_stream)
-            .await?;
-
-        match tokio::try_join!(
-            reader_handle,
-            transformer_handle.unwrap_or_else(|| tokio::spawn(async { Ok(()) })),
-            writer_handle,
-        ) {
-            Ok((reader_result, transformer_result, sink_writer_result)) => {
+        match tokio::try_join!(reader_handle, writer_handle,) {
+            Ok((reader_result, sink_writer_result)) => {
                 sink_writer_result?;
-                transformer_result?;
                 reader_result?;
                 Ok(())
             }
             Err(e) => Err(Error::Forwarder(format!(
-                "Error while joining reader, transformer, and sink writer: {:?}",
+                "Error while joining reader and sink writer: {:?}",
                 e
             ))),
         }
@@ -115,8 +70,8 @@ mod tests {
 
     use crate::config::pipeline::isb::BufferWriterConfig;
     use crate::config::pipeline::ToVertexConfig;
+    use crate::pipeline::forwarder::source_forwarder::SourceForwarder;
     use crate::pipeline::isb::jetstream::writer::JetstreamWriter;
-    use crate::pipeline::source_forwarder::SourceForwarderBuilder;
     use crate::shared::grpc::create_rpc_channel;
     use crate::source::user_defined::new_source;
     use crate::source::{Source, SourceType};
@@ -213,6 +168,30 @@ mod tests {
         // create the source which produces x number of messages
         let cln_token = CancellationToken::new();
 
+        // create a transformer
+        let (st_shutdown_tx, st_shutdown_rx) = oneshot::channel();
+        let tmp_dir = TempDir::new().unwrap();
+        let sock_file = tmp_dir.path().join("sourcetransform.sock");
+        let server_info_file = tmp_dir.path().join("sourcetransformer-server-info");
+
+        let server_info = server_info_file.clone();
+        let server_socket = sock_file.clone();
+        let transformer_handle = tokio::spawn(async move {
+            sourcetransform::Server::new(SimpleTransformer)
+                .with_socket_file(server_socket)
+                .with_server_info_file(server_info)
+                .start_with_shutdown(st_shutdown_rx)
+                .await
+                .expect("server failed");
+        });
+
+        // wait for the server to start
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let client = SourceTransformClient::new(create_rpc_channel(sock_file).await.unwrap());
+        let transformer = Transformer::new(10, 10, client, tracker_handle.clone())
+            .await
+            .unwrap();
+
         let (src_shutdown_tx, src_shutdown_rx) = oneshot::channel();
         let tmp_dir = TempDir::new().unwrap();
         let sock_file = tmp_dir.path().join("source.sock");
@@ -246,6 +225,7 @@ mod tests {
             SourceType::UserDefinedSource(src_read, src_ack, lag_reader),
             tracker_handle.clone(),
             true,
+            Some(transformer),
         );
 
         // create a js writer
@@ -294,34 +274,8 @@ mod tests {
             cln_token.clone(),
         );
 
-        // create a transformer
-        let (st_shutdown_tx, st_shutdown_rx) = oneshot::channel();
-        let tmp_dir = TempDir::new().unwrap();
-        let sock_file = tmp_dir.path().join("sourcetransform.sock");
-        let server_info_file = tmp_dir.path().join("sourcetransformer-server-info");
-
-        let server_info = server_info_file.clone();
-        let server_socket = sock_file.clone();
-        let transformer_handle = tokio::spawn(async move {
-            sourcetransform::Server::new(SimpleTransformer)
-                .with_socket_file(server_socket)
-                .with_server_info_file(server_info)
-                .start_with_shutdown(st_shutdown_rx)
-                .await
-                .expect("server failed");
-        });
-
-        // wait for the server to start
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        let client = SourceTransformClient::new(create_rpc_channel(sock_file).await.unwrap());
-        let transformer = Transformer::new(10, 10, client, tracker_handle)
-            .await
-            .unwrap();
-
         // create the forwarder with the source, transformer, and writer
-        let forwarder = SourceForwarderBuilder::new(source.clone(), writer, cln_token.clone())
-            .with_transformer(transformer)
-            .build();
+        let forwarder = SourceForwarder::new(source.clone(), writer, cln_token.clone());
 
         let forwarder_handle: JoinHandle<Result<()>> = tokio::spawn(async move {
             forwarder.start().await?;

--- a/rust/numaflow-core/src/shared/create_components.rs
+++ b/rust/numaflow-core/src/shared/create_components.rs
@@ -271,6 +271,7 @@ pub async fn create_source(
     read_timeout: Duration,
     source_config: &SourceConfig,
     tracker_handle: TrackerHandle,
+    transformer: Option<Transformer>,
     cln_token: CancellationToken,
 ) -> error::Result<(Source, Option<SourceClient<Channel>>)> {
     match &source_config.source_type {
@@ -283,6 +284,7 @@ pub async fn create_source(
                     source::SourceType::Generator(generator_read, generator_ack, generator_lag),
                     tracker_handle,
                     source_config.read_ahead,
+                    transformer,
                 ),
                 None,
             ))
@@ -321,6 +323,7 @@ pub async fn create_source(
                     source::SourceType::UserDefinedSource(ud_read, ud_ack, ud_lag),
                     tracker_handle,
                     source_config.read_ahead,
+                    transformer,
                 ),
                 Some(source_grpc_client),
             ))
@@ -333,6 +336,7 @@ pub async fn create_source(
                     source::SourceType::Pulsar(pulsar),
                     tracker_handle,
                     source_config.read_ahead,
+                    transformer,
                 ),
                 None,
             ))
@@ -351,6 +355,7 @@ pub async fn create_source(
                     source::SourceType::Serving(serving),
                     tracker_handle,
                     source_config.read_ahead,
+                    transformer,
                 ),
                 None,
             ))

--- a/rust/numaflow-core/src/transformer.rs
+++ b/rust/numaflow-core/src/transformer.rs
@@ -1,15 +1,15 @@
 use std::sync::Arc;
 
-use numaflow_pb::clients::sourcetransformer::source_transform_client::SourceTransformClient;
-use tokio::sync::{mpsc, oneshot, Semaphore};
-use tonic::transport::Channel;
-use tracing::info;
 use crate::error::Error;
 use crate::message::Message;
 use crate::metrics::{monovertex_metrics, mvtx_forward_metric_labels};
 use crate::tracker::TrackerHandle;
 use crate::transformer::user_defined::UserDefinedTransformer;
 use crate::Result;
+use numaflow_pb::clients::sourcetransformer::source_transform_client::SourceTransformClient;
+use tokio::sync::{mpsc, oneshot, Semaphore};
+use tonic::transport::Channel;
+use tracing::info;
 
 /// User-Defined Transformer is a custom transformer that can be built by the user.
 ///

--- a/rust/numaflow-core/src/transformer.rs
+++ b/rust/numaflow-core/src/transformer.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use numaflow_pb::clients::sourcetransformer::source_transform_client::SourceTransformClient;
 use tokio::sync::{mpsc, oneshot, Semaphore};
 use tonic::transport::Channel;
-
+use tracing::info;
 use crate::error::Error;
 use crate::message::Message;
 use crate::metrics::{monovertex_metrics, mvtx_forward_metric_labels};
@@ -53,6 +53,7 @@ impl TransformerActor {
         while let Some(msg) = self.receiver.recv().await {
             self.handle_message(msg).await;
         }
+        info!("transformer handler is stopping");
     }
 }
 


### PR DESCRIPTION
* Makes source transformer a sub-component of source.
* Removes streaming functionality for transformer, since source transformer is not meant for long running requests.