### PR TITLE
fix(test): use different approach to start jetstream service

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
         ports:
           - 4222:4222
         options: >-
-          --entrypoint "/nats-server"
+          --entrypoint "/nats-server -js"
 
     steps:
       - name: Start Pulsar standalone container

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,12 +73,11 @@ jobs:
           --health-retries 5
       nats:
         image: "bitnami/nats:latest"
+        entrypoint: /nats-server -js
         ports:
           - 4222:4222
           - 6222:6222
           - 8222:8222
-        options: |
-          -js
 
     steps:
       - name: Start Pulsar standalone container

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,14 +71,13 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-      nats:
-        image: "nats:latest"
-        ports:
-          - 4222:4222
 
     steps:
       - name: Start Pulsar standalone container
         run: docker run -d -p 6650:6650 -p 8080:8080 apachepulsar/pulsar:4.0.0 bin/pulsar standalone
+
+      - name: Start JetStream
+        run: docker run -d -p 4222:4222 nats:latest
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
         run: docker run -d -p 6650:6650 -p 8080:8080 apachepulsar/pulsar:4.0.0 bin/pulsar standalone
 
       - name: Start JetStream
-        run: docker run -d -p 4222:4222 nats:latest
+        run: docker run -d -p 4222:4222 nats:latest -js
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
           --health-retries 5
       nats:
         image: "bitnami/nats:latest"
-        entrypoint: /nats-server -js
+        entrypoint: "/nats-server -js"
         ports:
           - 4222:4222
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       nats:
-        image: "bitnami/nats:latest"
+        image: "bitnami/nats:2.10.23"
         ports:
           - 4222:4222
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
         ports:
           - 4222:4222
         options: >-
-          --entrypoint="/nats-server -js"
+          --entrypoint "[\"/nats-server\", \"-js\"]"
 
     steps:
       - name: Start Pulsar standalone container

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
         ports:
           - 4222:4222
         options: >-
-          --entrypoint "[\"/nats-server\", \"-js\"]"
+          --entrypoint "/nats-server"
 
     steps:
       - name: Start Pulsar standalone container

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,9 +73,10 @@ jobs:
           --health-retries 5
       nats:
         image: "bitnami/nats:latest"
-        entrypoint: "/nats-server -js"
         ports:
           - 4222:4222
+        options: >-
+          --entrypoint /nats-server -js
 
     steps:
       - name: Start Pulsar standalone container

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,11 +72,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       nats:
-        image: "bitnami/nats:latest"
+        image: "nats:latest"
         ports:
           - 4222:4222
-        options: >-
-          --entrypoint "/nats-server -js"
 
     steps:
       - name: Start Pulsar standalone container

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,8 +76,6 @@ jobs:
         entrypoint: /nats-server -js
         ports:
           - 4222:4222
-          - 6222:6222
-          - 8222:8222
 
     steps:
       - name: Start Pulsar standalone container

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
         ports:
           - 4222:4222
         options: >-
-          --entrypoint /nats-server -js
+          --entrypoint="/nats-server -js"
 
     steps:
       - name: Start Pulsar standalone container

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,11 +73,11 @@ jobs:
           --health-retries 5
 
     steps:
-      - name: Start Pulsar standalone container
-        run: docker run -d -p 6650:6650 -p 8080:8080 apachepulsar/pulsar:4.0.0 bin/pulsar standalone
-
       - name: Start JetStream
         run: docker run -d -p 4222:4222 nats:latest -js
+
+      - name: Start Pulsar standalone container
+        run: docker run -d -p 6650:6650 -p 8080:8080 apachepulsar/pulsar:4.0.0 bin/pulsar standalone
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,11 +72,13 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       nats:
-        image: "bitnami/nats:2.10.23"
+        image: "bitnami/nats:latest"
         ports:
           - 4222:4222
-        env:
-          NATS_EXTRA_ARGS: -js
+          - 6222:6222
+          - 8222:8222
+        options: |
+          -js
 
     steps:
       - name: Start Pulsar standalone container


### PR DESCRIPTION
From [2.10.24](https://github.com/bitnami/containers/pull/76503/files), there's no way to run `bitnami/nats` for JetStream in Github Action Services any more, have to use a different approach to do it.

The problem is there's no way to run `/nats-server -js` with Github Services - can not specify args, can specify endpoint but can not specify endpoint with args.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
