### PR TITLE
fix: get status of init containers in pods-info API call

### DIFF
--- a/ui/src/utils/fetcherHooks/podsViewFetch.ts
+++ b/ui/src/utils/fetcherHooks/podsViewFetch.ts
@@ -61,7 +61,7 @@ export const usePodsViewFetch = (
               JSON.stringify(pod?.spec?.containers)
             );
             pod?.spec?.initContainers
-              ?.filter((initContainer: any) => initContainer?.name !== "init")
+              ?.filter((initContainer: any) => initContainer?.restartPolicy === "Always")
               ?.forEach((container: any) => containersList.push(container));
 
             containersList?.forEach((container: any) => {


### PR DESCRIPTION
In the call to `pods-info` API for UI, get status of sidecar containers (udsink, udsource etc) as well. 