### PR TITLE
fix: error handling in case of udsink failures

### DIFF
--- a/rust/numaflow-core/src/sink.rs
+++ b/rust/numaflow-core/src/sink.rs
@@ -306,6 +306,7 @@ impl SinkWriter {
                                 // Discard the message from the tracker
                                 this.tracker_handle.discard(offset).await?;
                             }
+                            return Err(e);
                         }
                     }
 

--- a/rust/numaflow-core/src/source.rs
+++ b/rust/numaflow-core/src/source.rs
@@ -338,7 +338,7 @@ impl Source {
                 // write the messages to downstream.
                 for message in messages {
                     messages_tx.send(message).await.map_err(|e| {
-                        Error::Source(format!("failed to send message downstream {:?}", e))
+                        Error::Source(format!("failed to send message to downstream {:?}", e))
                     })?;
                 }
             }

--- a/rust/numaflow-core/src/source.rs
+++ b/rust/numaflow-core/src/source.rs
@@ -7,11 +7,11 @@ use crate::metrics::{
     pipeline_isb_metric_labels, pipeline_metrics,
 };
 use crate::tracker::TrackerHandle;
-use crate::Result;
 use crate::{
     message::{Message, Offset},
     reader::LagReader,
 };
+use crate::{Error, Result};
 use numaflow_pulsar::source::PulsarSource;
 use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
@@ -337,10 +337,9 @@ impl Source {
 
                 // write the messages to downstream.
                 for message in messages {
-                    messages_tx
-                        .send(message)
-                        .await
-                        .expect("send should not fail");
+                    messages_tx.send(message).await.map_err(|e| {
+                        Error::Source(format!("failed to send message downstream {:?}", e))
+                    })?;
                 }
             }
         });


### PR DESCRIPTION
@yhl25 and I were debugging a scenario where udsink panics. We observed that numa container wasn't restarting as it should. Fixed the error handling in this case.


Before PR:

```
2025-01-28T05:21:06.974698Z ERROR numaflow_core::source: Nak received for offset offset=String(StringOffset { offset: b"MTczODA0MTY2Njk0NzEwODU2NC0x", partition_idx: 0 })
2025-01-28T05:21:06.974694Z ERROR numaflow_core::source: Nak received for offset offset=String(StringOffset { offset: b"MTczODA0MTY2Njk0NzEwODU2NC0w", partition_idx: 0 })
2025-01-28T05:21:06.974628Z ERROR numaflow_core::sink: Error writing to sink e=Grpc("status: Unknown, message: \"panic inside sink handler: sink fn panicked on multiple of 3\", details: [], metadata: MetadataMap { headers: {} }")
```


With this PR:

```
2025-01-28T06:50:48.818759Z  INFO numaflow_core::metrics: Stopped the Lag-Reader Expose and Builder tasks
2025-01-28T06:50:48.818764Z ERROR numaflow_core: Application error running monovertex: Grpc("status: Unknown, message: \"panic inside sink handler: sink fn panicked on multiple of 3\", details: [], metadata: MetadataMap { headers: {} }")
2025-01-28T06:50:48.818768Z  INFO numaflow_core: Gracefully Exiting...
```

How to generate?

```
apiVersion: numaflow.numaproj.io/v1alpha1  
  
kind: MonoVertex  
  
metadata:  
  name: simple-mono-vertex  
spec:  
  source:  
    generator:  
      rpu: 50  
      duration: 1s  
  sink:  
    udsink:  
      container:  
        image: quay.io/adarsh0728/test/sink-log:stable
```

