### PR TITLE
fix: timestamp and level filter fix for logs

### DIFF
--- a/server/apis/v1/handler.go
+++ b/server/apis/v1/handler.go
@@ -924,10 +924,11 @@ func (h *handler) PodLogs(c *gin.Context) {
 	// parse the query parameters
 	tailLines := h.parseTailLines(c.Query("tailLines"))
 	logOptions := &corev1.PodLogOptions{
-		Container: c.Query("container"),
-		Follow:    c.Query("follow") == "true",
-		TailLines: tailLines,
-		Previous:  c.Query("previous") == "true",
+		Container:  c.Query("container"),
+		Follow:     c.Query("follow") == "true",
+		TailLines:  tailLines,
+		Timestamps: true,
+		Previous:   c.Query("previous") == "true",
 	}
 
 	stream, err := h.kubeClient.CoreV1().Pods(ns).GetLogs(pod, logOptions).Stream(c)

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
@@ -47,6 +47,7 @@ const parsePodLogs = (
 ): string[] => {
   const rawLogs = value.split("\n").filter((s) => s.length);
   return rawLogs.map((raw: string) => {
+    // 30 characters for RFC 3339 timestamp
     const timestamp = raw.substring(0, 30);
     const logWithoutTimestamp = raw.substring(31);
 

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
@@ -38,9 +38,6 @@ import { AppContext } from "../../../../../../../../../../../../../App";
 import "./style.css";
 
 const MAX_LOGS = 1000;
-// const LOGS_LEVEL_ERROR = "ERROR";
-// const LOGS_LEVEL_DEBUG = "DEBUG";
-// const LOGS_LEVEL_WARN = "WARN";
 
 const parsePodLogs = (
   value: string,
@@ -50,91 +47,39 @@ const parsePodLogs = (
 ): string[] => {
   const rawLogs = value.split("\n").filter((s) => s.length);
   return rawLogs.map((raw: string) => {
-    try {
-      if (type === "monoVertex") {
-        const msg = raw;
-        if (levelFilter !== "all" && !msg.toLowerCase().includes(levelFilter)) {
-          return "";
-        }
-        if (!enableTimestamp) {
-          // remove ISO 8601 timestamp from beginning of log if it exists
-          const date = msg.match(
-            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z/
-          );
-          if (date) {
-            return msg.substring(28);
-          }
-        }
-        return msg;
-      } else {
-        const obj = JSON.parse(raw);
-        let msg = ``;
-        if (enableTimestamp && obj?.ts) {
-          const date = obj.ts.split(/[-T:.Z]/);
-          const ds =
-            date[0] +
-            "/" +
-            date[1] +
-            "/" +
-            date[2] +
-            " " +
-            date[3] +
-            ":" +
-            date[4] +
-            ":" +
-            date[5];
-          msg = `${msg}${ds} | `;
-        }
-        if (obj?.level) {
-          msg = `${msg}${obj.level.toUpperCase()} | `;
-          if (levelFilter !== "all" && obj.level !== levelFilter) {
-            return "";
-          }
-        }
-        msg = `${msg}${raw}`;
-        return msg;
+    const timestamp = raw.substring(0, 30);
+    const logWithoutTimestamp = raw.substring(31);
+
+    let msg = enableTimestamp ? `${timestamp} ` : "";
+
+    if (type === "monoVertex") {
+      if (
+        levelFilter !== "all" &&
+        !logWithoutTimestamp.includes(levelFilter.toUpperCase())
+      )
+        return "";
+
+      return `${msg}${logWithoutTimestamp}`;
+    } else {
+      let obj;
+      try {
+        obj = JSON.parse(logWithoutTimestamp);
+      } catch (e) {
+        obj = logWithoutTimestamp;
       }
-    } catch (e) {
-      return raw;
+      // println log, it is not an object
+      if (obj === logWithoutTimestamp) {
+        if (levelFilter !== "all" && !obj.toLowerCase().includes(levelFilter))
+          return "";
+      } else if (obj?.level) {
+        // logger log
+        msg += `${obj.level.toUpperCase()} `;
+        if (levelFilter !== "all" && obj.level !== levelFilter) return "";
+      }
+      return `${msg}${logWithoutTimestamp}`;
     }
   });
 };
-
-// const logColor = (
-//   log: string,
-//   colorMode: string,
-//   enableTimestamp: boolean,
-//   type: string
-// ): string => {
-//   const logLevelColors: { [key: string]: string } = {
-//     ERROR: "#B80000",
-//     WARN: "#FFAD00",
-//     DEBUG: "#81b8ef",
-//   };
-//
-//   let startIndex = 0;
-//   if (enableTimestamp) {
-//     if (type === "monoVertex") {
-//       if (log?.includes(LOGS_LEVEL_ERROR) || log?.includes(LOGS_LEVEL_DEBUG))
-//         startIndex = 28;
-//       else startIndex = 29;
-//     } else {
-//       startIndex = 22;
-//     }
-//   } else {
-//     if (type === "monoVertex") {
-//       if (log?.includes(LOGS_LEVEL_WARN)) startIndex = 1;
-//     }
-//   }
-//
-//   for (const level in logLevelColors) {
-//     if (log.startsWith(level, startIndex)) {
-//       return logLevelColors[level];
-//     }
-//   }
-//
-//   return colorMode === "light" ? "black" : "white";
-// };
 
 export function PodLogs({
   namespaceId,
@@ -155,7 +100,7 @@ export function PodLogs({
   const [paused, setPaused] = useState<boolean>(false);
   const [colorMode, setColorMode] = useState<string>("light");
   const [logsOrder, setLogsOrder] = useState<string>("desc");
-  const [enableTimestamp, setEnableTimestamp] = useState<boolean>(true);
+  const [enableTimestamp, setEnableTimestamp] = useState<boolean>(false);
   const [levelFilter, setLevelFilter] = useState<string>("all");
   const [showPreviousLogs, setShowPreviousLogs] = useState(false);
   const { host } = useContext<AppContextProps>(AppContext);
@@ -603,8 +548,6 @@ export function PodLogs({
                       autoEscape={true}
                       textToHighlight={l}
                       style={{
-                        // uncomment to add color to logs
-                        // color: logColor(l, colorMode, enableTimestamp, type),
                         color: colorMode === "light" ? "black" : "white",
                         fontFamily:
                           "Consolas,Liberation Mono,Courier,monospace",
@@ -644,8 +587,6 @@ export function PodLogs({
                       autoEscape={true}
                       textToHighlight={l}
                       style={{
-                        // uncomment to add color to logs
-                        // color: logColor(l, colorMode, enableTimestamp, type),
                         color: colorMode === "light" ? "black" : "white",
                         fontFamily:
                           "Consolas,Liberation Mono,Courier,monospace",

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
@@ -45,11 +45,11 @@ const parsePodLogs = (
   levelFilter: string,
   type: string
 ): string[] => {
-  const rawLogs = value.split("\n").filter((s) => s.length);
+  const rawLogs = value.split("\n").filter((s) => s.trim().length);
   return rawLogs.map((raw: string) => {
     // 30 characters for RFC 3339 timestamp
-    const timestamp = raw.substring(0, 30);
-    const logWithoutTimestamp = raw.substring(31);
+    const timestamp = raw.length >= 31 ? raw.substring(0, 30) : "";
+    const logWithoutTimestamp = raw.length >= 31 ? raw.substring(31) : raw;
 
     let msg = enableTimestamp ? `${timestamp} ` : "";
 
@@ -65,7 +65,7 @@ const parsePodLogs = (
       let obj;
       try {
         obj = JSON.parse(logWithoutTimestamp);
-      } catch (e) {
+      } catch {
         obj = logWithoutTimestamp;
       }
       // println log, it is not an object


### PR DESCRIPTION
Timestamp is added to all logs from K8S API. 
'All' filter will show all logs and only logs with level info / name will come under respective filter.
Fixes #2354 
Fixes #2341 
Fixes #2342 