### PR TITLE
feat: contextual flow for remaining metrics

### DIFF
--- a/config/advanced-install/namespaced-numaflow-server.yaml
+++ b/config/advanced-install/namespaced-numaflow-server.yaml
@@ -223,52 +223,50 @@ data:
     \ expr: avg_over_time($metric_name{$filters}[$duration])\n  params:\n    - name:
     duration\n      required: true\n    - name: start_time\n      required: false\n
     \   - name: end_time\n      required: false\n  metrics: \n    # set your cpu metric
-    name here\n    - metric_name: namespace_pod_cpu_utilization\n      # set display
-    name as per metric name\n      display_name: CPU Utilization per Pod\n      metric_description:
-    This metric represents the percentage utilization of cpu usage over cpu resource
+    name here\n    - metric_name: namespace_pod_cpu_utilization\n      display_name:
+    Pod CPU Utilization\n      metric_description: This metric represents the percentage
+    utilization of cpu usage over cpu resource limits for a pod.\n      required_filters:\n
+    \       - namespace\n        - pod  \n      dimensions:\n        - name: mono-vertex\n
+    \         filters: \n            - name: pod\n              # expr: optional expression
+    for prometheus query\n              # overrides the default expression\n              required:
+    false\n        - name: vertex\n          filters: \n            - name: pod\n
+    \             # expr: optional expression for prometheus query\n              #
+    overrides the default expression \n              required: false\n    # set your
+    memory metric name here\n    - metric_name: namespace_pod_memory_utilization\n
+    \     display_name: Pod Memory Utilization\n      metric_description: This metric
+    represents the percentage utilization of memory usage in bytes over memory resource
     limits for a pod.\n      required_filters:\n        - namespace\n        - pod
     \ \n      dimensions:\n        - name: mono-vertex\n          filters: \n            -
     name: pod\n              # expr: optional expression for prometheus query\n              #
-    overrides the default expression\n              required: false\n        - name:
+    overrides the default expression \n              required: false\n        - name:
     vertex\n          filters: \n            - name: pod\n              # expr: optional
     expression for prometheus query\n              # overrides the default expression
-    \n              required: false\n    # set your memory metric name here\n    -
-    metric_name: namespace_pod_memory_utilization\n      # set display name as per
-    metric name\n      display_name: Memory Utilization per Pod\n      metric_description:
-    This metric represents the percentage utilization of memory usage in bytes over
-    memory resource limits for a pod.\n      required_filters:\n        - namespace\n
-    \       - pod  \n      dimensions:\n        - name: mono-vertex\n          filters:
-    \n            - name: pod\n              # expr: optional expression for prometheus
-    query\n              # overrides the default expression \n              required:
-    false\n        - name: vertex\n          filters: \n            - name: pod\n
-    \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n\n- name: container_cpu_memory_utilization\n
+    \n              required: false\n\n- name: container_cpu_memory_utilization\n
     \ objects: \n    - mono-vertex\n    - vertex\n  title: CPU and Memory Utilisation
     by Container\n  description: This pattern represents the CPU and Memory utilisation
     by container for mono-vertex and vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n
     \ params:\n    - name: duration\n      required: true\n    - name: start_time\n
     \     required: false\n    - name: end_time\n      required: false\n  metrics:\n
     \   # set your cpu metric name here\n    - metric_name: namespace_app_container_cpu_utilization\n
-    \     # set display name as per metric name\n      display_name: CPU Utilization
-    per Container\n      metric_description: This metric represents the percentage
-    utilization of cpu usage over cpu resource limits for a container.\n      required_filters:\n
-    \       - namespace\n      dimensions:\n        - name: mono-vertex\n          filters:
-    \n            - name: container\n              # expr: optional expression for
-    prometheus query\n              # overrides the default expression \n              required:
-    false\n        - name: vertex\n          filters:\n            - name: container\n
+    \     display_name: Container CPU Utilization\n      metric_description: This
+    metric represents the percentage utilization of cpu usage over cpu resource limits
+    for a container.\n      required_filters:\n        - namespace\n      dimensions:\n
+    \       - name: mono-vertex\n          filters: \n            - name: container\n
     \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n    # set your
-    memory metric name here\n    - metric_name: namespace_app_container_memory_utilization\n
-    \     # set display name as per metric name\n      display_name: Memory Utilization
-    per Container\n      metric_description: This metric represents the percentage
-    utilization of memory usage in bytes over memory resource limits for a container.\n
-    \     required_filters:\n        - namespace\n      dimensions:\n        - name:
-    mono-vertex\n          filters: \n            - name: container\n              #
-    expr: optional expression for prometheus query\n              # overrides the
-    default expression \n              required: false\n        - name: vertex\n          filters:
-    \n            - name: container\n              # expr: optional expression for
-    prometheus query\n              # overrides the default expression \n              required:
-    false\n"
+    overrides the default expression \n              required: false\n        - name:
+    vertex\n          filters:\n            - name: container\n              # expr:
+    optional expression for prometheus query\n              # overrides the default
+    expression \n              required: false\n    # set your memory metric name
+    here\n    - metric_name: namespace_app_container_memory_utilization\n      display_name:
+    Container Memory Utilization\n      metric_description: This metric represents
+    the percentage utilization of memory usage in bytes over memory resource limits
+    for a container.\n      required_filters:\n        - namespace\n      dimensions:\n
+    \       - name: mono-vertex\n          filters: \n            - name: container\n
+    \             # expr: optional expression for prometheus query\n              #
+    overrides the default expression \n              required: false\n        - name:
+    vertex\n          filters: \n            - name: container\n              # expr:
+    optional expression for prometheus query\n              # overrides the default
+    expression \n              required: false\n"
 kind: ConfigMap
 metadata:
   name: numaflow-server-metrics-proxy-config

--- a/config/advanced-install/namespaced-numaflow-server.yaml
+++ b/config/advanced-install/namespaced-numaflow-server.yaml
@@ -141,15 +141,15 @@ data:
     which the metrics proxy will connect\n# url: service_name + \".\" + service_namespace
     + \".svc.cluster.local\" + \":\" + port\n# example for local prometheus service\n#
     url: http://prometheus-operated.monitoring.svc.cluster.local:9090\npatterns:\n-
-    name: vertex_gauge\n  objects: \n    - vertex\n  title: Vertex Pending Messages\n
-    \ description: This query is the total number of pending messages for the vertex\n
-    \ expr: |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n
-    \   - name: start_time\n      required: false\n    - name: end_time\n      required:
-    false\n  metrics:\n    - metric_name: vertex_pending_messages\n      display_name:
-    Vertex Pending Messages\n      metric_description: This gauge metric keeps track
-    of the total number of messages that are waiting to be processed over varying
-    time frames of 1min, 5min, 15min and default period of 2min. \n      # set \"Units\"
-    or unset for default behaviour\n      # unit: Units\n      required_filters:\n
+    name: vertex_gauge\n  objects: \n    - vertex\n  title: Vertex Gauge Metrics\n
+    \ description: This pattern represents the gauge metrics for a vertex across different
+    dimensions\n  expr: |\n    sum($metric_name{$filters}) by ($dimension, period)\n
+    \ params:\n    - name: start_time\n      required: false\n    - name: end_time\n
+    \     required: false\n  metrics:\n    - metric_name: vertex_pending_messages\n
+    \     display_name: Vertex Pending Messages\n      metric_description: This gauge
+    metric keeps track of the total number of messages that are waiting to be processed
+    over varying time frames of 1min, 5min, 15min and default period of 2min. \n      #
+    set \"Units\" or unset for default behaviour\n      # unit: Units\n      required_filters:\n
     \       - namespace\n        - pipeline\n        - vertex\n      dimensions:\n
     \       - name: pod\n          # expr: optional expression for prometheus query\n
     \         # overrides the default expression\n          filters:\n            -
@@ -157,23 +157,24 @@ data:
     false\n        - name: vertex\n          # expr: optional expression for prometheus
     query\n          # overrides the default expression\n          filters:\n            -
     name: period\n              required: false\n\n- name: mono_vertex_gauge\n  objects:
-    \n    - mono-vertex\n  title: Pending Messages Lag\n  description: This query
-    is the total number of pending messages for the mono vertex\n  expr: |\n    sum($metric_name{$filters})
-    by ($dimension, period)\n  params:\n    - name: start_time\n      required: false\n
-    \   - name: end_time\n      required: false\n  metrics:\n    - metric_name: monovtx_pending\n
-    \     display_name: MonoVertex Pending Messages\n      metric_description: This
-    gauge metric keeps track of the total number of messages that are waiting to be
-    processed over varying time frames of 1min, 5min, 15min and default period of
-    2min. \n      # set \"Units\" or unset for default behaviour\n      # unit: Units\n
-    \     required_filters:\n        - namespace\n        - mvtx_name\n      dimensions:\n
-    \       - name: pod\n          # expr: optional expression for prometheus query\n
-    \         # overrides the default expression\n          filters:\n            -
-    name: pod\n              required: false\n            - name: period\n              required:
-    false\n        - name: mono-vertex\n          # expr: optional expression for
-    prometheus query\n          # overrides the default expression\n          filters:\n
-    \           - name: period\n              required: false\n\n- name: mono_vertex_histogram\n
-    \ objects: \n    - mono-vertex\n  title: Processing Time Latency\n  description:
-    This query pattern is for P99,P90 and P50 quantiles for a mono-vertex across different
+    \n    - mono-vertex\n  title: MonoVertex Gauge Metrics\n  description: This pattern
+    represents the gauge metrics for a mono-vertex across different dimensions\n  expr:
+    |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n    - name:
+    start_time\n      required: false\n    - name: end_time\n      required: false\n
+    \ metrics:\n    - metric_name: monovtx_pending\n      display_name: MonoVertex
+    Pending Messages\n      metric_description: This gauge metric keeps track of the
+    total number of messages that are waiting to be processed over varying time frames
+    of 1min, 5min, 15min and default period of 2min. \n      # set \"Units\" or unset
+    for default behaviour\n      # unit: Units\n      required_filters:\n        -
+    namespace\n        - mvtx_name\n      dimensions:\n        - name: pod\n          #
+    expr: optional expression for prometheus query\n          # overrides the default
+    expression\n          filters:\n            - name: pod\n              required:
+    false\n            - name: period\n              required: false\n        - name:
+    mono-vertex\n          # expr: optional expression for prometheus query\n          #
+    overrides the default expression\n          filters:\n            - name: period\n
+    \             required: false\n\n- name: mono_vertex_histogram\n  objects: \n
+    \   - mono-vertex\n  title: MonoVertex Histogram Metrics\n  description: This
+    pattern is for P99, P95, P90 and P50 quantiles for a mono-vertex across different
     dimensions\n  expr: |\n    histogram_quantile($quantile, sum by($dimension,le)
     (rate($metric_name{$filters}[$duration])))\n  params:\n    - name: quantile\n
     \     required: true\n    - name: duration\n      required: true\n    - name:
@@ -216,37 +217,38 @@ data:
     behaviour\n      # unit: Units\n      required_filters:\n        - namespace\n
     \       - mvtx_name\n      dimensions:\n        - name: mono-vertex\n        -
     name: pod\n          filters:\n            - name: pod\n              required:
-    false\n- name: pod_cpu_memory_utilization\n  objects: \n    - mono-vertex\n    -
-    vertex\n  title: cpu-memory utilization by pod\n  description: cpu and memory
-    utilization by pod for mono-vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n
-    \ params:\n    - name: duration\n      required: true\n    - name: start_time\n
-    \     required: false\n    - name: end_time\n      required: false\n  metrics:
-    \n    # set your cpu metric name here\n    - metric_name: namespace_pod_cpu_utilization\n
-    \     # set display name as per metric name\n      display_name: CPU Utilization
-    per Pod\n      metric_description: This metric represents the percentage utilization
-    of cpu usage over cpu resource limits for a pod.\n      required_filters:\n        -
-    namespace\n        - pod  \n      dimensions:\n        - name: mono-vertex\n          filters:
+    false\n\n- name: pod_cpu_memory_utilization\n  objects: \n    - mono-vertex\n
+    \   - vertex\n  title: CPU and Memory Utilisation by Pod\n  description: This
+    pattern represents the CPU and Memory utilisation by pod for mono-vertex and vertex\n
+    \ expr: avg_over_time($metric_name{$filters}[$duration])\n  params:\n    - name:
+    duration\n      required: true\n    - name: start_time\n      required: false\n
+    \   - name: end_time\n      required: false\n  metrics: \n    # set your cpu metric
+    name here\n    - metric_name: namespace_pod_cpu_utilization\n      # set display
+    name as per metric name\n      display_name: CPU Utilization per Pod\n      metric_description:
+    This metric represents the percentage utilization of cpu usage over cpu resource
+    limits for a pod.\n      required_filters:\n        - namespace\n        - pod
+    \ \n      dimensions:\n        - name: mono-vertex\n          filters: \n            -
+    name: pod\n              # expr: optional expression for prometheus query\n              #
+    overrides the default expression\n              required: false\n        - name:
+    vertex\n          filters: \n            - name: pod\n              # expr: optional
+    expression for prometheus query\n              # overrides the default expression
+    \n              required: false\n    # set your memory metric name here\n    -
+    metric_name: namespace_pod_memory_utilization\n      # set display name as per
+    metric name\n      display_name: Memory Utilization per Pod\n      metric_description:
+    This metric represents the percentage utilization of memory usage in bytes over
+    memory resource limits for a pod.\n      required_filters:\n        - namespace\n
+    \       - pod  \n      dimensions:\n        - name: mono-vertex\n          filters:
     \n            - name: pod\n              # expr: optional expression for prometheus
-    query\n              # overrides the default expression\n              required:
+    query\n              # overrides the default expression \n              required:
     false\n        - name: vertex\n          filters: \n            - name: pod\n
     \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n    # set your
-    memory metric name here\n    - metric_name: namespace_pod_memory_utilization\n
-    \     # set display name as per metric name\n      display_name: Memory Utilization
-    per Pod\n      metric_description: This metric represents the percentage utilization
-    of memory usage in bytes over memory resource limits for a pod.\n      required_filters:\n
-    \       - namespace\n        - pod  \n      dimensions:\n        - name: mono-vertex\n
-    \         filters: \n            - name: pod\n              # expr: optional expression
-    for prometheus query\n              # overrides the default expression \n              required:
-    false\n        - name: vertex\n          filters: \n            - name: pod\n
-    \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n- name: container_cpu_memory_utilization\n
-    \ objects: \n    - mono-vertex\n    - vertex\n  title: cpu-memory utilization
-    by container for mono-vertex\n  description: cpu and memory utilization by container
-    for mono-vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n  params:\n
-    \   - name: duration\n      required: true\n    - name: start_time\n      required:
-    false\n    - name: end_time\n      required: false\n  metrics:\n    # set your
-    cpu metric name here\n    - metric_name: namespace_app_container_cpu_utilization\n
+    overrides the default expression \n              required: false\n\n- name: container_cpu_memory_utilization\n
+    \ objects: \n    - mono-vertex\n    - vertex\n  title: CPU and Memory Utilisation
+    by Container\n  description: This pattern represents the CPU and Memory utilisation
+    by container for mono-vertex and vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n
+    \ params:\n    - name: duration\n      required: true\n    - name: start_time\n
+    \     required: false\n    - name: end_time\n      required: false\n  metrics:\n
+    \   # set your cpu metric name here\n    - metric_name: namespace_app_container_cpu_utilization\n
     \     # set display name as per metric name\n      display_name: CPU Utilization
     per Container\n      metric_description: This metric represents the percentage
     utilization of cpu usage over cpu resource limits for a container.\n      required_filters:\n

--- a/config/advanced-install/numaflow-server.yaml
+++ b/config/advanced-install/numaflow-server.yaml
@@ -230,52 +230,50 @@ data:
     \ expr: avg_over_time($metric_name{$filters}[$duration])\n  params:\n    - name:
     duration\n      required: true\n    - name: start_time\n      required: false\n
     \   - name: end_time\n      required: false\n  metrics: \n    # set your cpu metric
-    name here\n    - metric_name: namespace_pod_cpu_utilization\n      # set display
-    name as per metric name\n      display_name: CPU Utilization per Pod\n      metric_description:
-    This metric represents the percentage utilization of cpu usage over cpu resource
+    name here\n    - metric_name: namespace_pod_cpu_utilization\n      display_name:
+    Pod CPU Utilization\n      metric_description: This metric represents the percentage
+    utilization of cpu usage over cpu resource limits for a pod.\n      required_filters:\n
+    \       - namespace\n        - pod  \n      dimensions:\n        - name: mono-vertex\n
+    \         filters: \n            - name: pod\n              # expr: optional expression
+    for prometheus query\n              # overrides the default expression\n              required:
+    false\n        - name: vertex\n          filters: \n            - name: pod\n
+    \             # expr: optional expression for prometheus query\n              #
+    overrides the default expression \n              required: false\n    # set your
+    memory metric name here\n    - metric_name: namespace_pod_memory_utilization\n
+    \     display_name: Pod Memory Utilization\n      metric_description: This metric
+    represents the percentage utilization of memory usage in bytes over memory resource
     limits for a pod.\n      required_filters:\n        - namespace\n        - pod
     \ \n      dimensions:\n        - name: mono-vertex\n          filters: \n            -
     name: pod\n              # expr: optional expression for prometheus query\n              #
-    overrides the default expression\n              required: false\n        - name:
+    overrides the default expression \n              required: false\n        - name:
     vertex\n          filters: \n            - name: pod\n              # expr: optional
     expression for prometheus query\n              # overrides the default expression
-    \n              required: false\n    # set your memory metric name here\n    -
-    metric_name: namespace_pod_memory_utilization\n      # set display name as per
-    metric name\n      display_name: Memory Utilization per Pod\n      metric_description:
-    This metric represents the percentage utilization of memory usage in bytes over
-    memory resource limits for a pod.\n      required_filters:\n        - namespace\n
-    \       - pod  \n      dimensions:\n        - name: mono-vertex\n          filters:
-    \n            - name: pod\n              # expr: optional expression for prometheus
-    query\n              # overrides the default expression \n              required:
-    false\n        - name: vertex\n          filters: \n            - name: pod\n
-    \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n\n- name: container_cpu_memory_utilization\n
+    \n              required: false\n\n- name: container_cpu_memory_utilization\n
     \ objects: \n    - mono-vertex\n    - vertex\n  title: CPU and Memory Utilisation
     by Container\n  description: This pattern represents the CPU and Memory utilisation
     by container for mono-vertex and vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n
     \ params:\n    - name: duration\n      required: true\n    - name: start_time\n
     \     required: false\n    - name: end_time\n      required: false\n  metrics:\n
     \   # set your cpu metric name here\n    - metric_name: namespace_app_container_cpu_utilization\n
-    \     # set display name as per metric name\n      display_name: CPU Utilization
-    per Container\n      metric_description: This metric represents the percentage
-    utilization of cpu usage over cpu resource limits for a container.\n      required_filters:\n
-    \       - namespace\n      dimensions:\n        - name: mono-vertex\n          filters:
-    \n            - name: container\n              # expr: optional expression for
-    prometheus query\n              # overrides the default expression \n              required:
-    false\n        - name: vertex\n          filters:\n            - name: container\n
+    \     display_name: Container CPU Utilization\n      metric_description: This
+    metric represents the percentage utilization of cpu usage over cpu resource limits
+    for a container.\n      required_filters:\n        - namespace\n      dimensions:\n
+    \       - name: mono-vertex\n          filters: \n            - name: container\n
     \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n    # set your
-    memory metric name here\n    - metric_name: namespace_app_container_memory_utilization\n
-    \     # set display name as per metric name\n      display_name: Memory Utilization
-    per Container\n      metric_description: This metric represents the percentage
-    utilization of memory usage in bytes over memory resource limits for a container.\n
-    \     required_filters:\n        - namespace\n      dimensions:\n        - name:
-    mono-vertex\n          filters: \n            - name: container\n              #
-    expr: optional expression for prometheus query\n              # overrides the
-    default expression \n              required: false\n        - name: vertex\n          filters:
-    \n            - name: container\n              # expr: optional expression for
-    prometheus query\n              # overrides the default expression \n              required:
-    false\n"
+    overrides the default expression \n              required: false\n        - name:
+    vertex\n          filters:\n            - name: container\n              # expr:
+    optional expression for prometheus query\n              # overrides the default
+    expression \n              required: false\n    # set your memory metric name
+    here\n    - metric_name: namespace_app_container_memory_utilization\n      display_name:
+    Container Memory Utilization\n      metric_description: This metric represents
+    the percentage utilization of memory usage in bytes over memory resource limits
+    for a container.\n      required_filters:\n        - namespace\n      dimensions:\n
+    \       - name: mono-vertex\n          filters: \n            - name: container\n
+    \             # expr: optional expression for prometheus query\n              #
+    overrides the default expression \n              required: false\n        - name:
+    vertex\n          filters: \n            - name: container\n              # expr:
+    optional expression for prometheus query\n              # overrides the default
+    expression \n              required: false\n"
 kind: ConfigMap
 metadata:
   name: numaflow-server-metrics-proxy-config

--- a/config/advanced-install/numaflow-server.yaml
+++ b/config/advanced-install/numaflow-server.yaml
@@ -148,15 +148,15 @@ data:
     which the metrics proxy will connect\n# url: service_name + \".\" + service_namespace
     + \".svc.cluster.local\" + \":\" + port\n# example for local prometheus service\n#
     url: http://prometheus-operated.monitoring.svc.cluster.local:9090\npatterns:\n-
-    name: vertex_gauge\n  objects: \n    - vertex\n  title: Vertex Pending Messages\n
-    \ description: This query is the total number of pending messages for the vertex\n
-    \ expr: |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n
-    \   - name: start_time\n      required: false\n    - name: end_time\n      required:
-    false\n  metrics:\n    - metric_name: vertex_pending_messages\n      display_name:
-    Vertex Pending Messages\n      metric_description: This gauge metric keeps track
-    of the total number of messages that are waiting to be processed over varying
-    time frames of 1min, 5min, 15min and default period of 2min. \n      # set \"Units\"
-    or unset for default behaviour\n      # unit: Units\n      required_filters:\n
+    name: vertex_gauge\n  objects: \n    - vertex\n  title: Vertex Gauge Metrics\n
+    \ description: This pattern represents the gauge metrics for a vertex across different
+    dimensions\n  expr: |\n    sum($metric_name{$filters}) by ($dimension, period)\n
+    \ params:\n    - name: start_time\n      required: false\n    - name: end_time\n
+    \     required: false\n  metrics:\n    - metric_name: vertex_pending_messages\n
+    \     display_name: Vertex Pending Messages\n      metric_description: This gauge
+    metric keeps track of the total number of messages that are waiting to be processed
+    over varying time frames of 1min, 5min, 15min and default period of 2min. \n      #
+    set \"Units\" or unset for default behaviour\n      # unit: Units\n      required_filters:\n
     \       - namespace\n        - pipeline\n        - vertex\n      dimensions:\n
     \       - name: pod\n          # expr: optional expression for prometheus query\n
     \         # overrides the default expression\n          filters:\n            -
@@ -164,23 +164,24 @@ data:
     false\n        - name: vertex\n          # expr: optional expression for prometheus
     query\n          # overrides the default expression\n          filters:\n            -
     name: period\n              required: false\n\n- name: mono_vertex_gauge\n  objects:
-    \n    - mono-vertex\n  title: Pending Messages Lag\n  description: This query
-    is the total number of pending messages for the mono vertex\n  expr: |\n    sum($metric_name{$filters})
-    by ($dimension, period)\n  params:\n    - name: start_time\n      required: false\n
-    \   - name: end_time\n      required: false\n  metrics:\n    - metric_name: monovtx_pending\n
-    \     display_name: MonoVertex Pending Messages\n      metric_description: This
-    gauge metric keeps track of the total number of messages that are waiting to be
-    processed over varying time frames of 1min, 5min, 15min and default period of
-    2min. \n      # set \"Units\" or unset for default behaviour\n      # unit: Units\n
-    \     required_filters:\n        - namespace\n        - mvtx_name\n      dimensions:\n
-    \       - name: pod\n          # expr: optional expression for prometheus query\n
-    \         # overrides the default expression\n          filters:\n            -
-    name: pod\n              required: false\n            - name: period\n              required:
-    false\n        - name: mono-vertex\n          # expr: optional expression for
-    prometheus query\n          # overrides the default expression\n          filters:\n
-    \           - name: period\n              required: false\n\n- name: mono_vertex_histogram\n
-    \ objects: \n    - mono-vertex\n  title: Processing Time Latency\n  description:
-    This query pattern is for P99,P90 and P50 quantiles for a mono-vertex across different
+    \n    - mono-vertex\n  title: MonoVertex Gauge Metrics\n  description: This pattern
+    represents the gauge metrics for a mono-vertex across different dimensions\n  expr:
+    |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n    - name:
+    start_time\n      required: false\n    - name: end_time\n      required: false\n
+    \ metrics:\n    - metric_name: monovtx_pending\n      display_name: MonoVertex
+    Pending Messages\n      metric_description: This gauge metric keeps track of the
+    total number of messages that are waiting to be processed over varying time frames
+    of 1min, 5min, 15min and default period of 2min. \n      # set \"Units\" or unset
+    for default behaviour\n      # unit: Units\n      required_filters:\n        -
+    namespace\n        - mvtx_name\n      dimensions:\n        - name: pod\n          #
+    expr: optional expression for prometheus query\n          # overrides the default
+    expression\n          filters:\n            - name: pod\n              required:
+    false\n            - name: period\n              required: false\n        - name:
+    mono-vertex\n          # expr: optional expression for prometheus query\n          #
+    overrides the default expression\n          filters:\n            - name: period\n
+    \             required: false\n\n- name: mono_vertex_histogram\n  objects: \n
+    \   - mono-vertex\n  title: MonoVertex Histogram Metrics\n  description: This
+    pattern is for P99, P95, P90 and P50 quantiles for a mono-vertex across different
     dimensions\n  expr: |\n    histogram_quantile($quantile, sum by($dimension,le)
     (rate($metric_name{$filters}[$duration])))\n  params:\n    - name: quantile\n
     \     required: true\n    - name: duration\n      required: true\n    - name:
@@ -223,37 +224,38 @@ data:
     behaviour\n      # unit: Units\n      required_filters:\n        - namespace\n
     \       - mvtx_name\n      dimensions:\n        - name: mono-vertex\n        -
     name: pod\n          filters:\n            - name: pod\n              required:
-    false\n- name: pod_cpu_memory_utilization\n  objects: \n    - mono-vertex\n    -
-    vertex\n  title: cpu-memory utilization by pod\n  description: cpu and memory
-    utilization by pod for mono-vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n
-    \ params:\n    - name: duration\n      required: true\n    - name: start_time\n
-    \     required: false\n    - name: end_time\n      required: false\n  metrics:
-    \n    # set your cpu metric name here\n    - metric_name: namespace_pod_cpu_utilization\n
-    \     # set display name as per metric name\n      display_name: CPU Utilization
-    per Pod\n      metric_description: This metric represents the percentage utilization
-    of cpu usage over cpu resource limits for a pod.\n      required_filters:\n        -
-    namespace\n        - pod  \n      dimensions:\n        - name: mono-vertex\n          filters:
+    false\n\n- name: pod_cpu_memory_utilization\n  objects: \n    - mono-vertex\n
+    \   - vertex\n  title: CPU and Memory Utilisation by Pod\n  description: This
+    pattern represents the CPU and Memory utilisation by pod for mono-vertex and vertex\n
+    \ expr: avg_over_time($metric_name{$filters}[$duration])\n  params:\n    - name:
+    duration\n      required: true\n    - name: start_time\n      required: false\n
+    \   - name: end_time\n      required: false\n  metrics: \n    # set your cpu metric
+    name here\n    - metric_name: namespace_pod_cpu_utilization\n      # set display
+    name as per metric name\n      display_name: CPU Utilization per Pod\n      metric_description:
+    This metric represents the percentage utilization of cpu usage over cpu resource
+    limits for a pod.\n      required_filters:\n        - namespace\n        - pod
+    \ \n      dimensions:\n        - name: mono-vertex\n          filters: \n            -
+    name: pod\n              # expr: optional expression for prometheus query\n              #
+    overrides the default expression\n              required: false\n        - name:
+    vertex\n          filters: \n            - name: pod\n              # expr: optional
+    expression for prometheus query\n              # overrides the default expression
+    \n              required: false\n    # set your memory metric name here\n    -
+    metric_name: namespace_pod_memory_utilization\n      # set display name as per
+    metric name\n      display_name: Memory Utilization per Pod\n      metric_description:
+    This metric represents the percentage utilization of memory usage in bytes over
+    memory resource limits for a pod.\n      required_filters:\n        - namespace\n
+    \       - pod  \n      dimensions:\n        - name: mono-vertex\n          filters:
     \n            - name: pod\n              # expr: optional expression for prometheus
-    query\n              # overrides the default expression\n              required:
+    query\n              # overrides the default expression \n              required:
     false\n        - name: vertex\n          filters: \n            - name: pod\n
     \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n    # set your
-    memory metric name here\n    - metric_name: namespace_pod_memory_utilization\n
-    \     # set display name as per metric name\n      display_name: Memory Utilization
-    per Pod\n      metric_description: This metric represents the percentage utilization
-    of memory usage in bytes over memory resource limits for a pod.\n      required_filters:\n
-    \       - namespace\n        - pod  \n      dimensions:\n        - name: mono-vertex\n
-    \         filters: \n            - name: pod\n              # expr: optional expression
-    for prometheus query\n              # overrides the default expression \n              required:
-    false\n        - name: vertex\n          filters: \n            - name: pod\n
-    \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n- name: container_cpu_memory_utilization\n
-    \ objects: \n    - mono-vertex\n    - vertex\n  title: cpu-memory utilization
-    by container for mono-vertex\n  description: cpu and memory utilization by container
-    for mono-vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n  params:\n
-    \   - name: duration\n      required: true\n    - name: start_time\n      required:
-    false\n    - name: end_time\n      required: false\n  metrics:\n    # set your
-    cpu metric name here\n    - metric_name: namespace_app_container_cpu_utilization\n
+    overrides the default expression \n              required: false\n\n- name: container_cpu_memory_utilization\n
+    \ objects: \n    - mono-vertex\n    - vertex\n  title: CPU and Memory Utilisation
+    by Container\n  description: This pattern represents the CPU and Memory utilisation
+    by container for mono-vertex and vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n
+    \ params:\n    - name: duration\n      required: true\n    - name: start_time\n
+    \     required: false\n    - name: end_time\n      required: false\n  metrics:\n
+    \   # set your cpu metric name here\n    - metric_name: namespace_app_container_cpu_utilization\n
     \     # set display name as per metric name\n      display_name: CPU Utilization
     per Container\n      metric_description: This metric represents the percentage
     utilization of cpu usage over cpu resource limits for a container.\n      required_filters:\n

--- a/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
+++ b/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
@@ -208,8 +208,7 @@ data:
       metrics: 
         # set your cpu metric name here
         - metric_name: namespace_pod_cpu_utilization
-          # set display name as per metric name
-          display_name: CPU Utilization per Pod
+          display_name: Pod CPU Utilization
           metric_description: This metric represents the percentage utilization of cpu usage over cpu resource limits for a pod.
           required_filters:
             - namespace
@@ -229,8 +228,7 @@ data:
                   required: false
         # set your memory metric name here
         - metric_name: namespace_pod_memory_utilization
-          # set display name as per metric name
-          display_name: Memory Utilization per Pod
+          display_name: Pod Memory Utilization
           metric_description: This metric represents the percentage utilization of memory usage in bytes over memory resource limits for a pod.
           required_filters:
             - namespace
@@ -266,8 +264,7 @@ data:
       metrics:
         # set your cpu metric name here
         - metric_name: namespace_app_container_cpu_utilization
-          # set display name as per metric name
-          display_name: CPU Utilization per Container
+          display_name: Container CPU Utilization
           metric_description: This metric represents the percentage utilization of cpu usage over cpu resource limits for a container.
           required_filters:
             - namespace
@@ -286,8 +283,7 @@ data:
                   required: false
         # set your memory metric name here
         - metric_name: namespace_app_container_memory_utilization
-          # set display name as per metric name
-          display_name: Memory Utilization per Container
+          display_name: Container Memory Utilization
           metric_description: This metric represents the percentage utilization of memory usage in bytes over memory resource limits for a container.
           required_filters:
             - namespace

--- a/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
+++ b/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
@@ -12,8 +12,8 @@ data:
     - name: vertex_gauge
       objects: 
         - vertex
-      title: Vertex Pending Messages
-      description: This query is the total number of pending messages for the vertex
+      title: Vertex Gauge Metrics
+      description: This pattern represents the gauge metrics for a vertex across different dimensions
       expr: |
         sum($metric_name{$filters}) by ($dimension, period)
       params:
@@ -46,12 +46,12 @@ data:
               filters:
                 - name: period
                   required: false
-    
+
     - name: mono_vertex_gauge
       objects: 
         - mono-vertex
-      title: Pending Messages Lag
-      description: This query is the total number of pending messages for the mono vertex
+      title: MonoVertex Gauge Metrics
+      description: This pattern represents the gauge metrics for a mono-vertex across different dimensions
       expr: |
         sum($metric_name{$filters}) by ($dimension, period)
       params:
@@ -87,8 +87,8 @@ data:
     - name: mono_vertex_histogram
       objects: 
         - mono-vertex
-      title: Processing Time Latency
-      description: This query pattern is for P99,P90 and P50 quantiles for a mono-vertex across different dimensions
+      title: MonoVertex Histogram Metrics
+      description: This pattern is for P99, P95, P90 and P50 quantiles for a mono-vertex across different dimensions
       expr: |
         histogram_quantile($quantile, sum by($dimension,le) (rate($metric_name{$filters}[$duration])))
       params:
@@ -190,12 +190,13 @@ data:
               filters:
                 - name: pod
                   required: false
+
     - name: pod_cpu_memory_utilization
       objects: 
         - mono-vertex
         - vertex
-      title: cpu-memory utilization by pod
-      description: cpu and memory utilization by pod for mono-vertex
+      title: CPU and Memory Utilisation by Pod
+      description: This pattern represents the CPU and Memory utilisation by pod for mono-vertex and vertex
       expr: avg_over_time($metric_name{$filters}[$duration])
       params:
         - name: duration
@@ -247,12 +248,13 @@ data:
                   # expr: optional expression for prometheus query
                   # overrides the default expression 
                   required: false
+
     - name: container_cpu_memory_utilization
       objects: 
         - mono-vertex
         - vertex
-      title: cpu-memory utilization by container for mono-vertex
-      description: cpu and memory utilization by container for mono-vertex
+      title: CPU and Memory Utilisation by Container
+      description: This pattern represents the CPU and Memory utilisation by container for mono-vertex and vertex
       expr: avg_over_time($metric_name{$filters}[$duration])
       params:
         - name: duration
@@ -302,4 +304,3 @@ data:
                   # expr: optional expression for prometheus query
                   # overrides the default expression 
                   required: false
-

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -28876,15 +28876,15 @@ data:
     which the metrics proxy will connect\n# url: service_name + \".\" + service_namespace
     + \".svc.cluster.local\" + \":\" + port\n# example for local prometheus service\n#
     url: http://prometheus-operated.monitoring.svc.cluster.local:9090\npatterns:\n-
-    name: vertex_gauge\n  objects: \n    - vertex\n  title: Vertex Pending Messages\n
-    \ description: This query is the total number of pending messages for the vertex\n
-    \ expr: |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n
-    \   - name: start_time\n      required: false\n    - name: end_time\n      required:
-    false\n  metrics:\n    - metric_name: vertex_pending_messages\n      display_name:
-    Vertex Pending Messages\n      metric_description: This gauge metric keeps track
-    of the total number of messages that are waiting to be processed over varying
-    time frames of 1min, 5min, 15min and default period of 2min. \n      # set \"Units\"
-    or unset for default behaviour\n      # unit: Units\n      required_filters:\n
+    name: vertex_gauge\n  objects: \n    - vertex\n  title: Vertex Gauge Metrics\n
+    \ description: This pattern represents the gauge metrics for a vertex across different
+    dimensions\n  expr: |\n    sum($metric_name{$filters}) by ($dimension, period)\n
+    \ params:\n    - name: start_time\n      required: false\n    - name: end_time\n
+    \     required: false\n  metrics:\n    - metric_name: vertex_pending_messages\n
+    \     display_name: Vertex Pending Messages\n      metric_description: This gauge
+    metric keeps track of the total number of messages that are waiting to be processed
+    over varying time frames of 1min, 5min, 15min and default period of 2min. \n      #
+    set \"Units\" or unset for default behaviour\n      # unit: Units\n      required_filters:\n
     \       - namespace\n        - pipeline\n        - vertex\n      dimensions:\n
     \       - name: pod\n          # expr: optional expression for prometheus query\n
     \         # overrides the default expression\n          filters:\n            -
@@ -28892,23 +28892,24 @@ data:
     false\n        - name: vertex\n          # expr: optional expression for prometheus
     query\n          # overrides the default expression\n          filters:\n            -
     name: period\n              required: false\n\n- name: mono_vertex_gauge\n  objects:
-    \n    - mono-vertex\n  title: Pending Messages Lag\n  description: This query
-    is the total number of pending messages for the mono vertex\n  expr: |\n    sum($metric_name{$filters})
-    by ($dimension, period)\n  params:\n    - name: start_time\n      required: false\n
-    \   - name: end_time\n      required: false\n  metrics:\n    - metric_name: monovtx_pending\n
-    \     display_name: MonoVertex Pending Messages\n      metric_description: This
-    gauge metric keeps track of the total number of messages that are waiting to be
-    processed over varying time frames of 1min, 5min, 15min and default period of
-    2min. \n      # set \"Units\" or unset for default behaviour\n      # unit: Units\n
-    \     required_filters:\n        - namespace\n        - mvtx_name\n      dimensions:\n
-    \       - name: pod\n          # expr: optional expression for prometheus query\n
-    \         # overrides the default expression\n          filters:\n            -
-    name: pod\n              required: false\n            - name: period\n              required:
-    false\n        - name: mono-vertex\n          # expr: optional expression for
-    prometheus query\n          # overrides the default expression\n          filters:\n
-    \           - name: period\n              required: false\n\n- name: mono_vertex_histogram\n
-    \ objects: \n    - mono-vertex\n  title: Processing Time Latency\n  description:
-    This query pattern is for P99,P90 and P50 quantiles for a mono-vertex across different
+    \n    - mono-vertex\n  title: MonoVertex Gauge Metrics\n  description: This pattern
+    represents the gauge metrics for a mono-vertex across different dimensions\n  expr:
+    |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n    - name:
+    start_time\n      required: false\n    - name: end_time\n      required: false\n
+    \ metrics:\n    - metric_name: monovtx_pending\n      display_name: MonoVertex
+    Pending Messages\n      metric_description: This gauge metric keeps track of the
+    total number of messages that are waiting to be processed over varying time frames
+    of 1min, 5min, 15min and default period of 2min. \n      # set \"Units\" or unset
+    for default behaviour\n      # unit: Units\n      required_filters:\n        -
+    namespace\n        - mvtx_name\n      dimensions:\n        - name: pod\n          #
+    expr: optional expression for prometheus query\n          # overrides the default
+    expression\n          filters:\n            - name: pod\n              required:
+    false\n            - name: period\n              required: false\n        - name:
+    mono-vertex\n          # expr: optional expression for prometheus query\n          #
+    overrides the default expression\n          filters:\n            - name: period\n
+    \             required: false\n\n- name: mono_vertex_histogram\n  objects: \n
+    \   - mono-vertex\n  title: MonoVertex Histogram Metrics\n  description: This
+    pattern is for P99, P95, P90 and P50 quantiles for a mono-vertex across different
     dimensions\n  expr: |\n    histogram_quantile($quantile, sum by($dimension,le)
     (rate($metric_name{$filters}[$duration])))\n  params:\n    - name: quantile\n
     \     required: true\n    - name: duration\n      required: true\n    - name:
@@ -28951,37 +28952,38 @@ data:
     behaviour\n      # unit: Units\n      required_filters:\n        - namespace\n
     \       - mvtx_name\n      dimensions:\n        - name: mono-vertex\n        -
     name: pod\n          filters:\n            - name: pod\n              required:
-    false\n- name: pod_cpu_memory_utilization\n  objects: \n    - mono-vertex\n    -
-    vertex\n  title: cpu-memory utilization by pod\n  description: cpu and memory
-    utilization by pod for mono-vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n
-    \ params:\n    - name: duration\n      required: true\n    - name: start_time\n
-    \     required: false\n    - name: end_time\n      required: false\n  metrics:
-    \n    # set your cpu metric name here\n    - metric_name: namespace_pod_cpu_utilization\n
-    \     # set display name as per metric name\n      display_name: CPU Utilization
-    per Pod\n      metric_description: This metric represents the percentage utilization
-    of cpu usage over cpu resource limits for a pod.\n      required_filters:\n        -
-    namespace\n        - pod  \n      dimensions:\n        - name: mono-vertex\n          filters:
+    false\n\n- name: pod_cpu_memory_utilization\n  objects: \n    - mono-vertex\n
+    \   - vertex\n  title: CPU and Memory Utilisation by Pod\n  description: This
+    pattern represents the CPU and Memory utilisation by pod for mono-vertex and vertex\n
+    \ expr: avg_over_time($metric_name{$filters}[$duration])\n  params:\n    - name:
+    duration\n      required: true\n    - name: start_time\n      required: false\n
+    \   - name: end_time\n      required: false\n  metrics: \n    # set your cpu metric
+    name here\n    - metric_name: namespace_pod_cpu_utilization\n      # set display
+    name as per metric name\n      display_name: CPU Utilization per Pod\n      metric_description:
+    This metric represents the percentage utilization of cpu usage over cpu resource
+    limits for a pod.\n      required_filters:\n        - namespace\n        - pod
+    \ \n      dimensions:\n        - name: mono-vertex\n          filters: \n            -
+    name: pod\n              # expr: optional expression for prometheus query\n              #
+    overrides the default expression\n              required: false\n        - name:
+    vertex\n          filters: \n            - name: pod\n              # expr: optional
+    expression for prometheus query\n              # overrides the default expression
+    \n              required: false\n    # set your memory metric name here\n    -
+    metric_name: namespace_pod_memory_utilization\n      # set display name as per
+    metric name\n      display_name: Memory Utilization per Pod\n      metric_description:
+    This metric represents the percentage utilization of memory usage in bytes over
+    memory resource limits for a pod.\n      required_filters:\n        - namespace\n
+    \       - pod  \n      dimensions:\n        - name: mono-vertex\n          filters:
     \n            - name: pod\n              # expr: optional expression for prometheus
-    query\n              # overrides the default expression\n              required:
+    query\n              # overrides the default expression \n              required:
     false\n        - name: vertex\n          filters: \n            - name: pod\n
     \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n    # set your
-    memory metric name here\n    - metric_name: namespace_pod_memory_utilization\n
-    \     # set display name as per metric name\n      display_name: Memory Utilization
-    per Pod\n      metric_description: This metric represents the percentage utilization
-    of memory usage in bytes over memory resource limits for a pod.\n      required_filters:\n
-    \       - namespace\n        - pod  \n      dimensions:\n        - name: mono-vertex\n
-    \         filters: \n            - name: pod\n              # expr: optional expression
-    for prometheus query\n              # overrides the default expression \n              required:
-    false\n        - name: vertex\n          filters: \n            - name: pod\n
-    \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n- name: container_cpu_memory_utilization\n
-    \ objects: \n    - mono-vertex\n    - vertex\n  title: cpu-memory utilization
-    by container for mono-vertex\n  description: cpu and memory utilization by container
-    for mono-vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n  params:\n
-    \   - name: duration\n      required: true\n    - name: start_time\n      required:
-    false\n    - name: end_time\n      required: false\n  metrics:\n    # set your
-    cpu metric name here\n    - metric_name: namespace_app_container_cpu_utilization\n
+    overrides the default expression \n              required: false\n\n- name: container_cpu_memory_utilization\n
+    \ objects: \n    - mono-vertex\n    - vertex\n  title: CPU and Memory Utilisation
+    by Container\n  description: This pattern represents the CPU and Memory utilisation
+    by container for mono-vertex and vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n
+    \ params:\n    - name: duration\n      required: true\n    - name: start_time\n
+    \     required: false\n    - name: end_time\n      required: false\n  metrics:\n
+    \   # set your cpu metric name here\n    - metric_name: namespace_app_container_cpu_utilization\n
     \     # set display name as per metric name\n      display_name: CPU Utilization
     per Container\n      metric_description: This metric represents the percentage
     utilization of cpu usage over cpu resource limits for a container.\n      required_filters:\n

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -28958,52 +28958,50 @@ data:
     \ expr: avg_over_time($metric_name{$filters}[$duration])\n  params:\n    - name:
     duration\n      required: true\n    - name: start_time\n      required: false\n
     \   - name: end_time\n      required: false\n  metrics: \n    # set your cpu metric
-    name here\n    - metric_name: namespace_pod_cpu_utilization\n      # set display
-    name as per metric name\n      display_name: CPU Utilization per Pod\n      metric_description:
-    This metric represents the percentage utilization of cpu usage over cpu resource
+    name here\n    - metric_name: namespace_pod_cpu_utilization\n      display_name:
+    Pod CPU Utilization\n      metric_description: This metric represents the percentage
+    utilization of cpu usage over cpu resource limits for a pod.\n      required_filters:\n
+    \       - namespace\n        - pod  \n      dimensions:\n        - name: mono-vertex\n
+    \         filters: \n            - name: pod\n              # expr: optional expression
+    for prometheus query\n              # overrides the default expression\n              required:
+    false\n        - name: vertex\n          filters: \n            - name: pod\n
+    \             # expr: optional expression for prometheus query\n              #
+    overrides the default expression \n              required: false\n    # set your
+    memory metric name here\n    - metric_name: namespace_pod_memory_utilization\n
+    \     display_name: Pod Memory Utilization\n      metric_description: This metric
+    represents the percentage utilization of memory usage in bytes over memory resource
     limits for a pod.\n      required_filters:\n        - namespace\n        - pod
     \ \n      dimensions:\n        - name: mono-vertex\n          filters: \n            -
     name: pod\n              # expr: optional expression for prometheus query\n              #
-    overrides the default expression\n              required: false\n        - name:
+    overrides the default expression \n              required: false\n        - name:
     vertex\n          filters: \n            - name: pod\n              # expr: optional
     expression for prometheus query\n              # overrides the default expression
-    \n              required: false\n    # set your memory metric name here\n    -
-    metric_name: namespace_pod_memory_utilization\n      # set display name as per
-    metric name\n      display_name: Memory Utilization per Pod\n      metric_description:
-    This metric represents the percentage utilization of memory usage in bytes over
-    memory resource limits for a pod.\n      required_filters:\n        - namespace\n
-    \       - pod  \n      dimensions:\n        - name: mono-vertex\n          filters:
-    \n            - name: pod\n              # expr: optional expression for prometheus
-    query\n              # overrides the default expression \n              required:
-    false\n        - name: vertex\n          filters: \n            - name: pod\n
-    \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n\n- name: container_cpu_memory_utilization\n
+    \n              required: false\n\n- name: container_cpu_memory_utilization\n
     \ objects: \n    - mono-vertex\n    - vertex\n  title: CPU and Memory Utilisation
     by Container\n  description: This pattern represents the CPU and Memory utilisation
     by container for mono-vertex and vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n
     \ params:\n    - name: duration\n      required: true\n    - name: start_time\n
     \     required: false\n    - name: end_time\n      required: false\n  metrics:\n
     \   # set your cpu metric name here\n    - metric_name: namespace_app_container_cpu_utilization\n
-    \     # set display name as per metric name\n      display_name: CPU Utilization
-    per Container\n      metric_description: This metric represents the percentage
-    utilization of cpu usage over cpu resource limits for a container.\n      required_filters:\n
-    \       - namespace\n      dimensions:\n        - name: mono-vertex\n          filters:
-    \n            - name: container\n              # expr: optional expression for
-    prometheus query\n              # overrides the default expression \n              required:
-    false\n        - name: vertex\n          filters:\n            - name: container\n
+    \     display_name: Container CPU Utilization\n      metric_description: This
+    metric represents the percentage utilization of cpu usage over cpu resource limits
+    for a container.\n      required_filters:\n        - namespace\n      dimensions:\n
+    \       - name: mono-vertex\n          filters: \n            - name: container\n
     \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n    # set your
-    memory metric name here\n    - metric_name: namespace_app_container_memory_utilization\n
-    \     # set display name as per metric name\n      display_name: Memory Utilization
-    per Container\n      metric_description: This metric represents the percentage
-    utilization of memory usage in bytes over memory resource limits for a container.\n
-    \     required_filters:\n        - namespace\n      dimensions:\n        - name:
-    mono-vertex\n          filters: \n            - name: container\n              #
-    expr: optional expression for prometheus query\n              # overrides the
-    default expression \n              required: false\n        - name: vertex\n          filters:
-    \n            - name: container\n              # expr: optional expression for
-    prometheus query\n              # overrides the default expression \n              required:
-    false\n"
+    overrides the default expression \n              required: false\n        - name:
+    vertex\n          filters:\n            - name: container\n              # expr:
+    optional expression for prometheus query\n              # overrides the default
+    expression \n              required: false\n    # set your memory metric name
+    here\n    - metric_name: namespace_app_container_memory_utilization\n      display_name:
+    Container Memory Utilization\n      metric_description: This metric represents
+    the percentage utilization of memory usage in bytes over memory resource limits
+    for a container.\n      required_filters:\n        - namespace\n      dimensions:\n
+    \       - name: mono-vertex\n          filters: \n            - name: container\n
+    \             # expr: optional expression for prometheus query\n              #
+    overrides the default expression \n              required: false\n        - name:
+    vertex\n          filters: \n            - name: container\n              # expr:
+    optional expression for prometheus query\n              # overrides the default
+    expression \n              required: false\n"
 kind: ConfigMap
 metadata:
   name: numaflow-server-metrics-proxy-config

--- a/config/namespace-install.yaml
+++ b/config/namespace-install.yaml
@@ -28764,15 +28764,15 @@ data:
     which the metrics proxy will connect\n# url: service_name + \".\" + service_namespace
     + \".svc.cluster.local\" + \":\" + port\n# example for local prometheus service\n#
     url: http://prometheus-operated.monitoring.svc.cluster.local:9090\npatterns:\n-
-    name: vertex_gauge\n  objects: \n    - vertex\n  title: Vertex Pending Messages\n
-    \ description: This query is the total number of pending messages for the vertex\n
-    \ expr: |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n
-    \   - name: start_time\n      required: false\n    - name: end_time\n      required:
-    false\n  metrics:\n    - metric_name: vertex_pending_messages\n      display_name:
-    Vertex Pending Messages\n      metric_description: This gauge metric keeps track
-    of the total number of messages that are waiting to be processed over varying
-    time frames of 1min, 5min, 15min and default period of 2min. \n      # set \"Units\"
-    or unset for default behaviour\n      # unit: Units\n      required_filters:\n
+    name: vertex_gauge\n  objects: \n    - vertex\n  title: Vertex Gauge Metrics\n
+    \ description: This pattern represents the gauge metrics for a vertex across different
+    dimensions\n  expr: |\n    sum($metric_name{$filters}) by ($dimension, period)\n
+    \ params:\n    - name: start_time\n      required: false\n    - name: end_time\n
+    \     required: false\n  metrics:\n    - metric_name: vertex_pending_messages\n
+    \     display_name: Vertex Pending Messages\n      metric_description: This gauge
+    metric keeps track of the total number of messages that are waiting to be processed
+    over varying time frames of 1min, 5min, 15min and default period of 2min. \n      #
+    set \"Units\" or unset for default behaviour\n      # unit: Units\n      required_filters:\n
     \       - namespace\n        - pipeline\n        - vertex\n      dimensions:\n
     \       - name: pod\n          # expr: optional expression for prometheus query\n
     \         # overrides the default expression\n          filters:\n            -
@@ -28780,23 +28780,24 @@ data:
     false\n        - name: vertex\n          # expr: optional expression for prometheus
     query\n          # overrides the default expression\n          filters:\n            -
     name: period\n              required: false\n\n- name: mono_vertex_gauge\n  objects:
-    \n    - mono-vertex\n  title: Pending Messages Lag\n  description: This query
-    is the total number of pending messages for the mono vertex\n  expr: |\n    sum($metric_name{$filters})
-    by ($dimension, period)\n  params:\n    - name: start_time\n      required: false\n
-    \   - name: end_time\n      required: false\n  metrics:\n    - metric_name: monovtx_pending\n
-    \     display_name: MonoVertex Pending Messages\n      metric_description: This
-    gauge metric keeps track of the total number of messages that are waiting to be
-    processed over varying time frames of 1min, 5min, 15min and default period of
-    2min. \n      # set \"Units\" or unset for default behaviour\n      # unit: Units\n
-    \     required_filters:\n        - namespace\n        - mvtx_name\n      dimensions:\n
-    \       - name: pod\n          # expr: optional expression for prometheus query\n
-    \         # overrides the default expression\n          filters:\n            -
-    name: pod\n              required: false\n            - name: period\n              required:
-    false\n        - name: mono-vertex\n          # expr: optional expression for
-    prometheus query\n          # overrides the default expression\n          filters:\n
-    \           - name: period\n              required: false\n\n- name: mono_vertex_histogram\n
-    \ objects: \n    - mono-vertex\n  title: Processing Time Latency\n  description:
-    This query pattern is for P99,P90 and P50 quantiles for a mono-vertex across different
+    \n    - mono-vertex\n  title: MonoVertex Gauge Metrics\n  description: This pattern
+    represents the gauge metrics for a mono-vertex across different dimensions\n  expr:
+    |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n    - name:
+    start_time\n      required: false\n    - name: end_time\n      required: false\n
+    \ metrics:\n    - metric_name: monovtx_pending\n      display_name: MonoVertex
+    Pending Messages\n      metric_description: This gauge metric keeps track of the
+    total number of messages that are waiting to be processed over varying time frames
+    of 1min, 5min, 15min and default period of 2min. \n      # set \"Units\" or unset
+    for default behaviour\n      # unit: Units\n      required_filters:\n        -
+    namespace\n        - mvtx_name\n      dimensions:\n        - name: pod\n          #
+    expr: optional expression for prometheus query\n          # overrides the default
+    expression\n          filters:\n            - name: pod\n              required:
+    false\n            - name: period\n              required: false\n        - name:
+    mono-vertex\n          # expr: optional expression for prometheus query\n          #
+    overrides the default expression\n          filters:\n            - name: period\n
+    \             required: false\n\n- name: mono_vertex_histogram\n  objects: \n
+    \   - mono-vertex\n  title: MonoVertex Histogram Metrics\n  description: This
+    pattern is for P99, P95, P90 and P50 quantiles for a mono-vertex across different
     dimensions\n  expr: |\n    histogram_quantile($quantile, sum by($dimension,le)
     (rate($metric_name{$filters}[$duration])))\n  params:\n    - name: quantile\n
     \     required: true\n    - name: duration\n      required: true\n    - name:
@@ -28839,37 +28840,38 @@ data:
     behaviour\n      # unit: Units\n      required_filters:\n        - namespace\n
     \       - mvtx_name\n      dimensions:\n        - name: mono-vertex\n        -
     name: pod\n          filters:\n            - name: pod\n              required:
-    false\n- name: pod_cpu_memory_utilization\n  objects: \n    - mono-vertex\n    -
-    vertex\n  title: cpu-memory utilization by pod\n  description: cpu and memory
-    utilization by pod for mono-vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n
-    \ params:\n    - name: duration\n      required: true\n    - name: start_time\n
-    \     required: false\n    - name: end_time\n      required: false\n  metrics:
-    \n    # set your cpu metric name here\n    - metric_name: namespace_pod_cpu_utilization\n
-    \     # set display name as per metric name\n      display_name: CPU Utilization
-    per Pod\n      metric_description: This metric represents the percentage utilization
-    of cpu usage over cpu resource limits for a pod.\n      required_filters:\n        -
-    namespace\n        - pod  \n      dimensions:\n        - name: mono-vertex\n          filters:
+    false\n\n- name: pod_cpu_memory_utilization\n  objects: \n    - mono-vertex\n
+    \   - vertex\n  title: CPU and Memory Utilisation by Pod\n  description: This
+    pattern represents the CPU and Memory utilisation by pod for mono-vertex and vertex\n
+    \ expr: avg_over_time($metric_name{$filters}[$duration])\n  params:\n    - name:
+    duration\n      required: true\n    - name: start_time\n      required: false\n
+    \   - name: end_time\n      required: false\n  metrics: \n    # set your cpu metric
+    name here\n    - metric_name: namespace_pod_cpu_utilization\n      # set display
+    name as per metric name\n      display_name: CPU Utilization per Pod\n      metric_description:
+    This metric represents the percentage utilization of cpu usage over cpu resource
+    limits for a pod.\n      required_filters:\n        - namespace\n        - pod
+    \ \n      dimensions:\n        - name: mono-vertex\n          filters: \n            -
+    name: pod\n              # expr: optional expression for prometheus query\n              #
+    overrides the default expression\n              required: false\n        - name:
+    vertex\n          filters: \n            - name: pod\n              # expr: optional
+    expression for prometheus query\n              # overrides the default expression
+    \n              required: false\n    # set your memory metric name here\n    -
+    metric_name: namespace_pod_memory_utilization\n      # set display name as per
+    metric name\n      display_name: Memory Utilization per Pod\n      metric_description:
+    This metric represents the percentage utilization of memory usage in bytes over
+    memory resource limits for a pod.\n      required_filters:\n        - namespace\n
+    \       - pod  \n      dimensions:\n        - name: mono-vertex\n          filters:
     \n            - name: pod\n              # expr: optional expression for prometheus
-    query\n              # overrides the default expression\n              required:
+    query\n              # overrides the default expression \n              required:
     false\n        - name: vertex\n          filters: \n            - name: pod\n
     \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n    # set your
-    memory metric name here\n    - metric_name: namespace_pod_memory_utilization\n
-    \     # set display name as per metric name\n      display_name: Memory Utilization
-    per Pod\n      metric_description: This metric represents the percentage utilization
-    of memory usage in bytes over memory resource limits for a pod.\n      required_filters:\n
-    \       - namespace\n        - pod  \n      dimensions:\n        - name: mono-vertex\n
-    \         filters: \n            - name: pod\n              # expr: optional expression
-    for prometheus query\n              # overrides the default expression \n              required:
-    false\n        - name: vertex\n          filters: \n            - name: pod\n
-    \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n- name: container_cpu_memory_utilization\n
-    \ objects: \n    - mono-vertex\n    - vertex\n  title: cpu-memory utilization
-    by container for mono-vertex\n  description: cpu and memory utilization by container
-    for mono-vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n  params:\n
-    \   - name: duration\n      required: true\n    - name: start_time\n      required:
-    false\n    - name: end_time\n      required: false\n  metrics:\n    # set your
-    cpu metric name here\n    - metric_name: namespace_app_container_cpu_utilization\n
+    overrides the default expression \n              required: false\n\n- name: container_cpu_memory_utilization\n
+    \ objects: \n    - mono-vertex\n    - vertex\n  title: CPU and Memory Utilisation
+    by Container\n  description: This pattern represents the CPU and Memory utilisation
+    by container for mono-vertex and vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n
+    \ params:\n    - name: duration\n      required: true\n    - name: start_time\n
+    \     required: false\n    - name: end_time\n      required: false\n  metrics:\n
+    \   # set your cpu metric name here\n    - metric_name: namespace_app_container_cpu_utilization\n
     \     # set display name as per metric name\n      display_name: CPU Utilization
     per Container\n      metric_description: This metric represents the percentage
     utilization of cpu usage over cpu resource limits for a container.\n      required_filters:\n

--- a/config/namespace-install.yaml
+++ b/config/namespace-install.yaml
@@ -28846,52 +28846,50 @@ data:
     \ expr: avg_over_time($metric_name{$filters}[$duration])\n  params:\n    - name:
     duration\n      required: true\n    - name: start_time\n      required: false\n
     \   - name: end_time\n      required: false\n  metrics: \n    # set your cpu metric
-    name here\n    - metric_name: namespace_pod_cpu_utilization\n      # set display
-    name as per metric name\n      display_name: CPU Utilization per Pod\n      metric_description:
-    This metric represents the percentage utilization of cpu usage over cpu resource
+    name here\n    - metric_name: namespace_pod_cpu_utilization\n      display_name:
+    Pod CPU Utilization\n      metric_description: This metric represents the percentage
+    utilization of cpu usage over cpu resource limits for a pod.\n      required_filters:\n
+    \       - namespace\n        - pod  \n      dimensions:\n        - name: mono-vertex\n
+    \         filters: \n            - name: pod\n              # expr: optional expression
+    for prometheus query\n              # overrides the default expression\n              required:
+    false\n        - name: vertex\n          filters: \n            - name: pod\n
+    \             # expr: optional expression for prometheus query\n              #
+    overrides the default expression \n              required: false\n    # set your
+    memory metric name here\n    - metric_name: namespace_pod_memory_utilization\n
+    \     display_name: Pod Memory Utilization\n      metric_description: This metric
+    represents the percentage utilization of memory usage in bytes over memory resource
     limits for a pod.\n      required_filters:\n        - namespace\n        - pod
     \ \n      dimensions:\n        - name: mono-vertex\n          filters: \n            -
     name: pod\n              # expr: optional expression for prometheus query\n              #
-    overrides the default expression\n              required: false\n        - name:
+    overrides the default expression \n              required: false\n        - name:
     vertex\n          filters: \n            - name: pod\n              # expr: optional
     expression for prometheus query\n              # overrides the default expression
-    \n              required: false\n    # set your memory metric name here\n    -
-    metric_name: namespace_pod_memory_utilization\n      # set display name as per
-    metric name\n      display_name: Memory Utilization per Pod\n      metric_description:
-    This metric represents the percentage utilization of memory usage in bytes over
-    memory resource limits for a pod.\n      required_filters:\n        - namespace\n
-    \       - pod  \n      dimensions:\n        - name: mono-vertex\n          filters:
-    \n            - name: pod\n              # expr: optional expression for prometheus
-    query\n              # overrides the default expression \n              required:
-    false\n        - name: vertex\n          filters: \n            - name: pod\n
-    \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n\n- name: container_cpu_memory_utilization\n
+    \n              required: false\n\n- name: container_cpu_memory_utilization\n
     \ objects: \n    - mono-vertex\n    - vertex\n  title: CPU and Memory Utilisation
     by Container\n  description: This pattern represents the CPU and Memory utilisation
     by container for mono-vertex and vertex\n  expr: avg_over_time($metric_name{$filters}[$duration])\n
     \ params:\n    - name: duration\n      required: true\n    - name: start_time\n
     \     required: false\n    - name: end_time\n      required: false\n  metrics:\n
     \   # set your cpu metric name here\n    - metric_name: namespace_app_container_cpu_utilization\n
-    \     # set display name as per metric name\n      display_name: CPU Utilization
-    per Container\n      metric_description: This metric represents the percentage
-    utilization of cpu usage over cpu resource limits for a container.\n      required_filters:\n
-    \       - namespace\n      dimensions:\n        - name: mono-vertex\n          filters:
-    \n            - name: container\n              # expr: optional expression for
-    prometheus query\n              # overrides the default expression \n              required:
-    false\n        - name: vertex\n          filters:\n            - name: container\n
+    \     display_name: Container CPU Utilization\n      metric_description: This
+    metric represents the percentage utilization of cpu usage over cpu resource limits
+    for a container.\n      required_filters:\n        - namespace\n      dimensions:\n
+    \       - name: mono-vertex\n          filters: \n            - name: container\n
     \             # expr: optional expression for prometheus query\n              #
-    overrides the default expression \n              required: false\n    # set your
-    memory metric name here\n    - metric_name: namespace_app_container_memory_utilization\n
-    \     # set display name as per metric name\n      display_name: Memory Utilization
-    per Container\n      metric_description: This metric represents the percentage
-    utilization of memory usage in bytes over memory resource limits for a container.\n
-    \     required_filters:\n        - namespace\n      dimensions:\n        - name:
-    mono-vertex\n          filters: \n            - name: container\n              #
-    expr: optional expression for prometheus query\n              # overrides the
-    default expression \n              required: false\n        - name: vertex\n          filters:
-    \n            - name: container\n              # expr: optional expression for
-    prometheus query\n              # overrides the default expression \n              required:
-    false\n"
+    overrides the default expression \n              required: false\n        - name:
+    vertex\n          filters:\n            - name: container\n              # expr:
+    optional expression for prometheus query\n              # overrides the default
+    expression \n              required: false\n    # set your memory metric name
+    here\n    - metric_name: namespace_app_container_memory_utilization\n      display_name:
+    Container Memory Utilization\n      metric_description: This metric represents
+    the percentage utilization of memory usage in bytes over memory resource limits
+    for a container.\n      required_filters:\n        - namespace\n      dimensions:\n
+    \       - name: mono-vertex\n          filters: \n            - name: container\n
+    \             # expr: optional expression for prometheus query\n              #
+    overrides the default expression \n              required: false\n        - name:
+    vertex\n          filters: \n            - name: container\n              # expr:
+    optional expression for prometheus query\n              # overrides the default
+    expression \n              required: false\n"
 kind: ConfigMap
 metadata:
   name: numaflow-server-metrics-proxy-config

--- a/ui/src/components/common/MetricsModalWrapper/index.tsx
+++ b/ui/src/components/common/MetricsModalWrapper/index.tsx
@@ -13,6 +13,7 @@ interface MetricsModalWrapperProps {
   type: string;
   metricName: string;
   value: any;
+  presets?: any;
 }
 
 export function MetricsModalWrapper({
@@ -23,6 +24,7 @@ export function MetricsModalWrapper({
   type,
   metricName,
   value,
+  presets,
 }: MetricsModalWrapperProps) {
   const [open, setOpen] = useState<boolean>(false);
 
@@ -59,6 +61,7 @@ export function MetricsModalWrapper({
         pipelineId={pipelineId}
         vertexId={vertexId}
         type={type}
+        presets={presets}
       />
     </Box>
   );

--- a/ui/src/components/common/MetricsModalWrapper/index.tsx
+++ b/ui/src/components/common/MetricsModalWrapper/index.tsx
@@ -6,6 +6,7 @@ import { MetricsModal } from "./partials/MetricsModal";
 import "./style.css";
 
 interface MetricsModalWrapperProps {
+  disableMetricsCharts: boolean;
   namespaceId: string;
   pipelineId: string;
   vertexId: string;
@@ -15,6 +16,7 @@ interface MetricsModalWrapperProps {
 }
 
 export function MetricsModalWrapper({
+  disableMetricsCharts,
   namespaceId,
   pipelineId,
   vertexId,
@@ -42,7 +44,10 @@ export function MetricsModalWrapper({
         placement={"top-start"}
         arrow
       >
-        <Box className="metrics-hyperlink" onClick={() => handleOpen()}>
+        <Box
+          className={!disableMetricsCharts ? "metrics-hyperlink" : undefined}
+          onClick={!disableMetricsCharts ? handleOpen : undefined}
+        >
           {value}
         </Box>
       </Tooltip>

--- a/ui/src/components/common/MetricsModalWrapper/partials/MetricsModal/index.tsx
+++ b/ui/src/components/common/MetricsModalWrapper/partials/MetricsModal/index.tsx
@@ -73,7 +73,9 @@ export function MetricsModal({
             justifyContent: "space-between",
           }}
         >
-          <Box sx={{ fontSize: "1.6rem" }}>{metricNameMap[metricName]}</Box>
+          <Box sx={{ fontSize: "1.6rem", textTransform: "capitalize" }}>
+            {metricNameMap[metricName] ?? metricName}
+          </Box>
           <IconButton onClick={handleClose}>
             <CloseIcon fontSize="large" />
           </IconButton>

--- a/ui/src/components/common/MetricsModalWrapper/partials/MetricsModal/index.tsx
+++ b/ui/src/components/common/MetricsModalWrapper/partials/MetricsModal/index.tsx
@@ -8,9 +8,8 @@ import {
   VertexDetailsContext,
   VertexDetailsContextProps,
 } from "../../../SlidingSidebar/partials/VertexDetails";
-import { metricNameMap } from "../../../../pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants";
 
-const style = {
+const modalStyle = {
   position: "absolute",
   top: "50%",
   left: "50%",
@@ -23,9 +22,10 @@ const style = {
 };
 
 interface MetricsModalProps {
-  open: boolean;
-  handleClose: () => void;
-  metricName: string;
+  isModalOpen: boolean;
+  handleCloseModal: () => void;
+  metricDisplayName: string;
+  discoveredMetrics: any;
   namespaceId: string;
   pipelineId: string;
   vertexId: string;
@@ -34,61 +34,62 @@ interface MetricsModalProps {
 }
 
 export function MetricsModal({
-  open,
-  handleClose,
-  metricName,
+  isModalOpen,
+  handleCloseModal,
+  metricDisplayName,
+  discoveredMetrics,
   namespaceId,
   pipelineId,
   vertexId,
   type,
   presets,
 }: MetricsModalProps) {
-  const vertexDetailsContext =
-    useContext<VertexDetailsContextProps>(VertexDetailsContext);
   const { setVertexTab, setPodsViewTab, setExpanded, setPresets } =
-    vertexDetailsContext;
+    useContext<VertexDetailsContextProps>(VertexDetailsContext);
 
   const [metricsFound, setMetricsFound] = useState<boolean>(false);
 
   const handleRedirect = useCallback(() => {
-    handleClose();
+    handleCloseModal();
     if (presets) setPresets(presets);
     setVertexTab(0);
     setPodsViewTab(1);
-    const panelId = `${metricName}-panel`;
-    setExpanded((prevExpanded) => {
-      const newExpanded = new Set(prevExpanded);
-      newExpanded.add(panelId);
-      return newExpanded;
-    });
+    // expand the respective metrics accordion
+    const discoveredMetric = discoveredMetrics?.data?.find(
+      (m: any) => m?.display_name === metricDisplayName
+    );
+    const panelId = `${discoveredMetric?.metric_name}-panel`;
+    setExpanded((prevExpanded) => new Set(prevExpanded).add(panelId));
   }, [
-    handleClose,
+    handleCloseModal,
     presets,
     setPresets,
     setVertexTab,
     setPodsViewTab,
-    metricName,
+    discoveredMetrics,
+    metricDisplayName,
     setExpanded,
   ]);
 
   return (
     <Modal
-      open={open}
-      onClose={handleClose}
+      open={isModalOpen}
+      onClose={handleCloseModal}
       aria-labelledby="buffer-details-title"
       aria-describedby="buffer-details-description"
     >
-      <Box sx={style}>
+      <Box sx={modalStyle}>
         <Box
           sx={{
             display: "flex",
             justifyContent: "space-between",
+            alignItems: "center",
           }}
         >
           <Box sx={{ fontSize: "1.6rem", textTransform: "capitalize" }}>
-            {metricNameMap[metricName] ?? metricName}
+            {metricDisplayName}
           </Box>
-          <IconButton onClick={handleClose}>
+          <IconButton onClick={handleCloseModal} aria-label="close">
             <CloseIcon fontSize="large" />
           </IconButton>
         </Box>
@@ -98,7 +99,7 @@ export function MetricsModal({
             pipelineId={pipelineId}
             vertexId={vertexId}
             type={type}
-            metricName={metricName}
+            metricDisplayName={metricDisplayName}
             setMetricsFound={setMetricsFound}
             presets={presets}
           />

--- a/ui/src/components/common/MetricsModalWrapper/partials/MetricsModal/index.tsx
+++ b/ui/src/components/common/MetricsModalWrapper/partials/MetricsModal/index.tsx
@@ -30,6 +30,7 @@ interface MetricsModalProps {
   pipelineId: string;
   vertexId: string;
   type: string;
+  presets?: any;
 }
 
 export function MetricsModal({
@@ -40,15 +41,18 @@ export function MetricsModal({
   pipelineId,
   vertexId,
   type,
+  presets,
 }: MetricsModalProps) {
   const vertexDetailsContext =
     useContext<VertexDetailsContextProps>(VertexDetailsContext);
-  const { setVertexTab, setPodsViewTab, setExpanded } = vertexDetailsContext;
+  const { setVertexTab, setPodsViewTab, setExpanded, setPresets } =
+    vertexDetailsContext;
 
   const [metricsFound, setMetricsFound] = useState<boolean>(false);
 
   const handleRedirect = useCallback(() => {
     handleClose();
+    if (presets) setPresets(presets);
     setVertexTab(0);
     setPodsViewTab(1);
     const panelId = `${metricName}-panel`;
@@ -57,7 +61,15 @@ export function MetricsModal({
       newExpanded.add(panelId);
       return newExpanded;
     });
-  }, [handleClose, setVertexTab, setPodsViewTab, metricName, setExpanded]);
+  }, [
+    handleClose,
+    presets,
+    setPresets,
+    setVertexTab,
+    setPodsViewTab,
+    metricName,
+    setExpanded,
+  ]);
 
   return (
     <Modal
@@ -88,6 +100,7 @@ export function MetricsModal({
             type={type}
             metricName={metricName}
             setMetricsFound={setMetricsFound}
+            presets={presets}
           />
         </Box>
         {metricsFound && (

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/index.tsx
@@ -57,6 +57,8 @@ export interface VertexDetailsContextProps {
   setPodsViewTab: Dispatch<SetStateAction<number>>;
   expanded: Set<string>;
   setExpanded: Dispatch<SetStateAction<Set<string>>>;
+  presets: any;
+  setPresets: Dispatch<SetStateAction<any>>;
 }
 
 export const VertexDetailsContext = createContext<VertexDetailsContextProps>({
@@ -68,6 +70,9 @@ export const VertexDetailsContext = createContext<VertexDetailsContextProps>({
   expanded: new Set(),
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   setExpanded: () => {},
+  presets: undefined,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setPresets: () => {},
 });
 
 export function VertexDetails({
@@ -89,6 +94,7 @@ export function VertexDetails({
   const [updateModalOnClose, setUpdateModalOnClose] = useState<
     SpecEditorModalProps | undefined
   >();
+  const [presets, setPresets] = useState<any>(undefined);
   const [updateModalOpen, setUpdateModalOpen] = useState(false);
   const [targetTab, setTargetTab] = useState<number | undefined>();
 
@@ -226,6 +232,8 @@ export function VertexDetails({
         setPodsViewTab,
         expanded,
         setExpanded,
+        presets,
+        setPresets,
       }}
     >
       <Box

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/index.tsx
@@ -334,6 +334,7 @@ export function VertexDetails({
           {tabValue === PROCESSING_RATES_TAB_INDEX && (
             <ProcessingRates
               vertexId={vertexId}
+              namespaceId={namespaceId}
               pipelineId={pipelineId}
               type={type}
               vertexMetrics={vertexMetrics}

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Buffers/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Buffers/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import Box from "@mui/material/Box";
 import TableContainer from "@mui/material/TableContainer";
 import Table from "@mui/material/Table";
@@ -7,6 +7,8 @@ import TableCell from "@mui/material/TableCell";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { MetricsModalWrapper } from "../../../../../MetricsModalWrapper";
+import { AppContextProps } from "../../../../../../../types/declarations/app";
+import { AppContext } from "../../../../../../../App";
 
 export interface BuffersProps {
   buffers: any[];
@@ -26,6 +28,7 @@ export function Buffers({
   if (!buffers) {
     return <div>{`No resources found.`}</div>;
   }
+  const { disableMetricsCharts } = useContext<AppContextProps>(AppContext);
 
   return (
     <Box
@@ -84,6 +87,7 @@ export function Buffers({
                     <TableCell data-testid="usage">{bufferUsage}%</TableCell>
                     <TableCell data-testid="totalMessages">
                       <MetricsModalWrapper
+                        disableMetricsCharts={disableMetricsCharts}
                         namespaceId={namespaceId}
                         pipelineId={pipelineId}
                         vertexId={vertexId}

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Buffers/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Buffers/index.tsx
@@ -7,6 +7,7 @@ import TableCell from "@mui/material/TableCell";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { MetricsModalWrapper } from "../../../../../MetricsModalWrapper";
+import { VERTEX_PENDING_MESSAGES } from "../../../../../../pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants";
 import { AppContextProps } from "../../../../../../../types/declarations/app";
 import { AppContext } from "../../../../../../../App";
 
@@ -92,7 +93,7 @@ export function Buffers({
                         pipelineId={pipelineId}
                         vertexId={vertexId}
                         type={type}
-                        metricName={"vertex_pending_messages"}
+                        metricDisplayName={VERTEX_PENDING_MESSAGES}
                         value={buffer?.totalMessages}
                       />
                     </TableCell>

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
@@ -8,6 +8,10 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { MetricsModalWrapper } from "../../../../../MetricsModalWrapper";
 import { PipelineVertexMetric } from "../../../../../../../types/declarations/pipeline";
+import {
+  MONO_VERTEX_PROCESSING_RATE,
+  VERTEX_PROCESSING_RATE,
+} from "../../../../../../pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants";
 import { AppContextProps } from "../../../../../../../types/declarations/app";
 import { AppContext } from "../../../../../../../App";
 
@@ -106,10 +110,10 @@ export function ProcessingRates({
                         pipelineId={pipelineId}
                         vertexId={vertexId}
                         type={type}
-                        metricName={
+                        metricDisplayName={
                           type === "monoVertex"
-                            ? "monovtx_read_total"
-                            : "forwarder_data_read_total"
+                            ? MONO_VERTEX_PROCESSING_RATE
+                            : VERTEX_PROCESSING_RATE
                         }
                         value={formatRate(metric?.[RATE_LABELS_MAP[label]])}
                         presets={{ duration: label }}

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
@@ -6,12 +6,14 @@ import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
+import { MetricsModalWrapper } from "../../../../../MetricsModalWrapper";
 import { PipelineVertexMetric } from "../../../../../../../types/declarations/pipeline";
 
 import "./style.css";
 
 export interface ProcessingRatesProps {
   vertexId: string;
+  namespaceId: string;
   pipelineId: string;
   type: string;
   vertexMetrics: any;
@@ -19,6 +21,7 @@ export interface ProcessingRatesProps {
 
 export function ProcessingRates({
   vertexMetrics,
+  namespaceId,
   pipelineId,
   type,
   vertexId,
@@ -92,7 +95,20 @@ export function ProcessingRates({
                   {type !== "monoVertex" && (
                     <TableCell>{metric.partition}</TableCell>
                   )}
-                  <TableCell>{formatRate(metric.oneM)}</TableCell>
+                  <TableCell>
+                    <MetricsModalWrapper
+                      namespaceId={namespaceId}
+                      pipelineId={pipelineId}
+                      vertexId={vertexId}
+                      type={type}
+                      metricName={
+                        type === "monoVertex"
+                          ? "monovtx_read_total"
+                          : "forwarder_data_read_total"
+                      }
+                      value={formatRate(metric.oneM)}
+                    />
+                  </TableCell>
                   <TableCell>{formatRate(metric.fiveM)}</TableCell>
                   <TableCell>{formatRate(metric.fifteenM)}</TableCell>
                 </TableRow>

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Box from "@mui/material/Box";
 import TableContainer from "@mui/material/TableContainer";
 import Table from "@mui/material/Table";
@@ -8,6 +8,8 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { MetricsModalWrapper } from "../../../../../MetricsModalWrapper";
 import { PipelineVertexMetric } from "../../../../../../../types/declarations/pipeline";
+import { AppContextProps } from "../../../../../../../types/declarations/app";
+import { AppContext } from "../../../../../../../App";
 
 import "./style.css";
 
@@ -26,6 +28,7 @@ export function ProcessingRates({
   type,
   vertexId,
 }: ProcessingRatesProps) {
+  const { disableMetricsCharts } = useContext<AppContextProps>(AppContext);
   const [foundRates, setFoundRates] = useState<PipelineVertexMetric[]>([]);
 
   useEffect(() => {
@@ -97,6 +100,7 @@ export function ProcessingRates({
                   )}
                   <TableCell>
                     <MetricsModalWrapper
+                      disableMetricsCharts={disableMetricsCharts}
                       namespaceId={namespaceId}
                       pipelineId={pipelineId}
                       vertexId={vertexId}

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/ProcessingRates/index.tsx
@@ -21,6 +21,13 @@ export interface ProcessingRatesProps {
   vertexMetrics: any;
 }
 
+const RATE_LABELS: string[] = ["1m", "5m", "15m"];
+const RATE_LABELS_MAP: { [k: string]: string } = {
+  "1m": "oneM",
+  "5m": "fiveM",
+  "15m": "fifteenM",
+};
+
 export function ProcessingRates({
   vertexMetrics,
   namespaceId,
@@ -37,9 +44,8 @@ export function ProcessingRates({
     }
     const vertexData =
       type === "monoVertex" ? [vertexMetrics] : vertexMetrics[vertexId];
-    if (!vertexData) {
-      return;
-    }
+    if (!vertexData) return;
+
     const rates: PipelineVertexMetric[] = [];
     vertexData.forEach((item: any, index: number) => {
       const key = type === "monoVertex" ? "monoVertex" : "pipeline";
@@ -48,15 +54,9 @@ export function ProcessingRates({
       }
       rates.push({
         partition: index,
-        oneM: item.processingRates["1m"]
-          ? item.processingRates["1m"].toFixed(2)
-          : 0,
-        fiveM: item.processingRates["5m"]
-          ? item.processingRates["5m"].toFixed(2)
-          : 0,
-        fifteenM: item.processingRates["15m"]
-          ? item.processingRates["15m"].toFixed(2)
-          : 0,
+        oneM: item.processingRates["1m"]?.toFixed(2) || 0,
+        fiveM: item.processingRates["5m"]?.toFixed(2) || 0,
+        fifteenM: item.processingRates["15m"]?.toFixed(2) || 0,
       });
     });
     setFoundRates(rates);
@@ -79,9 +79,9 @@ export function ProcessingRates({
           <TableHead>
             <TableRow>
               {type !== "monoVertex" && <TableCell>Partition</TableCell>}
-              <TableCell>1m</TableCell>
-              <TableCell>5m</TableCell>
-              <TableCell>15m</TableCell>
+              {RATE_LABELS.map((label: string) => (
+                <TableCell key={label}>{label}</TableCell>
+              ))}
             </TableRow>
           </TableHead>
           <TableBody>
@@ -93,28 +93,29 @@ export function ProcessingRates({
               </TableRow>
             )}
             {!!foundRates.length &&
-              foundRates.map((metric) => (
+              foundRates.map((metric: any) => (
                 <TableRow key={metric.partition}>
                   {type !== "monoVertex" && (
                     <TableCell>{metric.partition}</TableCell>
                   )}
-                  <TableCell>
-                    <MetricsModalWrapper
-                      disableMetricsCharts={disableMetricsCharts}
-                      namespaceId={namespaceId}
-                      pipelineId={pipelineId}
-                      vertexId={vertexId}
-                      type={type}
-                      metricName={
-                        type === "monoVertex"
-                          ? "monovtx_read_total"
-                          : "forwarder_data_read_total"
-                      }
-                      value={formatRate(metric.oneM)}
-                    />
-                  </TableCell>
-                  <TableCell>{formatRate(metric.fiveM)}</TableCell>
-                  <TableCell>{formatRate(metric.fifteenM)}</TableCell>
+                  {RATE_LABELS?.map((label: string) => (
+                    <TableCell key={label}>
+                      <MetricsModalWrapper
+                        disableMetricsCharts={disableMetricsCharts}
+                        namespaceId={namespaceId}
+                        pipelineId={pipelineId}
+                        vertexId={vertexId}
+                        type={type}
+                        metricName={
+                          type === "monoVertex"
+                            ? "monovtx_read_total"
+                            : "forwarder_data_read_total"
+                        }
+                        value={formatRate(metric?.[RATE_LABELS_MAP[label]])}
+                        presets={{ duration: label }}
+                      />
+                    </TableCell>
+                  ))}
                 </TableRow>
               ))}
           </TableBody>

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/index.tsx
@@ -359,6 +359,10 @@ export function Pods(props: PodsProps) {
               }}
             >
               <ContainerInfo
+                namespaceId={namespaceId}
+                pipelineId={pipelineId}
+                vertexId={vertexId}
+                type={type}
                 pod={selectedPod}
                 podDetails={selectedPodDetails}
                 containerName={selectedContainer}

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/ContainerInfo/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/ContainerInfo/index.tsx
@@ -3,6 +3,12 @@ import Box from "@mui/material/Box";
 import { MetricsModalWrapper } from "../../../../../../../../../../../../common/MetricsModalWrapper";
 import { getPodContainerUsePercentages } from "../../../../../../../../../../../../../utils";
 import { PodInfoProps } from "../../../../../../../../../../../../../types/declarations/pods";
+import {
+  CONTAINER_CPU_UTILIZATION,
+  CONTAINER_MEMORY_UTILIZATION,
+  POD_CPU_UTILIZATION,
+  POD_MEMORY_UTILIZATION,
+} from "../Metrics/utils/constants";
 import { AppContextProps } from "../../../../../../../../../../../../../types/declarations/app";
 import { AppContext } from "../../../../../../../../../../../../../App";
 
@@ -126,7 +132,7 @@ export function ContainerInfo({
                 pipelineId={pipelineId}
                 vertexId={vertexId}
                 type={type}
-                metricName={"namespace_app_container_cpu_utilization"}
+                metricDisplayName={CONTAINER_CPU_UTILIZATION}
                 value={`${usedCPU} / ${specCPU} (${cpuPercent})`}
               />
             </Box>
@@ -141,7 +147,7 @@ export function ContainerInfo({
                 pipelineId={pipelineId}
                 vertexId={vertexId}
                 type={type}
-                metricName={"namespace_app_container_memory_utilization"}
+                metricDisplayName={CONTAINER_MEMORY_UTILIZATION}
                 value={`${usedMem} / ${specMem} (${memPercent})`}
               />
             </Box>
@@ -226,7 +232,7 @@ export function ContainerInfo({
                   pipelineId={pipelineId}
                   vertexId={vertexId}
                   type={type}
-                  metricName={"namespace_pod_cpu_utilization"}
+                  metricDisplayName={POD_CPU_UTILIZATION}
                   value={podSpecificInfo?.totalCPU}
                 />
               </Box>
@@ -243,7 +249,7 @@ export function ContainerInfo({
                   pipelineId={pipelineId}
                   vertexId={vertexId}
                   type={type}
-                  metricName={"namespace_pod_memory_utilization"}
+                  metricDisplayName={POD_MEMORY_UTILIZATION}
                   value={podSpecificInfo?.totalMemory}
                 />
               </Box>

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/ContainerInfo/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/ContainerInfo/index.tsx
@@ -1,17 +1,26 @@
-import React from "react";
+import React, { useContext } from "react";
 import Box from "@mui/material/Box";
+import { MetricsModalWrapper } from "../../../../../../../../../../../../common/MetricsModalWrapper";
 import { getPodContainerUsePercentages } from "../../../../../../../../../../../../../utils";
 import { PodInfoProps } from "../../../../../../../../../../../../../types/declarations/pods";
+import { AppContextProps } from "../../../../../../../../../../../../../types/declarations/app";
+import { AppContext } from "../../../../../../../../../../../../../App";
 
 import "./style.css";
 
 export function ContainerInfo({
+  namespaceId,
+  pipelineId,
+  vertexId,
+  type,
   pod,
   podDetails,
   containerName,
   containerInfo,
   podSpecificInfo,
 }: PodInfoProps) {
+  const { disableMetricsCharts } = useContext<AppContextProps>(AppContext);
+
   const resourceUsage = getPodContainerUsePercentages(
     pod,
     podDetails,
@@ -111,14 +120,30 @@ export function ContainerInfo({
           <Box className={"outer-box"}>
             <Box className={"inner-box-title"}>CPU</Box>
             <Box className={"inner-box-value"}>
-              {`${usedCPU} / ${specCPU}`} {` (${cpuPercent})`}
+              <MetricsModalWrapper
+                disableMetricsCharts={disableMetricsCharts}
+                namespaceId={namespaceId}
+                pipelineId={pipelineId}
+                vertexId={vertexId}
+                type={type}
+                metricName={"namespace_app_container_cpu_utilization"}
+                value={`${usedCPU} / ${specCPU} (${cpuPercent})`}
+              />
             </Box>
           </Box>
 
           <Box className={"outer-box"}>
             <Box className={"inner-box-title"}>Memory</Box>
             <Box className={"inner-box-value"}>
-              {`${usedMem} / ${specMem}`} {` (${memPercent})`}
+              <MetricsModalWrapper
+                disableMetricsCharts={disableMetricsCharts}
+                namespaceId={namespaceId}
+                pipelineId={pipelineId}
+                vertexId={vertexId}
+                type={type}
+                metricName={"namespace_app_container_memory_utilization"}
+                value={`${usedMem} / ${specMem} (${memPercent})`}
+              />
             </Box>
           </Box>
 
@@ -195,7 +220,15 @@ export function ContainerInfo({
             <Box className={"outer-box"}>
               <Box className={"inner-box-title"}>CPU</Box>
               <Box className={"inner-box-value"}>
-                {podSpecificInfo?.totalCPU}
+                <MetricsModalWrapper
+                  disableMetricsCharts={disableMetricsCharts}
+                  namespaceId={namespaceId}
+                  pipelineId={pipelineId}
+                  vertexId={vertexId}
+                  type={type}
+                  metricName={"namespace_pod_cpu_utilization"}
+                  value={podSpecificInfo?.totalCPU}
+                />
               </Box>
             </Box>
           )}
@@ -204,7 +237,15 @@ export function ContainerInfo({
             <Box className={"outer-box"}>
               <Box className={"inner-box-title"}>Memory</Box>
               <Box className={"inner-box-value"}>
-                {podSpecificInfo?.totalMemory}
+                <MetricsModalWrapper
+                  disableMetricsCharts={disableMetricsCharts}
+                  namespaceId={namespaceId}
+                  pipelineId={pipelineId}
+                  vertexId={vertexId}
+                  type={type}
+                  metricName={"namespace_pod_memory_utilization"}
+                  value={podSpecificInfo?.totalMemory}
+                />
               </Box>
             </Box>
           )}

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/index.tsx
@@ -13,10 +13,14 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import LineChartComponent from "./partials/LineChart";
 import { useMetricsDiscoveryDataFetch } from "../../../../../../../../../../../../../utils/fetchWrappers/metricsDiscoveryDataFetch";
 import {
+  dimensionReverseMap,
+  VERTEX_PENDING_MESSAGES,
+} from "./utils/constants";
+import {
   VertexDetailsContext,
   VertexDetailsContextProps,
 } from "../../../../../../../../../../../../common/SlidingSidebar/partials/VertexDetails";
-import { dimensionReverseMap, metricNameMap } from "./utils/constants";
+
 import "./style.css";
 
 export interface MetricsProps {
@@ -25,7 +29,7 @@ export interface MetricsProps {
   type: string;
   vertexId?: string;
   selectedPodName?: string;
-  metricName?: string;
+  metricDisplayName?: string;
   setMetricsFound?: Dispatch<SetStateAction<boolean>>;
   presets?: any;
 }
@@ -36,7 +40,7 @@ export function Metrics({
   type,
   vertexId,
   selectedPodName,
-  metricName,
+  metricDisplayName,
   setMetricsFound,
   presets,
 }: MetricsProps) {
@@ -90,9 +94,9 @@ export function Metrics({
 
   if (discoveredMetrics == undefined) return <Box>No metrics found</Box>;
 
-  if (metricName) {
+  if (metricDisplayName) {
     const discoveredMetric = discoveredMetrics?.data?.find(
-      (m: any) => m?.metric_name === metricName
+      (m: any) => m?.display_name === metricDisplayName
     );
     if (discoveredMetric) {
       if (setMetricsFound)
@@ -119,7 +123,10 @@ export function Metrics({
   return (
     <Box sx={{ height: "100%" }}>
       {discoveredMetrics?.data?.map((metric: any) => {
-        if (type === "source" && metric?.pattern_name === "vertex_gauge")
+        if (
+          type === "source" &&
+          metric?.display_name === VERTEX_PENDING_MESSAGES
+        )
           return null;
         const panelId = `${metric?.metric_name}-panel`;
         return (
@@ -134,19 +141,17 @@ export function Metrics({
               id={`${metric?.metric_name}-header`}
             >
               <Box sx={{ display: "flex", alignItems: "center" }}>
-                {metric?.display_name ||
-                  metricNameMap[metric?.metric_name] ||
-                  metric?.metric_name}
+                {metric?.display_name || metric?.metric_name}
                 <Tooltip
                   title={
-                    <Typography sx={{ fontSize: "1rem" }}>
+                    <Typography sx={{ fontSize: "1.4rem" }}>
                       {metric?.metric_description ||
                         metric?.display_name ||
-                        metricNameMap[metric?.metric_name] ||
                         metric?.metric_name}
                     </Typography>
                   }
                   arrow
+                  placement={"top-start"}
                 >
                   <Box sx={{ marginLeft: 1 }}>
                     <InfoOutlinedIcon sx={{ cursor: "pointer" }} />

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/index.tsx
@@ -1,9 +1,15 @@
 import React, { Dispatch, SetStateAction, useContext } from "react";
 import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
-import { Accordion, AccordionDetails, AccordionSummary, Tooltip, Typography } from "@mui/material";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import LineChartComponent from "./partials/LineChart";
 import { useMetricsDiscoveryDataFetch } from "../../../../../../../../../../../../../utils/fetchWrappers/metricsDiscoveryDataFetch";
 import {
@@ -21,16 +27,18 @@ export interface MetricsProps {
   selectedPodName?: string;
   metricName?: string;
   setMetricsFound?: Dispatch<SetStateAction<boolean>>;
+  presets?: any;
 }
 
 export function Metrics({
   namespaceId,
   pipelineId,
   type,
-  vertexId, 
+  vertexId,
   selectedPodName,
   metricName,
   setMetricsFound,
+  presets,
 }: MetricsProps) {
   const {
     metricsDiscoveryData: discoveredMetrics,
@@ -40,11 +48,16 @@ export function Metrics({
     objectType: dimensionReverseMap[type],
   });
 
-  const { expanded, setExpanded } =
-    useContext<VertexDetailsContextProps>(VertexDetailsContext);
+  const {
+    expanded,
+    setExpanded,
+    presets: presetsFromContext,
+    setPresets,
+  } = useContext<VertexDetailsContextProps>(VertexDetailsContext);
 
   const handleAccordionChange =
     (panel: string) => (_: any, isExpanded: boolean) => {
+      setPresets(undefined);
       setExpanded((prevExpanded) => {
         const newExpanded = new Set(prevExpanded);
         isExpanded ? newExpanded.add(panel) : newExpanded.delete(panel);
@@ -82,7 +95,10 @@ export function Metrics({
       (m: any) => m?.metric_name === metricName
     );
     if (discoveredMetric) {
-      if (setMetricsFound) setMetricsFound(true);
+      if (setMetricsFound)
+        setTimeout(() => {
+          setMetricsFound(true);
+        }, 100);
       return (
         <LineChartComponent
           namespaceId={namespaceId}
@@ -90,6 +106,7 @@ export function Metrics({
           type={type}
           metric={discoveredMetric}
           vertexId={vertexId}
+          presets={presets}
           fromModal
         />
       );
@@ -102,10 +119,7 @@ export function Metrics({
   return (
     <Box sx={{ height: "100%" }}>
       {discoveredMetrics?.data?.map((metric: any) => {
-        if (
-          type === "source" &&
-          metric?.pattern_name === "vertex_gauge"
-        )
+        if (type === "source" && metric?.pattern_name === "vertex_gauge")
           return null;
         const panelId = `${metric?.metric_name}-panel`;
         return (
@@ -119,23 +133,23 @@ export function Metrics({
               aria-controls={`${metric?.metric_name}-content`}
               id={`${metric?.metric_name}-header`}
             >
-              <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                {metric?.display_name || 
-                 metricNameMap[metric?.metric_name] || 
-                 metric?.metric_name}
-                <Tooltip 
+              <Box sx={{ display: "flex", alignItems: "center" }}>
+                {metric?.display_name ||
+                  metricNameMap[metric?.metric_name] ||
+                  metric?.metric_name}
+                <Tooltip
                   title={
-                    <Typography sx={{ fontSize: '1rem' }}>
-                      {metric?.metric_description || 
-                       metric?.display_name || 
-                       metricNameMap[metric?.metric_name] || 
-                       metric?.metric_name }
+                    <Typography sx={{ fontSize: "1rem" }}>
+                      {metric?.metric_description ||
+                        metric?.display_name ||
+                        metricNameMap[metric?.metric_name] ||
+                        metric?.metric_name}
                     </Typography>
-                  } 
+                  }
                   arrow
                 >
                   <Box sx={{ marginLeft: 1 }}>
-                    <InfoOutlinedIcon sx={{ cursor: 'pointer'}} />
+                    <InfoOutlinedIcon sx={{ cursor: "pointer" }} />
                   </Box>
                 </Tooltip>
               </Box>
@@ -148,6 +162,7 @@ export function Metrics({
                   type={type}
                   metric={metric}
                   vertexId={vertexId}
+                  presets={presetsFromContext}
                   selectedPodName={selectedPodName}
                 />
               )}

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
@@ -26,7 +26,12 @@ interface TooltipProps {
   active?: boolean;
 }
 
-function CustomTooltip({ payload, label, active, patternName }: TooltipProps & { patternName: string }) {
+function CustomTooltip({
+  payload,
+  label,
+  active,
+  patternName,
+}: TooltipProps & { patternName: string }) {
   if (active && payload && payload.length) {
     const maxWidth =
       Math.max(...payload.map((entry) => entry?.name?.length)) * 9.5;
@@ -42,20 +47,20 @@ function CustomTooltip({ payload, label, active, patternName }: TooltipProps & {
         <Box>{label}</Box>
         {payload.map((entry: any, index: any) => {
           const formattedValue = getDefaultFormatter(entry?.value, patternName);
-          return(
-          <Box key={`item-${index}`} sx={{ display: "flex" }}>
-            <Box
-              sx={{
-                width: `${maxWidth / 9}rem`,
-                display: "inline-block",
-                paddingRight: "1rem",
-                color: entry?.color,
-              }}
-            >
-              {entry?.name}:
+          return (
+            <Box key={`item-${index}`} sx={{ display: "flex" }}>
+              <Box
+                sx={{
+                  width: `${maxWidth / 9}rem`,
+                  display: "inline-block",
+                  paddingRight: "1rem",
+                  color: entry?.color,
+                }}
+              >
+                {entry?.name}:
+              </Box>
+              <Box sx={{ color: entry?.color }}>{formattedValue}</Box>
             </Box>
-            <Box sx={{ color: entry?.color }}>{formattedValue}</Box>
-          </Box>
           );
         })}
       </Box>
@@ -78,12 +83,12 @@ const getDefaultFormatter = (value: number, patternName: string) => {
       ? `${Math.floor(formattedValue)}${suffix}`
       : `${formattedValue}${suffix}`;
   };
-  switch(patternName){
+  switch (patternName) {
     case "mono_vertex_histogram":
-      if (value === 0){
+      if (value === 0) {
         return "0";
       } else if (value < 1000) {
-        return formatValue(value," μs");
+        return formatValue(value, " μs");
       } else if (value < 1000000) {
         return formatValue(value / 1000, " ms");
       } else {
@@ -91,10 +96,10 @@ const getDefaultFormatter = (value: number, patternName: string) => {
       }
     case "container_cpu_memory_utilization":
     case "pod_cpu_memory_utilization":
-      if (value === 0){
+      if (value === 0) {
         return "0";
       } else if (value < 1000) {
-        return formatValue(value," %");
+        return formatValue(value, " %");
       } else if (value < 1000000) {
         return formatValue(value / 1000, "k %");
       } else {
@@ -104,7 +109,7 @@ const getDefaultFormatter = (value: number, patternName: string) => {
       if (value === 0) {
         return "0";
       } else if (value < 1000) {
-        return formatValue(value,"");
+        return formatValue(value, "");
       } else if (value < 1000000) {
         return formatValue(value / 1000, " k");
       } else {
@@ -139,6 +144,7 @@ interface LineChartComponentProps {
   metric: any;
   vertexId?: string;
   selectedPodName?: string;
+  presets?: any;
   fromModal?: boolean;
 }
 
@@ -150,6 +156,7 @@ const LineChartComponent = ({
   metric,
   vertexId,
   selectedPodName,
+  presets,
   fromModal,
 }: LineChartComponentProps) => {
   const { addError } = useContext<AppContextProps>(AppContext);
@@ -185,15 +192,14 @@ const LineChartComponent = ({
           return vertexId;
         case "pod":
           // based on pattern names, update filter based on pod value or multiple pods based on regex
-          if (metric?.pattern_name === "pod_cpu_memory_utilization"){
-            switch(type){
+          if (metric?.pattern_name === "pod_cpu_memory_utilization") {
+            switch (type) {
               case "monoVertex":
                 return `${pipelineId}-.*`;
               default:
                 return `${pipelineId}-${vertexId}-.*`;
             }
-          }
-          else {
+          } else {
             return selectedPodName;
           }
         default:
@@ -268,7 +274,7 @@ const LineChartComponent = ({
   }, [error, addError]);
 
   const groupByLabel = useCallback((dimension: string, patternName: string) => {
-    switch(patternName){
+    switch (patternName) {
       case "pod_cpu_memory_utilization":
         return ["pod"];
       case "container_cpu_memory_utilization":
@@ -374,6 +380,7 @@ const LineChartComponent = ({
                   type={type}
                   field={param?.name}
                   setMetricReq={setMetricsReq}
+                  presets={presets}
                 />
               </Box>
             );
@@ -478,7 +485,9 @@ const LineChartComponent = ({
               />
             ))}
 
-            <Tooltip content={<CustomTooltip patternName={metric?.pattern_name} />}/>
+            <Tooltip
+              content={<CustomTooltip patternName={metric?.pattern_name} />}
+            />
             <Legend />
           </LineChart>
         </ResponsiveContainer>

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/common/Dropdown/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/common/Dropdown/index.tsx
@@ -29,11 +29,13 @@ const Dropdown = ({
 }: MetricDropDownProps) => {
   // to handle cases there is no "mono-vertex" as dimension at top level (for eg: container level cpu/memory)
   const initialDimensionValue = useMemo(() => {
-    if (!metric?.dimensions?.length) return metric?.dimensions[0]?.name;
+    if (!metric?.dimensions?.length) return dimensionReverseMap[type];
 
-    return metric?.dimensions?.find(
-      (val: any) => val?.name === dimensionReverseMap[type]
-    )?.name;
+    return (
+      metric?.dimensions?.find(
+        (val: any) => val?.name === dimensionReverseMap[type]
+      )?.name || metric?.dimensions[0]?.name
+    );
   }, [metric, type]);
 
   const getInitialValue = useMemo(() => {

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants.ts
@@ -1,9 +1,9 @@
-export const durationOptions = ["1m", "5m", "10m"];
+export const durationOptions = ["1m", "5m", "15m"];
 
 export const durationMap: { [p: string]: string } = {
   "1m": "1 min",
   "5m": "5 mins",
-  "10m": "10 mins",
+  "15m": "15 mins",
 };
 
 export const quantileOptions = ["0.50", "0.90", "0.95", "0.99"];
@@ -20,7 +20,7 @@ export const dimensionMap: { [p: string]: string } = {
   pod: "Pod",
   pipeline: "Pipeline",
   vertex: "Vertex",
-  container: "Container"
+  container: "Container",
 };
 
 export const dimensionReverseMap: { [p: string]: string } = {
@@ -30,19 +30,20 @@ export const dimensionReverseMap: { [p: string]: string } = {
   sink: "vertex",
   pipeline: "pipeline",
   pod: "pod",
-  container: "container"
+  container: "container",
 };
 
 export const metricNameMap: { [p: string]: string } = {
   monovtx_ack_time_bucket: "Mono Vertex Ack Time Latency",
   monovtx_read_time_bucket: "Mono Vertex Read Time Latency",
-  monovtx_processing_time_bucket:
-    "Mono Vertex Processing Time Latency",
-  monovtx_sink_time_bucket:
-    "Mono Vertex Sink Write Time Latency",
-  forwarder_data_read_total:
-    "Vertex Read Processing Rate",
+  monovtx_processing_time_bucket: "Mono Vertex Processing Time Latency",
+  monovtx_sink_time_bucket: "Mono Vertex Sink Write Time Latency",
+  forwarder_data_read_total: "Vertex Read Processing Rate",
   monovtx_read_total: "Mono Vertex Read Processing Rate",
   monovtx_pending: "Mono Vertex Pending Messages",
   vertex_pending_messages: "Vertex Pending Messages",
+  namespace_pod_cpu_utilization: "Pod CPU Utilization",
+  namespace_pod_memory_utilization: "Pod Memory Utilization",
+  namespace_app_container_cpu_utilization: "Container CPU Utilization",
+  namespace_app_container_memory_utilization: "Container Memory Utilization",
 };

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants.ts
@@ -33,17 +33,15 @@ export const dimensionReverseMap: { [p: string]: string } = {
   container: "container",
 };
 
-export const metricNameMap: { [p: string]: string } = {
-  monovtx_ack_time_bucket: "Mono Vertex Ack Time Latency",
-  monovtx_read_time_bucket: "Mono Vertex Read Time Latency",
-  monovtx_processing_time_bucket: "Mono Vertex Processing Time Latency",
-  monovtx_sink_time_bucket: "Mono Vertex Sink Write Time Latency",
-  forwarder_data_read_total: "Vertex Read Processing Rate",
-  monovtx_read_total: "Mono Vertex Read Processing Rate",
-  monovtx_pending: "Mono Vertex Pending Messages",
-  vertex_pending_messages: "Vertex Pending Messages",
-  namespace_pod_cpu_utilization: "Pod CPU Utilization",
-  namespace_pod_memory_utilization: "Pod Memory Utilization",
-  namespace_app_container_cpu_utilization: "Container CPU Utilization",
-  namespace_app_container_memory_utilization: "Container Memory Utilization",
-};
+export const VERTEX_PENDING_MESSAGES = "Vertex Pending Messages";
+export const VERTEX_PROCESSING_RATE = "Vertex Read Processing Rate";
+export const MONO_VERTEX_PENDING_MESSAGES = "MonoVertex Pending Messages";
+export const MONO_VERTEX_PROCESSING_RATE = "MonoVertex Read Processing Rate";
+export const MONO_VERTEX_PROCESSING_TIME_LATENCY =
+  "MonoVertex Processing Time Latency";
+export const MONO_VERTEX_SINK_WRITE_TIME_LATENCY =
+  "MonoVertex Sink Write Time Latency";
+export const POD_CPU_UTILIZATION = "Pod CPU Utilization";
+export const POD_MEMORY_UTILIZATION = "Pod Memory Utilization";
+export const CONTAINER_CPU_UTILIZATION = "Container CPU Utilization";
+export const CONTAINER_MEMORY_UTILIZATION = "Container Memory Utilization";

--- a/ui/src/types/declarations/pods.d.ts
+++ b/ui/src/types/declarations/pods.d.ts
@@ -125,6 +125,10 @@ export interface PodSpecificInfoProps {
   totalMemory: string;
 }
 export interface PodInfoProps {
+  namespaceId: string;
+  pipelineId: string;
+  vertexId: string;
+  type: string;
   pod: Pod;
   podDetails: PodDetail;
   containerName: string;

--- a/ui/src/utils/fetchWrappers/metricsFetch.ts
+++ b/ui/src/utils/fetchWrappers/metricsFetch.ts
@@ -21,14 +21,21 @@ export const useMetricsFetch = ({
   useEffect(() => {
     const fetchData = async () => {
       setIsLoading(true);
-      if ( Object.keys(filters).length > 0 && metricReq?.dimension !== undefined) {
+      if (
+        Object.keys(filters).length > 0 &&
+        metricReq?.dimension !== undefined
+      ) {
         try {
           const response = await fetch(urlPath, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
             },
-            body: JSON.stringify({ ...metricReq, filters }),
+            body: JSON.stringify({
+              ...metricReq,
+              filters,
+              display_name: undefined,
+            }),
           });
           const data = await response.json();
           if (data?.data === null) {
@@ -48,7 +55,7 @@ export const useMetricsFetch = ({
         } finally {
           setIsLoading(false);
         }
-      } else{
+      } else {
         setIsLoading(false);
       }
     };


### PR DESCRIPTION
Fixes #2315 
- adding contextual flow for processing rates and cpu/memory metrics

<img width="1278" alt="image" src="https://github.com/user-attachments/assets/11f202c2-dfb9-443c-8d09-a4f392a272d2" />

<img width="427" alt="image" src="https://github.com/user-attachments/assets/1e8a25bf-f2c2-4bfc-875f-a8f6dd57179d" />

<img width="381" alt="image" src="https://github.com/user-attachments/assets/d5bb657a-6b5e-450b-8dd9-50f4ca39d68f" />


