### PR TITLE
feat: Serving as a builtin source with Monovertex

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3568,6 +3568,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "http 1.2.0",
  "hyper-util",
  "numaflow-models",
  "parking_lot",

--- a/rust/numaflow-core/src/config/monovertex.rs
+++ b/rust/numaflow-core/src/config/monovertex.rs
@@ -94,7 +94,7 @@ impl MonovertexConfig {
             .metadata
             .as_ref()
             .and_then(|metadata| metadata.name.clone())
-            .ok_or_else(|| Error::Config("Monovertex name not found".to_string()))?;
+            .ok_or_else(|| Error::Config("MonoVertex name not found".to_string()))?;
 
         let transformer_config = mono_vertex_obj
             .spec

--- a/rust/numaflow-core/src/config/monovertex.rs
+++ b/rust/numaflow-core/src/config/monovertex.rs
@@ -94,7 +94,7 @@ impl MonovertexConfig {
             .metadata
             .as_ref()
             .and_then(|metadata| metadata.name.clone())
-            .ok_or_else(|| Error::Config("Mono vertex name not found".to_string()))?;
+            .ok_or_else(|| Error::Config("Monovertex name not found".to_string()))?;
 
         let transformer_config = mono_vertex_obj
             .spec

--- a/rust/serving/Cargo.toml
+++ b/rust/serving/Cargo.toml
@@ -25,7 +25,7 @@ axum-macros = "0.4.1"
 hyper-util = { version = "0.1.6", features = ["client-legacy"] }
 serde_json = "1.0.120"
 tower-http = { version = "0.5.2", features = ["trace", "timeout"] }
-uuid = { version = "1.10.0", features = ["v4", "std","v7"] }
+uuid = { version = "1.10.0", features = ["std","v7"] }
 redis = { version = "0.26.0", features = [
     "tokio-comp",
     "aio",

--- a/rust/serving/Cargo.toml
+++ b/rust/serving/Cargo.toml
@@ -25,7 +25,7 @@ axum-macros = "0.4.1"
 hyper-util = { version = "0.1.6", features = ["client-legacy"] }
 serde_json = "1.0.120"
 tower-http = { version = "0.5.2", features = ["trace", "timeout"] }
-uuid = { version = "1.10.0", features = ["v4"] }
+uuid = { version = "1.10.0", features = ["v4", "std","v7"] }
 redis = { version = "0.26.0", features = [
     "tokio-comp",
     "aio",
@@ -39,6 +39,7 @@ parking_lot = "0.12.3"
 prometheus-client = "0.22.3"
 thiserror = "1.0.63"
 reqwest = { workspace = true, features = ["rustls-tls", "json"] }
+http = "1.2.0"
 
 [dev-dependencies]
 reqwest = { workspace = true, features = ["json"] }

--- a/rust/serving/src/app.rs
+++ b/rust/serving/src/app.rs
@@ -19,7 +19,7 @@ use tracing::{info, info_span, Span};
 use uuid::Uuid;
 
 use self::{
-    callback::callback_handler, direct_proxy::direct_proxy, jetstream_proxy::serving_public_routes,
+    callback::callback_handler, direct_proxy::direct_proxy, jetstream_proxy::jetstream_proxy,
     message_path::get_message_path,
 };
 use crate::app::callback::store::Store;
@@ -251,7 +251,7 @@ async fn routes<T: Clone + Send + Sync + Store + 'static>(
     app_state: AppState<T>,
 ) -> crate::Result<Router> {
     let state = app_state.callback_state.clone();
-    let jetstream_proxy = serving_public_routes(app_state.clone()).await?;
+    let jetstream_proxy = jetstream_proxy(app_state.clone()).await?;
     let callback_router = callback_handler(
         app_state.settings.tid_header.clone(),
         app_state.callback_state.clone(),

--- a/rust/serving/src/app.rs
+++ b/rust/serving/src/app.rs
@@ -76,7 +76,6 @@ pub(crate) async fn router_with_auth<T>(app: AppState<T>) -> crate::Result<Route
 where
     T: Clone + Send + Sync + Store + 'static,
 {
-    let tid_header = app.settings.tid_header.clone();
     let layers = ServiceBuilder::new()
         // Add tracing to all requests
         .layer(
@@ -87,12 +86,8 @@ where
                         // We don't need request ID for these endpoints
                         return info_span!("request", method=?req.method(), path=req_path);
                     }
-                    let tid = req
-                        .headers()
-                        .get(&tid_header)
-                        .and_then(|v| v.to_str().ok())
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| Uuid::new_v4().to_string());
+                    let uuid = Uuid::now_v7().to_string();
+                    let tid = format!("{}{}{}", &uuid[..8], &uuid[10..13], &uuid[uuid.len() - 5..]);
 
                     let matched_path = req
                         .extensions()

--- a/rust/serving/src/app.rs
+++ b/rust/serving/src/app.rs
@@ -86,6 +86,10 @@ where
                         // We don't need request ID for these endpoints
                         return info_span!("request", method=?req.method(), path=req_path);
                     }
+
+                    // Generate a tid with good enough randomness and not too long
+                    // Example of a UUID v7: 01951b72-d0f4-711e-baba-4efe03d9cb76
+                    // We use the characters representing timestamp in milliseconds (without '-'), and last 5 characters for randomness.
                     let uuid = Uuid::now_v7().to_string();
                     let tid = format!("{}{}{}", &uuid[..8], &uuid[10..13], &uuid[uuid.len() - 5..]);
 

--- a/rust/serving/src/app.rs
+++ b/rust/serving/src/app.rs
@@ -19,7 +19,7 @@ use tracing::{info, info_span, Span};
 use uuid::Uuid;
 
 use self::{
-    callback::callback_handler, direct_proxy::direct_proxy, jetstream_proxy::jetstream_proxy,
+    callback::callback_handler, direct_proxy::direct_proxy, jetstream_proxy::serving_public_routes,
     message_path::get_message_path,
 };
 use crate::app::callback::store::Store;
@@ -256,7 +256,7 @@ async fn routes<T: Clone + Send + Sync + Store + 'static>(
     app_state: AppState<T>,
 ) -> crate::Result<Router> {
     let state = app_state.callback_state.clone();
-    let jetstream_proxy = jetstream_proxy(app_state.clone()).await?;
+    let jetstream_proxy = serving_public_routes(app_state.clone()).await?;
     let callback_router = callback_handler(
         app_state.settings.tid_header.clone(),
         app_state.callback_state.clone(),

--- a/rust/serving/src/app/callback.rs
+++ b/rust/serving/src/app/callback.rs
@@ -126,7 +126,7 @@ mod tests {
         let msg_graph = MessageGraph::from_pipeline(&pipeline_spec).unwrap();
         let mut state = CallbackState::new(msg_graph, store).await.unwrap();
 
-        let x = state.register("test_id".to_string());
+        let x = state.register("test_id".to_string()).await;
         // spawn a task which will be awaited later
         let handle = tokio::spawn(async move {
             let _ = x.await.unwrap();

--- a/rust/serving/src/app/callback.rs
+++ b/rust/serving/src/app/callback.rs
@@ -126,7 +126,7 @@ mod tests {
         let msg_graph = MessageGraph::from_pipeline(&pipeline_spec).unwrap();
         let mut state = CallbackState::new(msg_graph, store).await.unwrap();
 
-        let x = state.register("test_id".to_string()).await;
+        let (_, x) = state.register(Some("test_id".to_string())).await.unwrap();
         // spawn a task which will be awaited later
         let handle = tokio::spawn(async move {
             let _ = x.await.unwrap();

--- a/rust/serving/src/app/callback/state.rs
+++ b/rust/serving/src/app/callback/state.rs
@@ -5,7 +5,7 @@ use std::{
 
 use tokio::sync::oneshot;
 
-use super::store::{PipelineResult, Store};
+use super::store::{ProcessingStatus, Store};
 use crate::app::callback::store::Error as StoreError;
 use crate::app::callback::store::Result as StoreResult;
 use crate::app::callback::{store::PayloadToSave, Callback};
@@ -68,7 +68,10 @@ where
     }
 
     /// Retrieves the output of the numaflow pipeline
-    pub(crate) async fn retrieve_saved(&mut self, id: &str) -> Result<PipelineResult, StoreError> {
+    pub(crate) async fn retrieve_saved(
+        &mut self,
+        id: &str,
+    ) -> Result<ProcessingStatus, StoreError> {
         self.store.retrieve_datum(id).await.map_err(Into::into)
     }
 
@@ -273,7 +276,7 @@ mod tests {
         let saved = state.retrieve_saved(&id).await.unwrap();
         assert_eq!(
             saved,
-            PipelineResult::Completed(vec!["Test Message".as_bytes().to_vec()])
+            ProcessingStatus::Completed(vec!["Test Message".as_bytes().to_vec()])
         );
 
         // Test insert_callback_requests

--- a/rust/serving/src/app/callback/state.rs
+++ b/rust/serving/src/app/callback/state.rs
@@ -195,6 +195,8 @@ where
             ));
         };
 
+        self.store.deregister(id.to_string()).await.unwrap(); // FIXME:
+
         state
             .tx
             .send(Ok(id.to_string()))

--- a/rust/serving/src/app/callback/state.rs
+++ b/rust/serving/src/app/callback/state.rs
@@ -44,7 +44,8 @@ where
     }
 
     /// register a new connection
-    /// The oneshot receiver will be notified when all callbacks for this connection is received from the numaflow pipeline
+    /// The oneshot receiver will be notified when all callbacks for this connection is received from
+    /// the numaflow pipeline. 
     pub(crate) async fn register(
         &mut self,
         id: Option<String>,

--- a/rust/serving/src/app/callback/state.rs
+++ b/rust/serving/src/app/callback/state.rs
@@ -113,10 +113,9 @@ where
             let id = cbr.id.clone();
             {
                 let mut guard = self.callbacks.lock().expect("Getting lock on State");
-                let Some(req_state) = guard.get_mut(&id) else {
-                    tracing::debug!(id, "Request is not found in in-memory store");
-                    continue;
-                };
+                let req_state = guard.get_mut(&id).ok_or_else(|| {
+                    Error::SubGraphInvalidInput(format!("request id {id} doesn't exist in-memory"))
+                })?;
                 req_state.vtx_visited.push(cbr);
             }
 

--- a/rust/serving/src/app/callback/state.rs
+++ b/rust/serving/src/app/callback/state.rs
@@ -125,7 +125,8 @@ where
                             // if the sub graph is not generated, then we can continue
                             continue;
                         }
-                        _ => {
+                        err => {
+                            tracing::error!(?err, "Failed to generate subgraph");
                             // if there is an error, deregister with the error
                             self.deregister(&id).await?
                         }
@@ -221,6 +222,10 @@ where
     // Check if the store is ready
     pub(crate) async fn ready(&mut self) -> bool {
         self.store.ready().await
+    }
+
+    pub(crate) fn is_monovertex(&self) -> bool {
+        self.msg_graph_generator.is_monovertex()
     }
 }
 

--- a/rust/serving/src/app/callback/state.rs
+++ b/rust/serving/src/app/callback/state.rs
@@ -104,13 +104,11 @@ where
             let id = cbr.id.clone();
             {
                 let mut guard = self.callbacks.lock().expect("Getting lock on State");
-                guard
-                    .get_mut(&cbr.id)
-                    .ok_or(Error::IDNotFound(
-                        "Connection for the received callback is not present in the in-memory store",
-                    ))?
-                    .vtx_visited
-                    .push(cbr);
+                let Some(req_state) = guard.get_mut(&id) else {
+                    tracing::debug!(id, "Request is not found in in-memory store");
+                    continue;
+                };
+                req_state.vtx_visited.push(cbr);
             }
 
             // check if the sub graph can be generated
@@ -222,10 +220,6 @@ where
     // Check if the store is ready
     pub(crate) async fn ready(&mut self) -> bool {
         self.store.ready().await
-    }
-
-    pub(crate) fn is_monovertex(&self) -> bool {
-        self.msg_graph_generator.is_monovertex()
     }
 }
 

--- a/rust/serving/src/app/callback/state.rs
+++ b/rust/serving/src/app/callback/state.rs
@@ -5,7 +5,7 @@ use std::{
 
 use tokio::sync::oneshot;
 
-use super::store::Store;
+use super::store::{PipelineResult, Store};
 use crate::app::callback::{store::PayloadToSave, Callback};
 use crate::app::tracker::MessageGraph;
 use crate::Error;
@@ -65,7 +65,7 @@ where
     }
 
     /// Retrieves the output of the numaflow pipeline
-    pub(crate) async fn retrieve_saved(&mut self, id: &str) -> Result<Vec<Vec<u8>>, Error> {
+    pub(crate) async fn retrieve_saved(&mut self, id: &str) -> Result<PipelineResult, Error> {
         self.store.retrieve_datum(id).await
     }
 
@@ -269,7 +269,10 @@ mod tests {
 
         // Test retrieve_saved
         let saved = state.retrieve_saved(&id).await.unwrap();
-        assert_eq!(saved, vec!["Test Message".as_bytes()]);
+        assert_eq!(
+            saved,
+            PipelineResult::Completed(vec!["Test Message".as_bytes().to_vec()])
+        );
 
         // Test insert_callback_requests
         let cbs = vec![

--- a/rust/serving/src/app/callback/state.rs
+++ b/rust/serving/src/app/callback/state.rs
@@ -50,7 +50,7 @@ where
     ) -> StoreResult<(String, oneshot::Receiver<Result<String, Error>>)> {
         // TODO: add an entry in Redis to note that the entry has been registered
 
-        let id = self.store.register(id).await?; // FIXME:
+        let id = self.store.register(id).await?;
 
         let (tx, rx) = oneshot::channel();
         {
@@ -197,7 +197,7 @@ where
             ));
         };
 
-        self.store.deregister(id.to_string()).await.unwrap(); // FIXME:
+        self.store.done(id.to_string()).await?;
 
         state
             .tx

--- a/rust/serving/src/app/callback/state.rs
+++ b/rust/serving/src/app/callback/state.rs
@@ -6,6 +6,7 @@ use std::{
 use tokio::sync::oneshot;
 
 use super::store::{PipelineResult, Store};
+use crate::app::callback::store::Error as StoreError;
 use crate::app::callback::store::Result as StoreResult;
 use crate::app::callback::{store::PayloadToSave, Callback};
 use crate::app::tracker::MessageGraph;
@@ -67,7 +68,7 @@ where
     }
 
     /// Retrieves the output of the numaflow pipeline
-    pub(crate) async fn retrieve_saved(&mut self, id: &str) -> Result<PipelineResult, Error> {
+    pub(crate) async fn retrieve_saved(&mut self, id: &str) -> Result<PipelineResult, StoreError> {
         self.store.retrieve_datum(id).await.map_err(Into::into)
     }
 

--- a/rust/serving/src/app/callback/state.rs
+++ b/rust/serving/src/app/callback/state.rs
@@ -45,7 +45,7 @@ where
 
     /// register a new connection
     /// The oneshot receiver will be notified when all callbacks for this connection is received from
-    /// the numaflow pipeline. 
+    /// the numaflow pipeline.
     pub(crate) async fn register(
         &mut self,
         id: Option<String>,

--- a/rust/serving/src/app/callback/store.rs
+++ b/rust/serving/src/app/callback/store.rs
@@ -17,6 +17,12 @@ pub(crate) enum PayloadToSave {
     },
 }
 
+#[derive(Debug, PartialEq)]
+pub(crate) enum PipelineResult {
+    Processing,
+    Completed(Vec<Vec<u8>>),
+}
+
 /// Store trait to store the callback information.
 #[trait_variant::make(Store: Send)]
 #[allow(dead_code)]
@@ -26,6 +32,6 @@ pub(crate) trait LocalStore {
     async fn save(&mut self, messages: Vec<PayloadToSave>) -> crate::Result<()>;
     /// retrieve the callback payloads
     async fn retrieve_callbacks(&mut self, id: &str) -> Result<Vec<Arc<Callback>>, crate::Error>;
-    async fn retrieve_datum(&mut self, id: &str) -> Result<Vec<Vec<u8>>, crate::Error>;
+    async fn retrieve_datum(&mut self, id: &str) -> Result<PipelineResult, crate::Error>;
     async fn ready(&mut self) -> bool;
 }

--- a/rust/serving/src/app/callback/store.rs
+++ b/rust/serving/src/app/callback/store.rs
@@ -27,16 +27,16 @@ pub(crate) enum PipelineResult {
 
 #[derive(Error, Debug, Clone)]
 pub(crate) enum Error {
-    #[error("Connecting to store: {0}")]
+    #[error("Connecting to the store: {0}")]
     Connection(String),
 
     #[error("Request id {0} already exists in the store")]
     DuplicateRequest(String),
 
-    #[error("Reading from store: {0}")]
+    #[error("Reading from the store: {0}")]
     StoreRead(String),
 
-    #[error("Writing payload to store: {0}")]
+    #[error("Writing payload to the store: {0}")]
     StoreWrite(String),
 }
 

--- a/rust/serving/src/app/callback/store.rs
+++ b/rust/serving/src/app/callback/store.rs
@@ -27,7 +27,10 @@ pub(crate) enum PipelineResult {
 #[trait_variant::make(Store: Send)]
 #[allow(dead_code)]
 pub(crate) trait LocalStore {
-    async fn register(&mut self, id: String) -> crate::Result<()>;
+    /// Register a request id in the store. If user provides a request id, the same will be returned
+    /// if the same doesn't already exist in the store. An error is returned if the user-specified request id
+    /// already exists in the store. If the `id` is `None`, the store will generate a new unique request id.
+    async fn register(&mut self, id: Option<String>) -> crate::Result<String>;
     async fn deregister(&mut self, id: String) -> crate::Result<()>;
     async fn save(&mut self, messages: Vec<PayloadToSave>) -> crate::Result<()>;
     /// retrieve the callback payloads

--- a/rust/serving/src/app/callback/store.rs
+++ b/rust/serving/src/app/callback/store.rs
@@ -20,8 +20,9 @@ pub(crate) enum PayloadToSave {
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum PipelineResult {
-    Processing,
+/// Represents the current processing status of a request id in the `Store`.
+pub(crate) enum ProcessingStatus {
+    InProgress,
     Completed(Vec<Vec<u8>>),
 }
 
@@ -64,6 +65,6 @@ pub(crate) trait LocalStore {
     async fn save(&mut self, messages: Vec<PayloadToSave>) -> Result<()>;
     /// retrieve the callback payloads
     async fn retrieve_callbacks(&mut self, id: &str) -> Result<Vec<Arc<Callback>>>;
-    async fn retrieve_datum(&mut self, id: &str) -> Result<PipelineResult>;
+    async fn retrieve_datum(&mut self, id: &str) -> Result<ProcessingStatus>;
     async fn ready(&mut self) -> bool;
 }

--- a/rust/serving/src/app/callback/store.rs
+++ b/rust/serving/src/app/callback/store.rs
@@ -30,6 +30,9 @@ pub(crate) enum Error {
     #[error("Connecting to the store: {0}")]
     Connection(String),
 
+    #[error("Request id {0} doesn't exist in store")]
+    InvalidRequestId(String),
+
     #[error("Request id {0} already exists in the store")]
     DuplicateRequest(String),
 

--- a/rust/serving/src/app/callback/store.rs
+++ b/rust/serving/src/app/callback/store.rs
@@ -21,6 +21,7 @@ pub(crate) enum PayloadToSave {
 #[trait_variant::make(Store: Send)]
 #[allow(dead_code)]
 pub(crate) trait LocalStore {
+    async fn register(&mut self, id: String) -> crate::Result<()>;
     async fn save(&mut self, messages: Vec<PayloadToSave>) -> crate::Result<()>;
     /// retrieve the callback payloads
     async fn retrieve_callbacks(&mut self, id: &str) -> Result<Vec<Arc<Callback>>, crate::Error>;

--- a/rust/serving/src/app/callback/store.rs
+++ b/rust/serving/src/app/callback/store.rs
@@ -55,11 +55,12 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 #[trait_variant::make(Store: Send)]
 #[allow(dead_code)]
 pub(crate) trait LocalStore {
-    /// Register a request id in the store. If user provides a request id, the same will be returned
-    /// if the same doesn't already exist in the store. An error is returned if the user-specified request id
-    /// already exists in the store. If the `id` is `None`, the store will generate a new unique request id.
+    /// Register a request id in the store. If user provides a request id, the same should be returned
+    /// if it doesn't already exist in the store. An error should be returned if the user-specified request id
+    /// already exists in the store. If the `id` is `None`, the store should generate a new unique request id.
     async fn register(&mut self, id: Option<String>) -> Result<String>;
-    async fn deregister(&mut self, id: String) -> Result<()>;
+    /// This method will be called when processing is completed for a request id.
+    async fn done(&mut self, id: String) -> Result<()>;
     async fn save(&mut self, messages: Vec<PayloadToSave>) -> Result<()>;
     /// retrieve the callback payloads
     async fn retrieve_callbacks(&mut self, id: &str) -> Result<Vec<Arc<Callback>>>;

--- a/rust/serving/src/app/callback/store.rs
+++ b/rust/serving/src/app/callback/store.rs
@@ -22,6 +22,7 @@ pub(crate) enum PayloadToSave {
 #[allow(dead_code)]
 pub(crate) trait LocalStore {
     async fn register(&mut self, id: String) -> crate::Result<()>;
+    async fn deregister(&mut self, id: String) -> crate::Result<()>;
     async fn save(&mut self, messages: Vec<PayloadToSave>) -> crate::Result<()>;
     /// retrieve the callback payloads
     async fn retrieve_callbacks(&mut self, id: &str) -> Result<Vec<Arc<Callback>>, crate::Error>;

--- a/rust/serving/src/app/callback/store/memstore.rs
+++ b/rust/serving/src/app/callback/store/memstore.rs
@@ -25,8 +25,8 @@ impl InMemoryStore {
 }
 
 impl super::Store for InMemoryStore {
-    async fn register(&mut self, _id: String) -> crate::Result<()> {
-        Ok(())
+    async fn register(&mut self, _id: Option<String>) -> crate::Result<String> {
+        Ok("".into())
     }
     async fn deregister(&mut self, _id: String) -> crate::Result<()> {
         Ok(())

--- a/rust/serving/src/app/callback/store/memstore.rs
+++ b/rust/serving/src/app/callback/store/memstore.rs
@@ -28,6 +28,9 @@ impl super::Store for InMemoryStore {
     async fn register(&mut self, _id: String) -> crate::Result<()> {
         Ok(())
     }
+    async fn deregister(&mut self, _id: String) -> crate::Result<()> {
+        Ok(())
+    }
     /// Saves a vector of `PayloadToSave` into the `HashMap`.
     /// Each `PayloadToSave` is serialized into bytes and stored in the `HashMap` under its key.
     async fn save(&mut self, messages: Vec<PayloadToSave>) -> crate::Result<()> {

--- a/rust/serving/src/app/callback/store/memstore.rs
+++ b/rust/serving/src/app/callback/store/memstore.rs
@@ -94,7 +94,7 @@ impl super::Store for InMemoryStore {
         let data = self.data.lock().unwrap();
         match data.get(&id) {
             Some(result) => Ok(PipelineResult::Completed(result.to_vec())),
-            None => Err(StoreError::StoreRead(format!(
+            None => Err(StoreError::InvalidRequestId(format!(
                 "No entry found for id: {}",
                 id
             ))),

--- a/rust/serving/src/app/callback/store/memstore.rs
+++ b/rust/serving/src/app/callback/store/memstore.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use uuid::Uuid;
+
 use super::{Error as StoreError, Result as StoreResult};
 use super::{PayloadToSave, PipelineResult};
 use crate::app::callback::Callback;
@@ -25,8 +27,8 @@ impl InMemoryStore {
 }
 
 impl super::Store for InMemoryStore {
-    async fn register(&mut self, _id: Option<String>) -> StoreResult<String> {
-        Ok("".into())
+    async fn register(&mut self, id: Option<String>) -> StoreResult<String> {
+        Ok(id.unwrap_or_else(|| Uuid::now_v7().to_string()))
     }
     async fn deregister(&mut self, _id: String) -> StoreResult<()> {
         Ok(())

--- a/rust/serving/src/app/callback/store/memstore.rs
+++ b/rust/serving/src/app/callback/store/memstore.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use super::PayloadToSave;
 use crate::app::callback::Callback;
-use crate::consts::SAVED;
 use crate::Error;
 
 /// `InMemoryStore` is an in-memory implementation of the `Store` trait.
@@ -26,6 +25,9 @@ impl InMemoryStore {
 }
 
 impl super::Store for InMemoryStore {
+    async fn register(&mut self, _id: String) -> crate::Result<()> {
+        Ok(())
+    }
     /// Saves a vector of `PayloadToSave` into the `HashMap`.
     /// Each `PayloadToSave` is serialized into bytes and stored in the `HashMap` under its key.
     async fn save(&mut self, messages: Vec<PayloadToSave>) -> crate::Result<()> {
@@ -44,7 +46,7 @@ impl super::Store for InMemoryStore {
                     if key.is_empty() {
                         return Err(Error::StoreWrite("Key cannot be empty".to_string()));
                     }
-                    data.entry(format!("{}_{}", key, SAVED))
+                    data.entry(format!("{}_{}", key, "saved"))
                         .or_default()
                         .push(value.into());
                 }
@@ -79,7 +81,7 @@ impl super::Store for InMemoryStore {
     /// Retrieves data for a given id from the `HashMap`.
     /// Each piece of data is deserialized from bytes into a `String`.
     async fn retrieve_datum(&mut self, id: &str) -> Result<Vec<Vec<u8>>, Error> {
-        let id = format!("{}_{}", id, SAVED);
+        let id = format!("{}_{}", id, "saved");
         let data = self.data.lock().unwrap();
         match data.get(&id) {
             Some(result) => Ok(result.to_vec()),

--- a/rust/serving/src/app/callback/store/memstore.rs
+++ b/rust/serving/src/app/callback/store/memstore.rs
@@ -30,7 +30,7 @@ impl super::Store for InMemoryStore {
     async fn register(&mut self, id: Option<String>) -> StoreResult<String> {
         Ok(id.unwrap_or_else(|| Uuid::now_v7().to_string()))
     }
-    async fn deregister(&mut self, _id: String) -> StoreResult<()> {
+    async fn done(&mut self, _id: String) -> StoreResult<()> {
         Ok(())
     }
     /// Saves a vector of `PayloadToSave` into the `HashMap`.

--- a/rust/serving/src/app/callback/store/redisstore.rs
+++ b/rust/serving/src/app/callback/store/redisstore.rs
@@ -164,7 +164,7 @@ impl super::Store for RedisConnection {
             }
         }
     }
-    async fn deregister(&mut self, id: String) -> StoreResult<()> {
+    async fn done(&mut self, id: String) -> StoreResult<()> {
         let key = format!("request:{id}:status");
         let status: bool = redis::cmd("SET")
             .arg(&key)
@@ -365,7 +365,7 @@ mod tests {
 
         assert_eq!(datums.unwrap(), PipelineResult::Processing);
 
-        redis_conn.deregister(key.clone()).await.unwrap();
+        redis_conn.done(key.clone()).await.unwrap();
         let datums = redis_conn.retrieve_datum(&key).await.unwrap();
         let PipelineResult::Completed(datums) = datums else {
             panic!("Expected completed results");

--- a/rust/serving/src/app/callback/store/redisstore.rs
+++ b/rust/serving/src/app/callback/store/redisstore.rs
@@ -113,7 +113,17 @@ impl super::Store for RedisConnection {
         self.conn_manager
             .set_nx(format!("request:{id}:status"), "processing")
             .await
-            .map_err(|e| Error::StoreWrite(format!("Registering request_id in Redis: {e:?}")))
+            .map_err(|e| Error::StoreWrite(format!("Registering request_id={id} in Redis: {e:?}")))
+    }
+    async fn deregister(&mut self, id: String) -> crate::Result<()> {
+        self.conn_manager
+            .set(format!("request:{id}:status"), "completed")
+            .await
+            .map_err(|e| {
+                Error::StoreWrite(format!(
+                    "Setting processing status as completed in Redis for request_id={id}: {e:?}"
+                ))
+            })
     }
     // Attempt to save all payloads. Returns error if we fail to save at least one message.
     async fn save(&mut self, messages: Vec<PayloadToSave>) -> crate::Result<()> {

--- a/rust/serving/src/app/callback/store/redisstore.rs
+++ b/rust/serving/src/app/callback/store/redisstore.rs
@@ -158,9 +158,9 @@ impl super::Store for RedisConnection {
                     }
                     return Ok(id);
                 }
-                Err(StoreError::StoreWrite(format!(
-                    "Could not generate a unique request id"
-                )))
+                Err(StoreError::StoreWrite(
+                    "Could not generate a unique request id".to_string(),
+                ))
             }
         }
     }

--- a/rust/serving/src/app/callback/store/redisstore.rs
+++ b/rust/serving/src/app/callback/store/redisstore.rs
@@ -136,7 +136,8 @@ impl super::Store for RedisConnection {
                 Ok(id)
             }
             None => {
-                // We use UUID v7 as the request id. Attempt for a maxium of 5 times to generate an id that doesn't currently exist in the Store.
+                // We use UUID v7 as the request id. Attempt for a maxium of 5 times to generate an 
+                // id that doesn't currently exist in the Store.
                 for _ in 0..5 {
                     let id = Uuid::now_v7().to_string();
                     let mut pipe = redis::pipe();

--- a/rust/serving/src/app/callback/store/redisstore.rs
+++ b/rust/serving/src/app/callback/store/redisstore.rs
@@ -136,7 +136,7 @@ impl super::Store for RedisConnection {
                 Ok(id)
             }
             None => {
-                // We use UUID v7 as the request id. Attempt for a maxium of 5 times to generate an 
+                // We use UUID v7 as the request id. Attempt for a maxium of 5 times to generate an
                 // id that doesn't currently exist in the Store.
                 for _ in 0..5 {
                     let id = Uuid::now_v7().to_string();

--- a/rust/serving/src/app/jetstream_proxy.rs
+++ b/rust/serving/src/app/jetstream_proxy.rs
@@ -16,6 +16,7 @@ use super::{
     callback::store::{PipelineResult, Store},
     AppState,
 };
+use crate::app::callback::store::Error as StoreError;
 use crate::app::response::{ApiError, ServeResponse};
 use crate::{app::callback::state, Message, MessageWrapper};
 
@@ -132,6 +133,11 @@ async fn sync_publish<T: Send + Sync + Clone + Store>(
         Ok(result) => result,
         Err(e) => {
             error!(error = ?e, "Registering request in data store");
+            if let StoreError::DuplicateRequest(id) = e {
+                return Err(ApiError::Conflict(format!(
+                    "Specified request id {id} already exists in the store"
+                )));
+            }
             return Err(ApiError::InternalServerError(
                 "Failed to register message".to_string(),
             ));
@@ -237,6 +243,11 @@ async fn async_publish<T: Send + Sync + Clone + Store>(
         Ok(result) => result,
         Err(e) => {
             error!(error = ?e, "Registering request in data store");
+            if let StoreError::DuplicateRequest(id) = e {
+                return Err(ApiError::Conflict(format!(
+                    "Specified request id {id} already exists in the store"
+                )));
+            }
             return Err(ApiError::InternalServerError(
                 "Failed to register message".to_string(),
             ));
@@ -293,11 +304,12 @@ mod tests {
     use crate::app::callback::state::State as CallbackState;
     use crate::app::callback::store::memstore::InMemoryStore;
     use crate::app::callback::store::PayloadToSave;
+    use crate::app::callback::store::Result as StoreResult;
     use crate::app::tracker::MessageGraph;
     use crate::callback::{Callback, Response};
     use crate::config::DEFAULT_ID_HEADER;
     use crate::pipeline::PipelineDCG;
-    use crate::{Error, Settings};
+    use crate::Settings;
 
     const PIPELINE_SPEC_ENCODED: &str = "eyJ2ZXJ0aWNlcyI6W3sibmFtZSI6ImluIiwic291cmNlIjp7InNlcnZpbmciOnsiYXV0aCI6bnVsbCwic2VydmljZSI6dHJ1ZSwibXNnSURIZWFkZXJLZXkiOiJYLU51bWFmbG93LUlkIiwic3RvcmUiOnsidXJsIjoicmVkaXM6Ly9yZWRpczo2Mzc5In19fSwiY29udGFpbmVyVGVtcGxhdGUiOnsicmVzb3VyY2VzIjp7fSwiaW1hZ2VQdWxsUG9saWN5IjoiTmV2ZXIiLCJlbnYiOlt7Im5hbWUiOiJSVVNUX0xPRyIsInZhbHVlIjoiZGVidWcifV19LCJzY2FsZSI6eyJtaW4iOjF9LCJ1cGRhdGVTdHJhdGVneSI6eyJ0eXBlIjoiUm9sbGluZ1VwZGF0ZSIsInJvbGxpbmdVcGRhdGUiOnsibWF4VW5hdmFpbGFibGUiOiIyNSUifX19LHsibmFtZSI6InBsYW5uZXIiLCJ1ZGYiOnsiY29udGFpbmVyIjp7ImltYWdlIjoiYXNjaWk6MC4xIiwiYXJncyI6WyJwbGFubmVyIl0sInJlc291cmNlcyI6e30sImltYWdlUHVsbFBvbGljeSI6Ik5ldmVyIn0sImJ1aWx0aW4iOm51bGwsImdyb3VwQnkiOm51bGx9LCJjb250YWluZXJUZW1wbGF0ZSI6eyJyZXNvdXJjZXMiOnt9LCJpbWFnZVB1bGxQb2xpY3kiOiJOZXZlciJ9LCJzY2FsZSI6eyJtaW4iOjF9LCJ1cGRhdGVTdHJhdGVneSI6eyJ0eXBlIjoiUm9sbGluZ1VwZGF0ZSIsInJvbGxpbmdVcGRhdGUiOnsibWF4VW5hdmFpbGFibGUiOiIyNSUifX19LHsibmFtZSI6InRpZ2VyIiwidWRmIjp7ImNvbnRhaW5lciI6eyJpbWFnZSI6ImFzY2lpOjAuMSIsImFyZ3MiOlsidGlnZXIiXSwicmVzb3VyY2VzIjp7fSwiaW1hZ2VQdWxsUG9saWN5IjoiTmV2ZXIifSwiYnVpbHRpbiI6bnVsbCwiZ3JvdXBCeSI6bnVsbH0sImNvbnRhaW5lclRlbXBsYXRlIjp7InJlc291cmNlcyI6e30sImltYWdlUHVsbFBvbGljeSI6Ik5ldmVyIn0sInNjYWxlIjp7Im1pbiI6MX0sInVwZGF0ZVN0cmF0ZWd5Ijp7InR5cGUiOiJSb2xsaW5nVXBkYXRlIiwicm9sbGluZ1VwZGF0ZSI6eyJtYXhVbmF2YWlsYWJsZSI6IjI1JSJ9fX0seyJuYW1lIjoiZG9nIiwidWRmIjp7ImNvbnRhaW5lciI6eyJpbWFnZSI6ImFzY2lpOjAuMSIsImFyZ3MiOlsiZG9nIl0sInJlc291cmNlcyI6e30sImltYWdlUHVsbFBvbGljeSI6Ik5ldmVyIn0sImJ1aWx0aW4iOm51bGwsImdyb3VwQnkiOm51bGx9LCJjb250YWluZXJUZW1wbGF0ZSI6eyJyZXNvdXJjZXMiOnt9LCJpbWFnZVB1bGxQb2xpY3kiOiJOZXZlciJ9LCJzY2FsZSI6eyJtaW4iOjF9LCJ1cGRhdGVTdHJhdGVneSI6eyJ0eXBlIjoiUm9sbGluZ1VwZGF0ZSIsInJvbGxpbmdVcGRhdGUiOnsibWF4VW5hdmFpbGFibGUiOiIyNSUifX19LHsibmFtZSI6ImVsZXBoYW50IiwidWRmIjp7ImNvbnRhaW5lciI6eyJpbWFnZSI6ImFzY2lpOjAuMSIsImFyZ3MiOlsiZWxlcGhhbnQiXSwicmVzb3VyY2VzIjp7fSwiaW1hZ2VQdWxsUG9saWN5IjoiTmV2ZXIifSwiYnVpbHRpbiI6bnVsbCwiZ3JvdXBCeSI6bnVsbH0sImNvbnRhaW5lclRlbXBsYXRlIjp7InJlc291cmNlcyI6e30sImltYWdlUHVsbFBvbGljeSI6Ik5ldmVyIn0sInNjYWxlIjp7Im1pbiI6MX0sInVwZGF0ZVN0cmF0ZWd5Ijp7InR5cGUiOiJSb2xsaW5nVXBkYXRlIiwicm9sbGluZ1VwZGF0ZSI6eyJtYXhVbmF2YWlsYWJsZSI6IjI1JSJ9fX0seyJuYW1lIjoiYXNjaWlhcnQiLCJ1ZGYiOnsiY29udGFpbmVyIjp7ImltYWdlIjoiYXNjaWk6MC4xIiwiYXJncyI6WyJhc2NpaWFydCJdLCJyZXNvdXJjZXMiOnt9LCJpbWFnZVB1bGxQb2xpY3kiOiJOZXZlciJ9LCJidWlsdGluIjpudWxsLCJncm91cEJ5IjpudWxsfSwiY29udGFpbmVyVGVtcGxhdGUiOnsicmVzb3VyY2VzIjp7fSwiaW1hZ2VQdWxsUG9saWN5IjoiTmV2ZXIifSwic2NhbGUiOnsibWluIjoxfSwidXBkYXRlU3RyYXRlZ3kiOnsidHlwZSI6IlJvbGxpbmdVcGRhdGUiLCJyb2xsaW5nVXBkYXRlIjp7Im1heFVuYXZhaWxhYmxlIjoiMjUlIn19fSx7Im5hbWUiOiJzZXJ2ZS1zaW5rIiwic2luayI6eyJ1ZHNpbmsiOnsiY29udGFpbmVyIjp7ImltYWdlIjoic2VydmVzaW5rOjAuMSIsImVudiI6W3sibmFtZSI6Ik5VTUFGTE9XX0NBTExCQUNLX1VSTF9LRVkiLCJ2YWx1ZSI6IlgtTnVtYWZsb3ctQ2FsbGJhY2stVXJsIn0seyJuYW1lIjoiTlVNQUZMT1dfTVNHX0lEX0hFQURFUl9LRVkiLCJ2YWx1ZSI6IlgtTnVtYWZsb3ctSWQifV0sInJlc291cmNlcyI6e30sImltYWdlUHVsbFBvbGljeSI6Ik5ldmVyIn19LCJyZXRyeVN0cmF0ZWd5Ijp7fX0sImNvbnRhaW5lclRlbXBsYXRlIjp7InJlc291cmNlcyI6e30sImltYWdlUHVsbFBvbGljeSI6Ik5ldmVyIn0sInNjYWxlIjp7Im1pbiI6MX0sInVwZGF0ZVN0cmF0ZWd5Ijp7InR5cGUiOiJSb2xsaW5nVXBkYXRlIiwicm9sbGluZ1VwZGF0ZSI6eyJtYXhVbmF2YWlsYWJsZSI6IjI1JSJ9fX0seyJuYW1lIjoiZXJyb3Itc2luayIsInNpbmsiOnsidWRzaW5rIjp7ImNvbnRhaW5lciI6eyJpbWFnZSI6InNlcnZlc2luazowLjEiLCJlbnYiOlt7Im5hbWUiOiJOVU1BRkxPV19DQUxMQkFDS19VUkxfS0VZIiwidmFsdWUiOiJYLU51bWFmbG93LUNhbGxiYWNrLVVybCJ9LHsibmFtZSI6Ik5VTUFGTE9XX01TR19JRF9IRUFERVJfS0VZIiwidmFsdWUiOiJYLU51bWFmbG93LUlkIn1dLCJyZXNvdXJjZXMiOnt9LCJpbWFnZVB1bGxQb2xpY3kiOiJOZXZlciJ9fSwicmV0cnlTdHJhdGVneSI6e319LCJjb250YWluZXJUZW1wbGF0ZSI6eyJyZXNvdXJjZXMiOnt9LCJpbWFnZVB1bGxQb2xpY3kiOiJOZXZlciJ9LCJzY2FsZSI6eyJtaW4iOjF9LCJ1cGRhdGVTdHJhdGVneSI6eyJ0eXBlIjoiUm9sbGluZ1VwZGF0ZSIsInJvbGxpbmdVcGRhdGUiOnsibWF4VW5hdmFpbGFibGUiOiIyNSUifX19XSwiZWRnZXMiOlt7ImZyb20iOiJpbiIsInRvIjoicGxhbm5lciIsImNvbmRpdGlvbnMiOm51bGx9LHsiZnJvbSI6InBsYW5uZXIiLCJ0byI6ImFzY2lpYXJ0IiwiY29uZGl0aW9ucyI6eyJ0YWdzIjp7Im9wZXJhdG9yIjoib3IiLCJ2YWx1ZXMiOlsiYXNjaWlhcnQiXX19fSx7ImZyb20iOiJwbGFubmVyIiwidG8iOiJ0aWdlciIsImNvbmRpdGlvbnMiOnsidGFncyI6eyJvcGVyYXRvciI6Im9yIiwidmFsdWVzIjpbInRpZ2VyIl19fX0seyJmcm9tIjoicGxhbm5lciIsInRvIjoiZG9nIiwiY29uZGl0aW9ucyI6eyJ0YWdzIjp7Im9wZXJhdG9yIjoib3IiLCJ2YWx1ZXMiOlsiZG9nIl19fX0seyJmcm9tIjoicGxhbm5lciIsInRvIjoiZWxlcGhhbnQiLCJjb25kaXRpb25zIjp7InRhZ3MiOnsib3BlcmF0b3IiOiJvciIsInZhbHVlcyI6WyJlbGVwaGFudCJdfX19LHsiZnJvbSI6InRpZ2VyIiwidG8iOiJzZXJ2ZS1zaW5rIiwiY29uZGl0aW9ucyI6bnVsbH0seyJmcm9tIjoiZG9nIiwidG8iOiJzZXJ2ZS1zaW5rIiwiY29uZGl0aW9ucyI6bnVsbH0seyJmcm9tIjoiZWxlcGhhbnQiLCJ0byI6InNlcnZlLXNpbmsiLCJjb25kaXRpb25zIjpudWxsfSx7ImZyb20iOiJhc2NpaWFydCIsInRvIjoic2VydmUtc2luayIsImNvbmRpdGlvbnMiOm51bGx9LHsiZnJvbSI6InBsYW5uZXIiLCJ0byI6ImVycm9yLXNpbmsiLCJjb25kaXRpb25zIjp7InRhZ3MiOnsib3BlcmF0b3IiOiJvciIsInZhbHVlcyI6WyJlcnJvciJdfX19XSwibGlmZWN5Y2xlIjp7fSwid2F0ZXJtYXJrIjp7fX0=";
 
@@ -305,19 +317,19 @@ mod tests {
     struct MockStore;
 
     impl Store for MockStore {
-        async fn register(&mut self, _id: Option<String>) -> crate::Result<String> {
+        async fn register(&mut self, _id: Option<String>) -> StoreResult<String> {
             Ok("".into())
         }
-        async fn deregister(&mut self, _id: String) -> crate::Result<()> {
+        async fn deregister(&mut self, _id: String) -> StoreResult<()> {
             Ok(())
         }
-        async fn save(&mut self, _messages: Vec<PayloadToSave>) -> crate::Result<()> {
+        async fn save(&mut self, _messages: Vec<PayloadToSave>) -> StoreResult<()> {
             Ok(())
         }
-        async fn retrieve_callbacks(&mut self, _id: &str) -> Result<Vec<Arc<Callback>>, Error> {
+        async fn retrieve_callbacks(&mut self, _id: &str) -> StoreResult<Vec<Arc<Callback>>> {
             Ok(vec![])
         }
-        async fn retrieve_datum(&mut self, _id: &str) -> Result<PipelineResult, Error> {
+        async fn retrieve_datum(&mut self, _id: &str) -> StoreResult<PipelineResult> {
             Ok(PipelineResult::Completed(vec![]))
         }
         async fn ready(&mut self) -> bool {

--- a/rust/serving/src/app/jetstream_proxy.rs
+++ b/rust/serving/src/app/jetstream_proxy.rs
@@ -321,7 +321,7 @@ mod tests {
         async fn register(&mut self, id: Option<String>) -> StoreResult<String> {
             Ok(id.unwrap_or_else(|| Uuid::now_v7().to_string()))
         }
-        async fn deregister(&mut self, _id: String) -> StoreResult<()> {
+        async fn done(&mut self, _id: String) -> StoreResult<()> {
             Ok(())
         }
         async fn save(&mut self, _messages: Vec<PayloadToSave>) -> StoreResult<()> {

--- a/rust/serving/src/app/jetstream_proxy.rs
+++ b/rust/serving/src/app/jetstream_proxy.rs
@@ -66,7 +66,7 @@ async fn sync_publish_serve<T: Send + Sync + Clone + Store>(
     let id = extract_id_from_headers(&proxy_state.tid_header, &headers);
 
     // Register the ID in the callback proxy state
-    let notify = proxy_state.callback.clone().register(id.clone());
+    let notify = proxy_state.callback.clone().register(id.clone()).await;
 
     let mut msg_headers: HashMap<String, String> = HashMap::new();
     for (key, value) in headers.iter() {
@@ -168,7 +168,7 @@ async fn sync_publish<T: Send + Sync + Clone + Store>(
     };
 
     // Register the ID in the callback proxy state
-    let notify = proxy_state.callback.clone().register(id.clone());
+    let notify = proxy_state.callback.clone().register(id.clone()).await;
     proxy_state.message.send(message).await.unwrap(); // FIXME:
 
     if let Err(e) = rx.await {
@@ -279,6 +279,9 @@ mod tests {
     struct MockStore;
 
     impl Store for MockStore {
+        async fn register(&mut self, _id: String) -> crate::Result<()> {
+            Ok(())
+        }
         async fn save(&mut self, _messages: Vec<PayloadToSave>) -> crate::Result<()> {
             Ok(())
         }

--- a/rust/serving/src/app/jetstream_proxy.rs
+++ b/rust/serving/src/app/jetstream_proxy.rs
@@ -46,7 +46,7 @@ struct ProxyState<T> {
     callback: state::State<T>,
 }
 
-pub(crate) async fn serving_public_routes<T: Clone + Send + Sync + Store + 'static>(
+pub(crate) async fn jetstream_proxy<T: Clone + Send + Sync + Store + 'static>(
     state: AppState<T>,
 ) -> crate::Result<Router> {
     let proxy_state = Arc::new(ProxyState {
@@ -229,7 +229,7 @@ async fn async_publish<T: Send + Sync + Clone + Store>(
     let mut msg_headers: HashMap<String, String> = HashMap::new();
     for (key, value) in headers.iter() {
         // Exclude request ID
-        if key.as_str() == &proxy_state.tid_header {
+        if key.as_str() == proxy_state.tid_header {
             continue;
         }
         msg_headers.insert(
@@ -368,7 +368,7 @@ mod tests {
             callback_state,
         };
 
-        let app = serving_public_routes(app_state).await?;
+        let app = jetstream_proxy(app_state).await?;
         let res = Request::builder()
             .method("POST")
             .uri("/async")
@@ -460,7 +460,7 @@ mod tests {
             callback_state: callback_state.clone(),
         };
 
-        let app = serving_public_routes(app_state).await.unwrap();
+        let app = jetstream_proxy(app_state).await.unwrap();
 
         tokio::spawn(async move {
             let mut retries = 0;
@@ -532,7 +532,7 @@ mod tests {
             callback_state: callback_state.clone(),
         };
 
-        let app = serving_public_routes(app_state).await.unwrap();
+        let app = jetstream_proxy(app_state).await.unwrap();
 
         // pipeline is in -> cat -> out, so we will have 3 callback requests
 

--- a/rust/serving/src/app/jetstream_proxy.rs
+++ b/rust/serving/src/app/jetstream_proxy.rs
@@ -209,6 +209,10 @@ async fn async_publish<T: Send + Sync + Clone + Store>(
     let id = extract_id_from_headers(&proxy_state.tid_header, &headers);
     let mut msg_headers: HashMap<String, String> = HashMap::new();
     for (key, value) in headers.iter() {
+        // Exclude request ID
+        if key.as_str() == &proxy_state.tid_header {
+            continue;
+        }
         msg_headers.insert(
             key.to_string(),
             String::from_utf8_lossy(value.as_bytes()).to_string(),

--- a/rust/serving/src/app/jetstream_proxy.rs
+++ b/rust/serving/src/app/jetstream_proxy.rs
@@ -282,6 +282,9 @@ mod tests {
         async fn register(&mut self, _id: String) -> crate::Result<()> {
             Ok(())
         }
+        async fn deregister(&mut self, _id: String) -> crate::Result<()> {
+            Ok(())
+        }
         async fn save(&mut self, _messages: Vec<PayloadToSave>) -> crate::Result<()> {
             Ok(())
         }

--- a/rust/serving/src/app/jetstream_proxy.rs
+++ b/rust/serving/src/app/jetstream_proxy.rs
@@ -203,12 +203,7 @@ async fn sync_publish<T: Send + Sync + Clone + Store>(
         HeaderValue::from_str(&id).unwrap(),
     );
     let PipelineResult::Completed(result) = result else {
-        header_map.insert(
-            http::header::CONTENT_TYPE,
-            HeaderValue::from_static("application/json"),
-        );
-        let body = r#"{'status': 'processing'}"#.as_bytes().to_vec();
-        return Ok((header_map, body));
+        return Ok(Json(json!({"status": "processing"})).into_response());
     };
 
     // The response can be a binary array of elements as single chunk. For the user to process the blob, we return the array len and
@@ -230,7 +225,7 @@ async fn sync_publish<T: Send + Sync + Clone + Store>(
     // concatenate as single result, should use header values to decompose based on the len
     let body = result.concat();
 
-    Ok((header_map, body))
+    Ok((header_map, body).into_response())
 }
 
 async fn async_publish<T: Send + Sync + Clone + Store>(

--- a/rust/serving/src/app/jetstream_proxy.rs
+++ b/rust/serving/src/app/jetstream_proxy.rs
@@ -41,7 +41,7 @@ struct ProxyState<T> {
     callback: state::State<T>,
 }
 
-pub(crate) async fn jetstream_proxy<T: Clone + Send + Sync + Store + 'static>(
+pub(crate) async fn serving_public_routes<T: Clone + Send + Sync + Store + 'static>(
     state: AppState<T>,
 ) -> crate::Result<Router> {
     let proxy_state = Arc::new(ProxyState {
@@ -320,7 +320,7 @@ mod tests {
             callback_state,
         };
 
-        let app = jetstream_proxy(app_state).await?;
+        let app = serving_public_routes(app_state).await?;
         let res = Request::builder()
             .method("POST")
             .uri("/async")
@@ -412,7 +412,7 @@ mod tests {
             callback_state: callback_state.clone(),
         };
 
-        let app = jetstream_proxy(app_state).await.unwrap();
+        let app = serving_public_routes(app_state).await.unwrap();
 
         tokio::spawn(async move {
             let mut retries = 0;
@@ -484,7 +484,7 @@ mod tests {
             callback_state: callback_state.clone(),
         };
 
-        let app = jetstream_proxy(app_state).await.unwrap();
+        let app = serving_public_routes(app_state).await.unwrap();
 
         // pipeline is in -> cat -> out, so we will have 3 callback requests
 

--- a/rust/serving/src/app/message_path.rs
+++ b/rust/serving/src/app/message_path.rs
@@ -11,7 +11,7 @@ pub fn get_message_path<T: Send + Sync + Clone + Store + 'static>(
     callback_store: CallbackState<T>,
 ) -> Router {
     Router::new()
-        .route("/message", routing::get(message_path))
+        .route("/status", routing::get(message_path))
         .with_state(callback_store)
 }
 
@@ -60,7 +60,7 @@ mod tests {
 
         let res = Request::builder()
             .method("GET")
-            .uri("/message?id=test_id")
+            .uri("/status?id=test_id")
             .header(CONTENT_TYPE, "application/json")
             .body(Body::empty())
             .unwrap();

--- a/rust/serving/src/app/response.rs
+++ b/rust/serving/src/app/response.rs
@@ -30,6 +30,7 @@ pub enum ApiError {
     BadRequest(String),
     InternalServerError(String),
     BadGateway(String),
+    Conflict(String),
 }
 
 impl IntoResponse for ApiError {
@@ -45,6 +46,7 @@ impl IntoResponse for ApiError {
             ApiError::BadRequest(message) => (StatusCode::BAD_REQUEST, message),
             ApiError::InternalServerError(message) => (StatusCode::INTERNAL_SERVER_ERROR, message),
             ApiError::BadGateway(message) => (StatusCode::BAD_GATEWAY, message),
+            ApiError::Conflict(message) => (StatusCode::CONFLICT, message),
         };
 
         (

--- a/rust/serving/src/app/tracker.rs
+++ b/rust/serving/src/app/tracker.rs
@@ -242,13 +242,10 @@ impl MessageGraph {
 
     // from_env reads the pipeline stored in the environment variable and creates a MessageGraph from it.
     pub(crate) fn from_pipeline(pipeline_spec: &PipelineDCG) -> Result<Self, Error> {
-        tracing::info!("Creating Messagegraph: {:#?}", pipeline_spec);
         let mut dag = Graph::with_capacity(pipeline_spec.edges.len());
         for edge in &pipeline_spec.edges {
             dag.entry(edge.from.clone()).or_default().push(edge.clone());
         }
-        tracing::info!("Constructed message graph: {:#?}", dag);
-
         Ok(MessageGraph { dag })
     }
 

--- a/rust/serving/src/app/tracker.rs
+++ b/rust/serving/src/app/tracker.rs
@@ -61,7 +61,22 @@ impl MessageGraph {
         callbacks: Vec<Arc<Callback>>,
     ) -> Result<Option<String>, Error> {
         if self.is_monovertex() && callbacks.len() == 1 {
-            return Ok(Some(id));
+            let cb = callbacks.first();
+            let mut subgraph: Subgraph = Subgraph {
+                id,
+                blocks: Vec::new(),
+            };
+            if let Some(cb) = cb {
+                subgraph.blocks.push(Block {
+                    from: cb.from_vertex.clone(),
+                    to: cb.vertex.clone(),
+                    cb_time: cb.cb_time,
+                });
+            }
+            return match serde_json::to_string(&subgraph) {
+                Ok(json) => Ok(Some(json)),
+                Err(e) => Err(Error::SubGraphGenerator(e.to_string())),
+            };
         }
 
         // Create a HashMap to map each vertex to its corresponding callbacks

--- a/rust/serving/src/app/tracker.rs
+++ b/rust/serving/src/app/tracker.rs
@@ -23,7 +23,7 @@ type Graph = HashMap<String, Vec<Edge>>;
 #[derive(Serialize, Deserialize, Debug)]
 struct Subgraph {
     id: String,
-    blocks: Vec<Block>,
+    edge_callbacks: Vec<EdgeCallback>,
 }
 
 /// MessageGraph is a struct that generates the graph from the source vertex to the downstream vertices
@@ -32,9 +32,10 @@ pub(crate) struct MessageGraph {
     dag: Graph,
 }
 
-/// Block is a struct that contains the information about the block in the subgraph.
+/// Block is a struct that contains the information about the edge-information and callback info in
+/// the subgraph.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) struct Block {
+pub(crate) struct EdgeCallback {
     from: String,
     to: String,
     cb_time: u64,
@@ -61,15 +62,16 @@ impl MessageGraph {
         callbacks: Vec<Arc<Callback>>,
     ) -> Result<Option<String>, Error> {
         // For a monovertex, there will only be 1 callback.
+        // Transformer will only do a callback if the message is dropped.
         if self.is_monovertex() && callbacks.len() == 1 {
             // We return a json object similar to that returned by pipeline.
             let cb = callbacks.first();
             let mut subgraph: Subgraph = Subgraph {
                 id,
-                blocks: Vec::new(),
+                edge_callbacks: Vec::new(),
             };
             if let Some(cb) = cb {
-                subgraph.blocks.push(Block {
+                subgraph.edge_callbacks.push(EdgeCallback {
                     from: cb.from_vertex.clone(),
                     to: cb.vertex.clone(),
                     cb_time: cb.cb_time,
@@ -116,7 +118,7 @@ impl MessageGraph {
         // Create a new subgraph.
         let mut subgraph: Subgraph = Subgraph {
             id,
-            blocks: Vec::new(),
+            edge_callbacks: Vec::new(),
         };
         // Call the `generate_subgraph` function to generate the subgraph from the source vertex
         let result = self.generate_subgraph(
@@ -180,7 +182,7 @@ impl MessageGraph {
         };
 
         // add the current block to the subgraph
-        subgraph.blocks.push(Block {
+        subgraph.edge_callbacks.push(EdgeCallback {
             from: current_callback.from_vertex.clone(),
             to: current_callback.vertex.clone(),
             cb_time: current_callback.cb_time,
@@ -315,7 +317,7 @@ mod tests {
 
         let mut subgraph: Subgraph = Subgraph {
             id: "uuid1".to_string(),
-            blocks: Vec::new(),
+            edge_callbacks: Vec::new(),
         };
         let result = message_graph.generate_subgraph(
             "a".to_string(),
@@ -392,7 +394,7 @@ mod tests {
 
         let mut subgraph: Subgraph = Subgraph {
             id: "uuid1".to_string(),
-            blocks: Vec::new(),
+            edge_callbacks: Vec::new(),
         };
         let result = message_graph.generate_subgraph(
             "a".to_string(),
@@ -593,7 +595,7 @@ mod tests {
 
         let mut subgraph: Subgraph = Subgraph {
             id: "xxxx".to_string(),
-            blocks: Vec::new(),
+            edge_callbacks: Vec::new(),
         };
         let result = message_graph.generate_subgraph(
             source_vertex.clone(),
@@ -669,7 +671,7 @@ mod tests {
 
         let mut subgraph: Subgraph = Subgraph {
             id: "xxxx".to_string(),
-            blocks: Vec::new(),
+            edge_callbacks: Vec::new(),
         };
         let result = message_graph.generate_subgraph(
             source_vertex.clone(),
@@ -843,7 +845,7 @@ mod tests {
 
         let mut subgraph: Subgraph = Subgraph {
             id: "xxxx".to_string(),
-            blocks: Vec::new(),
+            edge_callbacks: Vec::new(),
         };
         let result = message_graph.generate_subgraph(
             source_vertex.clone(),
@@ -948,7 +950,7 @@ mod tests {
 
         let mut subgraph: Subgraph = Subgraph {
             id: "xxxx".to_string(),
-            blocks: Vec::new(),
+            edge_callbacks: Vec::new(),
         };
         let result = message_graph.generate_subgraph(
             source_vertex.clone(),
@@ -1098,7 +1100,7 @@ mod tests {
 
         let mut subgraph: Subgraph = Subgraph {
             id: "xxxx".to_string(),
-            blocks: Vec::new(),
+            edge_callbacks: Vec::new(),
         };
         let result = message_graph.generate_subgraph(
             source_vertex.clone(),
@@ -1390,7 +1392,7 @@ mod tests {
 
         let mut subgraph: Subgraph = Subgraph {
             id: "xxxx".to_string(),
-            blocks: Vec::new(),
+            edge_callbacks: Vec::new(),
         };
         let result = message_graph.generate_subgraph(
             source_vertex.clone(),

--- a/rust/serving/src/app/tracker.rs
+++ b/rust/serving/src/app/tracker.rs
@@ -60,7 +60,9 @@ impl MessageGraph {
         id: String,
         callbacks: Vec<Arc<Callback>>,
     ) -> Result<Option<String>, Error> {
+        // For a monovertex, there will only be 1 callback.
         if self.is_monovertex() && callbacks.len() == 1 {
+            // We return a json object similar to that returned by pipeline.
             let cb = callbacks.first();
             let mut subgraph: Subgraph = Subgraph {
                 id,
@@ -265,6 +267,7 @@ impl MessageGraph {
     }
 
     pub(crate) fn is_monovertex(&self) -> bool {
+        // The DAG is created from the edges. For a monovertex, edges will be empty.
         self.dag.is_empty()
     }
 }

--- a/rust/serving/src/callback.rs
+++ b/rust/serving/src/callback.rs
@@ -219,7 +219,10 @@ mod tests {
 
         // Register the request id in the store. This normally happens when the Serving source
         // receives a request from the client. The callbacks for this request must only happen after this.
-        let _callback_notify_rx = app_state.callback_state.register(ID_VALUE.into()).await;
+        let _callback_notify_rx = app_state
+            .callback_state
+            .register(Some(ID_VALUE.into()))
+            .await;
 
         let server_handle = tokio::spawn(start_main_server(app_state, tls_config));
 

--- a/rust/serving/src/callback.rs
+++ b/rust/serving/src/callback.rs
@@ -219,7 +219,7 @@ mod tests {
 
         // Register the request id in the store. This normally happens when the Serving source
         // receives a request from the client. The callbacks for this request must only happen after this.
-        let _callback_notify_rx = app_state.callback_state.register(ID_VALUE.into());
+        let _callback_notify_rx = app_state.callback_state.register(ID_VALUE.into()).await;
 
         let server_handle = tokio::spawn(start_main_server(app_state, tls_config));
 

--- a/rust/serving/src/config.rs
+++ b/rust/serving/src/config.rs
@@ -173,7 +173,7 @@ impl TryFrom<HashMap<String, String>> for Settings {
             true => {
                 let vertex_obj = serde_json::from_slice::<MonoVertex>(&source_spec_decoded)
                     .map_err(|e| ParseConfig(format!("parsing {ENV_VERTEX_OBJ}: {e:?}")))?;
-                let serving_spec = vertex_obj
+                vertex_obj
                     .spec
                     .source
                     .ok_or_else(|| {
@@ -184,14 +184,13 @@ impl TryFrom<HashMap<String, String>> for Settings {
                         ParseConfig(format!(
                             "parsing {ENV_VERTEX_OBJ}: Serving source spec is not found"
                         ))
-                    })?;
-                serving_spec
+                    })?
             }
             false => {
                 let vertex_obj = serde_json::from_slice::<Vertex>(&source_spec_decoded)
                     .map_err(|e| ParseConfig(format!("parsing {ENV_VERTEX_OBJ}: {e:?}")))?;
 
-                let serving_spec = vertex_obj
+                vertex_obj
                     .spec
                     .source
                     .ok_or_else(|| {
@@ -202,8 +201,7 @@ impl TryFrom<HashMap<String, String>> for Settings {
                         ParseConfig(format!(
                             "parsing {ENV_VERTEX_OBJ}: Serving source spec is not found"
                         ))
-                    })?;
-                serving_spec
+                    })?
             }
         };
         // Update tid_header from source_spec

--- a/rust/serving/src/config.rs
+++ b/rust/serving/src/config.rs
@@ -64,7 +64,7 @@ pub struct Settings {
     /// The IP address of the numaserve pod. This will be used to construct the value for X-Numaflow-Callback-Url header
     pub host_ip: String,
     pub api_auth_token: Option<String>,
-    pub(crate) pipeline_spec: PipelineDCG,
+    pub pipeline_spec: PipelineDCG,
 }
 
 impl Default for Settings {

--- a/rust/serving/src/config.rs
+++ b/rust/serving/src/config.rs
@@ -53,6 +53,8 @@ impl Default for RedisConfig {
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct Settings {
+    /// The HTTP header used to communicate to the client about the unique id assigned for a request in the store
+    /// The client may also set the value of this header when sending the payload.
     pub tid_header: String,
     pub app_listen_port: u16,
     pub metrics_server_listen_port: u16,

--- a/rust/serving/src/config.rs
+++ b/rust/serving/src/config.rs
@@ -64,7 +64,7 @@ pub struct Settings {
     /// The IP address of the numaserve pod. This will be used to construct the value for X-Numaflow-Callback-Url header
     pub host_ip: String,
     pub api_auth_token: Option<String>,
-    pub pipeline_spec: PipelineDCG,
+    pub(crate) pipeline_spec: PipelineDCG,
 }
 
 impl Default for Settings {

--- a/rust/serving/src/consts.rs
+++ b/rust/serving/src/consts.rs
@@ -1,1 +1,0 @@
-pub(crate) const SAVED: &str = "SAVED";

--- a/rust/serving/src/error.rs
+++ b/rust/serving/src/error.rs
@@ -19,9 +19,9 @@ pub enum Error {
     // subgraph generator errors
     SubGraphGenerator(String),
 
-    #[error("StoreWrite Error - {0}")]
-    // Store write errors
-    StoreWrite(String),
+    #[error("Store - {0}")]
+    // Store operation errors
+    Store(String),
 
     #[error("SubGraphNotFound Error - {0}")]
     // Sub Graph Not Found Error
@@ -30,10 +30,6 @@ pub enum Error {
     #[error("SubGraphInvalidInput Error - {0}")]
     // Sub Graph Invalid Input Error
     SubGraphInvalidInput(String),
-
-    #[error("StoreRead Error - {0}")]
-    // Store read errors
-    StoreRead(String),
 
     #[error("Metrics Error - {0}")]
     // Metrics errors

--- a/rust/serving/src/lib.rs
+++ b/rust/serving/src/lib.rs
@@ -17,7 +17,6 @@ mod app;
 mod config;
 pub use {config::Settings, config::DEFAULT_CALLBACK_URL_HEADER_KEY, config::DEFAULT_ID_HEADER};
 
-mod consts;
 mod error;
 mod metrics;
 mod pipeline;

--- a/rust/serving/src/pipeline.rs
+++ b/rust/serving/src/pipeline.rs
@@ -66,7 +66,7 @@ pub(crate) struct Edge {
 /// from the pipeline spec
 /// A monovertex is represented as a single source vertex with zero edges.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
-pub(crate) struct PipelineDCG {
+pub struct PipelineDCG {
     pub(crate) vertices: Vec<Vertex>,
     pub(crate) edges: Vec<Edge>,
 }

--- a/rust/serving/src/pipeline.rs
+++ b/rust/serving/src/pipeline.rs
@@ -64,6 +64,7 @@ pub(crate) struct Edge {
 
 /// DCG (directed compute graph) of the pipeline with minimal information build using vertices and edges
 /// from the pipeline spec
+/// A monovertex is represented as a single source vertex with zero edges.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 pub struct PipelineDCG {
     pub(crate) vertices: Vec<Vertex>,
@@ -71,6 +72,7 @@ pub struct PipelineDCG {
 }
 
 impl PipelineDCG {
+    /// Monovertex is represented as a single vertex with zero edges.
     pub fn monovertex() -> Self {
         Self {
             vertices: vec![Vertex {

--- a/rust/serving/src/pipeline.rs
+++ b/rust/serving/src/pipeline.rs
@@ -70,6 +70,17 @@ pub struct PipelineDCG {
     pub(crate) edges: Vec<Edge>,
 }
 
+impl PipelineDCG {
+    pub fn monovertex() -> Self {
+        Self {
+            vertices: vec![Vertex {
+                name: "source".into(),
+            }],
+            edges: vec![],
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub(crate) struct Vertex {
     pub(crate) name: String,

--- a/rust/serving/src/pipeline.rs
+++ b/rust/serving/src/pipeline.rs
@@ -66,14 +66,14 @@ pub(crate) struct Edge {
 /// from the pipeline spec
 /// A monovertex is represented as a single source vertex with zero edges.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
-pub struct PipelineDCG {
+pub(crate) struct PipelineDCG {
     pub(crate) vertices: Vec<Vertex>,
     pub(crate) edges: Vec<Edge>,
 }
 
 impl PipelineDCG {
     /// Monovertex is represented as a single vertex with zero edges.
-    pub fn monovertex() -> Self {
+    pub(crate) fn monovertex() -> Self {
         Self {
             vertices: vec![Vertex {
                 name: "source".into(),

--- a/rust/serving/src/source.rs
+++ b/rust/serving/src/source.rs
@@ -47,7 +47,7 @@ struct ServingSourceActor {
     /// Channel for the actor handle to communicate with this actor
     handler_rx: mpsc::Receiver<ActorMessage>,
     /// Mapping from request's ID header (usually `X-Numaflow-Id` header) to a channel.
-    /// This sending a message on this channel notifies the HTTP handler function that the message
+    /// Sending a message on this channel notifies the HTTP handler function that the message
     /// has been successfully processed.
     tracker: HashMap<String, oneshot::Sender<()>>,
     vertex_replica_id: u16,


### PR DESCRIPTION
Fixes https://github.com/numaproj/numaflow/issues/2350

APIs:
----
- `POST /v1/process/sync`
- `POST /v1/process/async`
- `GET /v1/process/fetch?id=req_id`
- `GET /v1/process/status?id=req_id`



The responsibilty of generating a unique request id is moved to the Store implementation if the user doesn't provide one with `X-Numaflow-Id` header. If one is provided and if it already exist in the Store, we return 409 conflict status.

Since request id is generated by Store (or validated if user provides it), we use different tid for tracing (logs).

A request (`/sync` and `/async`) is registered in the store as the first step. With Redis store implementation, this adds an entry:
```
request:${request_id}:status  = 'pending'
``` 
When the processing is completed and all callbacks are received, the removal of request id from the tracker implementation causes the Redis status key to change value to 'completed'.

The callbacks will be stored in Redis in a list with the key `request:${request}:callbacks` and the result will be saved using the key `request:${request}:results`.

Example: The entries in Redis follows below structure:
```
request:01951c1a-418f-74f3-a2b2-ee480d877f80:status  = "completed"
request:01951c1a-418f-74f3-a2b2-ee480d877f80:results = {"hello":"world"}

request:01951c1a-418f-74f3-a2b2-ee480d877f80:callbacks = [
    {"id":"01951c1a-418f-74f3-a2b2-ee480d877f80","vertex":"serve-sink","cb_time":1739933238792,"from_vertex":"serving-in","responses":[{"tags":null}]}

    {"id":"01951c1a-418f-74f3-a2b2-ee480d877f80","vertex":"serving-in","cb_time":1739933237779,"from_vertex":"serving-in","responses":[{"tags":null}]}
]
```

Monovertex still needs to make a callback (localhost) when Sink processing is successful. I attempted to remove this by storing a handle to the callback state within the callback handler implementation. However it resulted in generics everywhere (`start_source_forwarder`, `create_components`, etc.) since callback state is generic over store.

Currently the callbacks are stored when serving pod receives a callback from each vertex for each message. Doing this only when pod is shutting down or when all callback is received can reduce the Redis API calls. This can be implemented in the future. Currently I'm prioritizing things that will make the main branch in a working/usable state.

