### PR TITLE
fix: error state & search/negate search in case of prev terminated logs

### DIFF
--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
@@ -152,12 +152,12 @@ export function PodLogs({
               let isErrorMessage = false;
               try{
                 const jsonResponse = JSON.parse(value);
-                if (jsonResponse.errMsg) {
+                if (jsonResponse?.errMsg) {
                   // If there's an error message, set value to errMsg
                   value = jsonResponse.errMsg;
                   isErrorMessage = true;
                 }
-              }catch(e){
+              } catch {
                 //do nothing
               }
               setLogs((logs) => {
@@ -211,12 +211,12 @@ export function PodLogs({
                 let isErrorMessage = false;
                 try{
                   const jsonResponse = JSON.parse(value);
-                  if (jsonResponse.errMsg) {
+                  if (jsonResponse?.errMsg) {
                     // If there's an error message, set value to errMsg
                     value = jsonResponse.errMsg;
                     isErrorMessage = true;
                   }
-                }catch(e){
+                } catch {
                   //do nothing
                 }
                 setPreviousLogs((prevLogs) => {
@@ -263,15 +263,10 @@ export function PodLogs({
       return;
     }
     const searchLowerCase = search.toLowerCase();
-    const filtered = showPreviousLogs ? previousLogs.filter((log) =>
+    const filtered = (showPreviousLogs ? previousLogs : logs)?.filter((log) =>
       negateSearch
         ? !log.toLowerCase().includes(searchLowerCase)
-        : log.toLowerCase().includes(searchLowerCase)) :
-     logs.filter((log) =>
-      negateSearch
-        ? !log.toLowerCase().includes(searchLowerCase)
-        : log.toLowerCase().includes(searchLowerCase)
-    );
+        : log.toLowerCase().includes(searchLowerCase));
     
     if (!filtered.length) {
       filtered.push("No logs matching search.");

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
@@ -43,13 +43,14 @@ const parsePodLogs = (
   value: string,
   enableTimestamp: boolean,
   levelFilter: string,
-  type: string
+  type: string,
+  isErrorMessage: boolean
 ): string[] => {
   const rawLogs = value.split("\n").filter((s) => s.trim().length);
   return rawLogs.map((raw: string) => {
     // 30 characters for RFC 3339 timestamp
-    const timestamp = raw.length >= 31 ? raw.substring(0, 30) : "";
-    const logWithoutTimestamp = raw.length >= 31 ? raw.substring(31) : raw;
+    const timestamp = raw.length >= 31 && !isErrorMessage ? raw.substring(0, 30) : "";
+    const logWithoutTimestamp = raw.length >= 31 && !isErrorMessage ? raw.substring(31) : raw;
 
     let msg = enableTimestamp ? `${timestamp} ` : "";
 
@@ -147,12 +148,25 @@ export function PodLogs({
               return;
             }
             if (value) {
+              // Check if the value is an error response
+              let isErrorMessage = false;
+              try{
+                const jsonResponse = JSON.parse(value);
+                if (jsonResponse.errMsg) {
+                  // If there's an error message, set value to errMsg
+                  value = jsonResponse.errMsg;
+                  isErrorMessage = true;
+                }
+              }catch(e){
+                //do nothing
+              }
               setLogs((logs) => {
                 const latestLogs = parsePodLogs(
                   value,
                   enableTimestamp,
                   levelFilter,
-                  type
+                  type,
+                  isErrorMessage
                 )?.filter((logs) => logs !== "");
                 let updated = [...logs, ...latestLogs];
                 if (updated.length > MAX_LOGS) {
@@ -193,12 +207,25 @@ export function PodLogs({
                 return;
               }
               if (value) {
+                // Check if the value is an error response
+                let isErrorMessage = false;
+                try{
+                  const jsonResponse = JSON.parse(value);
+                  if (jsonResponse.errMsg) {
+                    // If there's an error message, set value to errMsg
+                    value = jsonResponse.errMsg;
+                    isErrorMessage = true;
+                  }
+                }catch(e){
+                  //do nothing
+                }
                 setPreviousLogs((prevLogs) => {
                   const latestLogs = parsePodLogs(
                     value,
                     enableTimestamp,
                     levelFilter,
-                    type
+                    type,
+                    isErrorMessage
                   )?.filter((logs) => logs !== "");
                   let updated = [...prevLogs, ...latestLogs];
                   if (updated.length > MAX_LOGS) {
@@ -228,20 +255,30 @@ export function PodLogs({
 
   useEffect(() => {
     if (!search) {
-      setFilteredLogs(logs);
+      if(showPreviousLogs){
+        setFilteredLogs(previousLogs);
+      }else{
+        setFilteredLogs(logs);
+      }
       return;
     }
     const searchLowerCase = search.toLowerCase();
-    const filtered = logs.filter((log) =>
+    const filtered = showPreviousLogs ? previousLogs.filter((log) =>
+      negateSearch
+        ? !log.toLowerCase().includes(searchLowerCase)
+        : log.toLowerCase().includes(searchLowerCase)) :
+     logs.filter((log) =>
       negateSearch
         ? !log.toLowerCase().includes(searchLowerCase)
         : log.toLowerCase().includes(searchLowerCase)
     );
+    
     if (!filtered.length) {
       filtered.push("No logs matching search.");
     }
     setFilteredLogs(filtered);
-  }, [logs, search, negateSearch]);
+    
+  }, [showPreviousLogs, previousLogs, logs, search, negateSearch]);
 
   const handleSearchChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -533,7 +570,7 @@ export function PodLogs({
             }}
           >
             {logsOrder === "asc" &&
-              (showPreviousLogs ? previousLogs : filteredLogs).map(
+               filteredLogs.map(
                 (l: string, idx) => (
                   <Box
                     key={`${idx}-${podName}-logs`}
@@ -570,7 +607,7 @@ export function PodLogs({
                 )
               )}
             {logsOrder === "desc" &&
-              (showPreviousLogs ? previousLogs : filteredLogs)
+              filteredLogs
                 .slice()
                 .reverse()
                 .map((l: string, idx) => (


### PR DESCRIPTION
1. In case logs API returns an error mssg, add/remove timestamp wouldn't work. Show the error message as it is.
2. Fixes search and negate search functionality in case of previous terminated container logs.

![bug_prev_container](https://github.com/user-attachments/assets/a1252d3f-5059-4fa8-82b8-8605f5caa1eb)
