### PR TITLE
fix: sorting metrics chart tooltip values

### DIFF
--- a/ui/src/components/common/MetricsModalWrapper/index.tsx
+++ b/ui/src/components/common/MetricsModalWrapper/index.tsx
@@ -46,12 +46,25 @@ export function MetricsModalWrapper({
   });
 
   const isClickable = useMemo(() => {
-    return (
+    if (
+      discoveredMetrics &&
       !discoveredMetricsError &&
-      !discoveredMetricsLoading &&
-      !disableMetricsCharts
-    );
-  }, [discoveredMetricsError, discoveredMetricsLoading, disableMetricsCharts]);
+      !discoveredMetricsLoading
+    ) {
+      return (
+        !disableMetricsCharts &&
+        discoveredMetrics?.data?.some(
+          (metric: any) => metric?.display_name === metricDisplayName
+        )
+      );
+    }
+    return false;
+  }, [
+    discoveredMetrics,
+    discoveredMetricsError,
+    discoveredMetricsLoading,
+    disableMetricsCharts,
+  ]);
 
   return (
     <Box>

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
@@ -373,9 +373,19 @@ const LineChartComponent = ({
 
     const labels: string[] = [];
     const transformedData: Record<string, any>[] = [];
+    let filteredChartData = chartData;
     const label = groupByLabel(metricsReq?.dimension, metricsReq?.display_name);
 
-    chartData?.forEach((item) => {
+    if (
+      [VERTEX_PENDING_MESSAGES, MONO_VERTEX_PENDING_MESSAGES]?.includes(
+        metricsReq?.display_name
+      )
+    )
+      filteredChartData = filteredChartData?.filter((item) => {
+        return item?.metric?.["period"] !== "default";
+      });
+
+    filteredChartData?.forEach((item) => {
       let labelVal = "";
       label?.forEach((eachLabel: string) => {
         if (item?.metric?.[eachLabel] !== undefined) {

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
@@ -82,6 +82,13 @@ const CustomTooltip = ({
 }: TooltipProps & { displayName: string }) => {
   if (!active || !payload || !payload.length) return null;
 
+  // sorting tooltip based on values in descending order
+  payload?.sort((a, b) => {
+    const period1 = a?.value;
+    const period2 = b?.value;
+    return period2 - period1;
+  });
+
   const maxWidth = Math.max(...payload.map((entry) => entry?.name?.length));
   const timestamp = payload[0]?.payload?.timestamp;
 
@@ -368,12 +375,6 @@ const LineChartComponent = ({
     [labelVal]: parseFloat(value),
   });
 
-  const periodOrder = {
-    "1m": 1,
-    "5m": 2,
-    "15m": 3,
-  };
-
   const updateChartData = useCallback(() => {
     if (!chartData) return;
 
@@ -389,26 +390,24 @@ const LineChartComponent = ({
     )
       filteredChartData = filteredChartData
         // Filter out default period for pending messages
-        ?.filter((item) => item?.metric?.["period"] !== "default")
-        // Sort data based on period for pending messages
-        ?.sort((a, b) => {
-          const period1: "1m" | "5m" | "15m" = a?.metric?.["period"];
-          const period2: "1m" | "5m" | "15m" = b?.metric?.["period"];
-          return (periodOrder[period1] || 0) - (periodOrder[period2] || 0);
-        });
+        ?.filter((item) => item?.metric?.["period"] !== "default");
 
-    if (Array.isArray(label) && label.length === 1 && label[0] === "container"){
+    if (
+      Array.isArray(label) &&
+      label.length === 1 &&
+      label[0] === "container"
+    ) {
       filteredChartData = filteredChartData?.filter((item) => {
-        return pod?.containers?.includes(item?.metric?.["container"])
-      })
+        return pod?.containers?.includes(item?.metric?.["container"]);
+      });
     }
-    
-    if (Array.isArray(label) && label.length === 1 && label[0] === "pod"){
+
+    if (Array.isArray(label) && label.length === 1 && label[0] === "pod") {
       filteredChartData = filteredChartData?.filter((item) => {
-        return !item?.metric?.["pod"]?.includes("daemon")
-      })
+        return !item?.metric?.["pod"]?.includes("daemon");
+      });
     }
-    
+
     filteredChartData?.forEach((item) => {
       let labelVal = "";
       label?.forEach((eachLabel: string) => {
@@ -507,31 +506,31 @@ const LineChartComponent = ({
 
       {filtersList?.filter((filterEle: any) => !filterEle?.required)?.length >
         0 && (
-          <Box
-            sx={{
-              display: fromModal ? "none" : "flex",
-              alignItems: "center",
-              justifyContent: "space-around",
-              mt: "1rem",
-              mb: "2rem",
-              px: "6rem",
-            }}
-          >
-            <Box sx={{ mr: "1rem" }}>Filters</Box>
-            <FiltersDropdown
-              items={filtersList?.filter(
-                (filterEle: any) => !filterEle?.required
-              )}
-              namespaceId={namespaceId}
-              pipelineId={pipelineId}
-              type={type}
-              vertexId={vertexId}
-              setFilters={setFilters}
-              selectedPodName={pod?.name}
-              metric={metric}
-            />
-          </Box>
-        )}
+        <Box
+          sx={{
+            display: fromModal ? "none" : "flex",
+            alignItems: "center",
+            justifyContent: "space-around",
+            mt: "1rem",
+            mb: "2rem",
+            px: "6rem",
+          }}
+        >
+          <Box sx={{ mr: "1rem" }}>Filters</Box>
+          <FiltersDropdown
+            items={filtersList?.filter(
+              (filterEle: any) => !filterEle?.required
+            )}
+            namespaceId={namespaceId}
+            pipelineId={pipelineId}
+            type={type}
+            vertexId={vertexId}
+            setFilters={setFilters}
+            selectedPodName={pod?.name}
+            metric={metric}
+          />
+        </Box>
+      )}
 
       {isLoading && (
         <Box

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
@@ -375,6 +375,12 @@ const LineChartComponent = ({
     [labelVal]: parseFloat(value),
   });
 
+  const periodOrder = {
+    "1m": 1,
+    "5m": 2,
+    "15m": 3,
+  };
+
   const updateChartData = useCallback(() => {
     if (!chartData) return;
 
@@ -390,7 +396,12 @@ const LineChartComponent = ({
     )
       filteredChartData = filteredChartData
         // Filter out default period for pending messages
-        ?.filter((item) => item?.metric?.["period"] !== "default");
+        ?.filter((item) => item?.metric?.["period"] !== "default")
+        ?.sort((a, b) => {
+          const period1: "1m" | "5m" | "15m" = a?.metric?.["period"];
+          const period2: "1m" | "5m" | "15m" = b?.metric?.["period"];
+          return (periodOrder[period1] || 0) - (periodOrder[period2] || 0);
+        });
 
     if (
       Array.isArray(label) &&

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
@@ -368,6 +368,12 @@ const LineChartComponent = ({
     [labelVal]: parseFloat(value),
   });
 
+  const periodOrder = {
+    "1m": 1,
+    "5m": 2,
+    "15m": 3,
+  };
+
   const updateChartData = useCallback(() => {
     if (!chartData) return;
 
@@ -381,9 +387,15 @@ const LineChartComponent = ({
         metricsReq?.display_name
       )
     )
-      filteredChartData = filteredChartData?.filter((item) => {
-        return item?.metric?.["period"] !== "default";
-      });
+      filteredChartData = filteredChartData
+        // Filter out default period for pending messages
+        ?.filter((item) => item?.metric?.["period"] !== "default")
+        // Sort data based on period for pending messages
+        ?.sort((a, b) => {
+          const period1: "1m" | "5m" | "15m" = a?.metric?.["period"];
+          const period2: "1m" | "5m" | "15m" = b?.metric?.["period"];
+          return (periodOrder[period1] || 0) - (periodOrder[period2] || 0);
+        });
 
     filteredChartData?.forEach((item) => {
       let labelVal = "";

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
@@ -81,8 +81,7 @@ const CustomTooltip = ({
 }: TooltipProps & { displayName: string }) => {
   if (!active || !payload || !payload.length) return null;
 
-  const maxWidth =
-    Math.max(...payload.map((entry) => entry?.name?.length)) * 9.5;
+  const maxWidth = Math.max(...payload.map((entry) => entry?.name?.length));
   const timestamp = payload[0]?.payload?.timestamp;
 
   return (
@@ -101,7 +100,7 @@ const CustomTooltip = ({
           <Box key={`item-${index}`} sx={{ display: "flex" }}>
             <Box
               sx={{
-                width: `${maxWidth / 9}rem`,
+                width: `${maxWidth + 1}rem`,
                 display: "inline-block",
                 paddingRight: "1rem",
                 color: entry?.color,


### PR DESCRIPTION
- Remove hyperlink for contextual navigation when metrics is not in config map
- Remove `default` label for pending metrics
- Sorted tooltip for metrics charts in descending order based on value
- Fixed tooltip spacing

<img width="763" alt="image" src="https://github.com/user-attachments/assets/feaf9d3a-9d83-4853-90b3-2d76e479937d" />

<img width="763" alt="image" src="https://github.com/user-attachments/assets/089e87b5-e320-4c77-80e9-f8ae0d3b957b" />