### PR TITLE
Use atomic operation when registering a request in Jestream KV store

### DIFF
--- a/rust/numaflow-core/src/pipeline.rs
+++ b/rust/numaflow-core/src/pipeline.rs
@@ -480,10 +480,9 @@ async fn create_buffer_reader(
 async fn create_js_context(config: pipeline::isb::jetstream::ClientConfig) -> Result<Context> {
     // TODO: make these configurable. today this is hardcoded on Golang code too.
     let mut opts = ConnectOptions::new()
-        .max_reconnects(None) // -1 for unlimited reconnects
+        .max_reconnects(None) // unlimited reconnects
         .ping_interval(Duration::from_secs(3))
         .max_reconnects(None)
-        .ping_interval(Duration::from_secs(3))
         .retry_on_initial_connect();
 
     if let (Some(user), Some(password)) = (config.user, config.password) {

--- a/rust/serving/src/app/callback/cbstore/jetstreamstore.rs
+++ b/rust/serving/src/app/callback/cbstore/jetstreamstore.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use async_nats::jetstream::kv::Store;
+use async_nats::jetstream::kv::{CreateErrorKind, Store};
 use async_nats::jetstream::Context;
 use bytes::Bytes;
 use tokio::task::JoinHandle;
@@ -28,22 +28,20 @@ impl JSCallbackStore {
 
 impl super::CallbackStore for JSCallbackStore {
     async fn register(&mut self, id: &str) -> StoreResult<()> {
-        let key = format!("{}=status", id);
-        println!("Registering key: {}", key);
-        let exists = self.kv_store.get(&key).await.map_err(|e| {
-            StoreError::StoreRead(format!("Failed to get request id in kv store: {e:?}"))
-        })?;
-        if exists.is_some() {
-            return Err(StoreError::DuplicateRequest(id.to_string()));
-        }
+        let key = format!("{id}=status");
+        tracing::info!(key, "Registering key in Jetstream KV store");
 
         self.kv_store
-            .put(&key, ProcessingStatus::InProgress.into())
+            .create(&key, ProcessingStatus::InProgress.into())
             .await
             .map_err(|e| {
-                StoreError::StoreWrite(format!(
-                    "Failed to register request id {key} in kv store: {e:?}"
-                ))
+                if e.kind() == CreateErrorKind::AlreadyExists {
+                    StoreError::DuplicateRequest(id.to_string())
+                } else {
+                    StoreError::StoreWrite(format!(
+                        "Failed to register request id {key} in kv store: {e:?}"
+                    ))
+                }
             })?;
 
         self.kv_store
@@ -101,7 +99,14 @@ impl super::CallbackStore for JSCallbackStore {
 
         let handle = tokio::spawn(async move {
             // TODO: handle watch errors
-            while let Some(Ok(entry)) = watcher.next().await {
+            while let Some(watch_event) = watcher.next().await {
+                let entry = match watch_event {
+                    Ok(event) => event,
+                    Err(e) => {
+                        tracing::error!(?e, "Received error from Jetstream KV watcher");
+                        continue;
+                    }
+                };
                 // all callbacks received
                 if entry.operation == async_nats::jetstream::kv::Operation::Delete {
                     break;
@@ -185,6 +190,9 @@ mod tests {
         let client = async_nats::connect(js_url).await.unwrap();
         let context = jetstream::new(client);
         let serving_store = "test_watch_callbacks";
+
+        // Delete bucket so that re-running the test won't fail
+        let _ = context.delete_key_value(serving_store).await;
 
         context
             .create_key_value(Config {


### PR DESCRIPTION
Use `create` ([atomic operation](https://docs.nats.io/nats-concepts/jetstream/key-value-store#atomic-operations-used-for-locking-and-concurrency-control)) when registering request
<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
