### PR TITLE
chore: mark unhealthy if there is recent container restart

### DIFF
--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -64,7 +64,7 @@ func isPodHealthy(pod *corev1.Pod) (healthy bool, reason string) {
 			}
 		}
 	}
-	// Container restart happened 2 in the last 2 mins
+	// Container restart happened in the last 2 mins
 	if !lastRestartTime.IsZero() && lastRestartTime.Add(2*time.Minute).After(time.Now()) {
 		return false, "RecentRestart"
 	}

--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -60,7 +60,11 @@ func isPodHealthy(pod *corev1.Pod) (healthy bool, reason string) {
 		}
 		if x := c.LastTerminationState.Terminated; x != nil && !x.FinishedAt.Time.IsZero() {
 			if lastRestartTime.IsZero() || x.FinishedAt.Time.After(lastRestartTime) {
-				lastRestartTime = x.FinishedAt.Time
+				// Only check OOM or exit with Error
+				// TODO: revisit later if needed.
+				if x.ExitCode == 137 || (x.ExitCode == 143 && x.Reason == "Error") {
+					lastRestartTime = x.FinishedAt.Time
+				}
 			}
 		}
 	}

--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -52,7 +52,6 @@ func CheckPodsStatus(pods *corev1.PodList) (healthy bool, reason string, message
 func isPodHealthy(pod *corev1.Pod) (healthy bool, reason string) {
 	var lastRestartTime time.Time
 	for _, c := range pod.Status.ContainerStatuses {
-
 		if c.State.Waiting != nil && slices.Contains(unhealthyWaitingStatus, c.State.Waiting.Reason) {
 			return false, c.State.Waiting.Reason
 		}

--- a/pkg/reconciler/util_test.go
+++ b/pkg/reconciler/util_test.go
@@ -18,6 +18,7 @@ package reconciler
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	appv1 "k8s.io/api/apps/v1"
@@ -66,6 +67,52 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 		assert.Equal(t, "No Pods found", message)
 		assert.Equal(t, "NoPodsFound", reason)
 		assert.True(t, done)
+	})
+
+	t.Run("Test Vertex status as true with non-recent restart", func(t *testing.T) {
+		pods := corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}, Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "Running"}},
+						LastTerminationState: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								FinishedAt: metav1.Time{
+									Time: time.Now().Add(-3 * time.Minute),
+								},
+							},
+						},
+					},
+				}},
+			}},
+		}
+		done, reason, message := CheckPodsStatus(&pods)
+		assert.Equal(t, "All pods are healthy", message)
+		assert.Equal(t, "Running", reason)
+		assert.True(t, done)
+	})
+
+	t.Run("Test Vertex status as false with recent restart", func(t *testing.T) {
+		pods := corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}, Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "Running"}},
+						LastTerminationState: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								FinishedAt: metav1.Time{
+									Time: time.Now().Add(-1 * time.Minute),
+								},
+							},
+						},
+					},
+				}},
+			}},
+		}
+		done, reason, message := CheckPodsStatus(&pods)
+		assert.Equal(t, "Pod test-pod is unhealthy", message)
+		assert.Equal(t, "PodRecentRestart", reason)
+		assert.False(t, done)
 	})
 }
 

--- a/pkg/reconciler/util_test.go
+++ b/pkg/reconciler/util_test.go
@@ -103,6 +103,7 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 								FinishedAt: metav1.Time{
 									Time: time.Now().Add(-1 * time.Minute),
 								},
+								ExitCode: 137,
 							},
 						},
 					},


### PR DESCRIPTION
Explain what this PR does.

If there's container restart in the last 2 mins, mark it unhealthy.

Closes: #2446

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
