### PR TITLE
chore: E2E tests for Serving source

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -217,6 +217,7 @@ jobs:
             idle-source-e2e,
             monovertex-e2e,
             builtin-source-e2e,
+            serving-e2e,
           ]
         include:
           - driver: redis

--- a/test/e2e-api/main.go
+++ b/test/e2e-api/main.go
@@ -41,6 +41,7 @@ func main() {
 
 	servingController := NewServingController()
 	http.HandleFunc("/serving/send-message", servingController.SendMessage)
+	http.HandleFunc("/serving/fetch-results", servingController.FetchResults)
 
 	// initialize NATS handler
 	natsController := NewNatsController("nats", "testingtoken")

--- a/test/e2e-api/main.go
+++ b/test/e2e-api/main.go
@@ -39,6 +39,9 @@ func main() {
 	httpController := NewHttpController()
 	http.HandleFunc("/http/send-message", httpController.SendMessage)
 
+	servingController := NewServingController()
+	http.HandleFunc("/serving/send-message", servingController.SendMessage)
+
 	// initialize NATS handler
 	natsController := NewNatsController("nats", "testingtoken")
 	http.HandleFunc("/nats/pump-subject", natsController.PumpSubject)

--- a/test/e2e-api/serving.go
+++ b/test/e2e-api/serving.go
@@ -84,7 +84,7 @@ func (h *ServingController) SendMessage(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Write(body)
+	_, _ = w.Write(body)
 }
 
 func (h *ServingController) FetchResults(w http.ResponseWriter, r *http.Request) {
@@ -124,7 +124,7 @@ func (h *ServingController) FetchResults(w http.ResponseWriter, r *http.Request)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Write(body)
+	_, _ = w.Write(body)
 }
 
 // Close closes the http client

--- a/test/e2e-api/serving.go
+++ b/test/e2e-api/serving.go
@@ -42,6 +42,7 @@ func NewServingController() *ServingController {
 func (h *ServingController) SendMessage(w http.ResponseWriter, r *http.Request) {
 	host := r.URL.Query().Get("host")
 	sync := r.URL.Query().Get("sync")
+	reqId := r.URL.Query().Get("reqId")
 	reqBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Println(err)
@@ -60,8 +61,51 @@ func (h *ServingController) SendMessage(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	if reqId != "" {
+		postReq.Header.Set("X-Numaflow-Id", reqId)
+	}
 
 	resp, err := h.client.Do(postReq)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("[ERROR] Expected %d, Got %d", http.StatusOK, resp.StatusCode)
+		http.Error(w, fmt.Sprintf("Bad status: %s", resp.Status), http.StatusInternalServerError)
+		return
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("[ERROR] Reading response body from Serving source: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Write(body)
+}
+
+func (h *ServingController) FetchResults(w http.ResponseWriter, r *http.Request) {
+	host := r.URL.Query().Get("host")
+	reqId := r.URL.Query().Get("reqId")
+
+	if reqId == "" {
+		http.Error(w, "request id can not be empty for fetch API", http.StatusInternalServerError)
+		return
+	}
+
+	uri := fmt.Sprintf("https://%s:8443/v1/process/fetch?id=%s", host, reqId)
+
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp, err := h.client.Do(req)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/test/e2e-api/serving.go
+++ b/test/e2e-api/serving.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+type ServingController struct {
+	client *http.Client
+}
+
+func NewServingController() *ServingController {
+	return &ServingController{
+		client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		},
+	}
+}
+
+func (h *ServingController) SendMessage(w http.ResponseWriter, r *http.Request) {
+	host := r.URL.Query().Get("host")
+	sync := r.URL.Query().Get("sync")
+	reqBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	uri := fmt.Sprintf("https://%s:8443/v1/process/sync", host)
+	if sync == "false" {
+		uri = fmt.Sprintf("https://%s:8443/v1/process/async", host)
+	}
+
+	postReq, err := http.NewRequest("POST", uri, bytes.NewBuffer(reqBytes))
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp, err := h.client.Do(postReq)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("[ERROR] Expected %d, Got %d", http.StatusOK, resp.StatusCode)
+		http.Error(w, fmt.Sprintf("Bad status: %s", resp.Status), http.StatusInternalServerError)
+		return
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("[ERROR] Reading response body from Serving source: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Write(body)
+}
+
+// Close closes the http client
+func (h *ServingController) Close() {
+	h.client.CloseIdleConnections()
+}

--- a/test/fixtures/serving.go
+++ b/test/fixtures/serving.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fixtures
+
+func SendServingMessage(host string, payload string, sync bool) string {
+	return InvokeE2EAPIPOST("/serving/send-message?host=%s&sync=%t", payload, host, sync)
+}

--- a/test/fixtures/serving.go
+++ b/test/fixtures/serving.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package fixtures
 
-func SendServingMessage(host string, payload string, sync bool) string {
-	return InvokeE2EAPIPOST("/serving/send-message?host=%s&sync=%t", payload, host, sync)
+func SendServingMessage(host, reqId, payload string, sync bool) string {
+	return InvokeE2EAPIPOST("/serving/send-message?host=%s&reqId=%s&sync=%t", payload, host, reqId, sync)
+}
+
+func FetchServingResult(host, reqId string) string {
+	return InvokeE2EAPIPOST("/serving/fetch-results?host=%s&reqId=%s", "", host, reqId)
 }

--- a/test/serving-e2e/serving_test.go
+++ b/test/serving-e2e/serving_test.go
@@ -1,0 +1,93 @@
+//go:build test
+
+/*
+Copyright 2022 The Numaproj Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serving_e2e
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/numaproj/numaflow/test/fixtures"
+)
+
+//go:generate kubectl -n numaflow-system set env deploy/numaflow-controller NUMAFLOW_EXECUTE_RUST_BINARY=true
+//go:generate kubectl delete -f testdata/serving-pipeline-cat.yaml -n numaflow-system --ignore-not-found=true
+//go:generate kubectl -n numaflow-system wait --for=condition=ready pod -l app.kubernetes.io/name=controller-manager --timeout 30s
+
+const Namespace = "numaflow-system"
+
+type ServingSuite struct {
+	fixtures.E2ESuite
+}
+
+// {"message":"Successfully published message","id":"0195859e-b05f-78d3-b0b6-6946a77f842e","code":200,"timestamp":"2025-03-11T14:32:05.455629106Z"}
+type asyncAPIResponse struct {
+	Message   string    `json:"message"`
+	Id        string    `json:"id"`
+	Code      int       `json:"code"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func (resp *asyncAPIResponse) isValid() error {
+	if resp.Message != "Successfully published message" {
+		return fmt.Errorf("message field = %q, expected='Successfully published message'", resp.Message)
+	}
+	if resp.Id == "" {
+		return errors.New("id field can not be empty")
+	}
+	var defaultTime time.Time
+	if resp.Timestamp == defaultTime {
+		return fmt.Errorf("invalid value for timestamp field: %q", resp.Timestamp)
+	}
+	if resp.Code != 200 {
+		return fmt.Errorf("expected value of 'code' field is 200, got %d", resp.Code)
+	}
+	return nil
+}
+
+func (ss *ServingSuite) TestServingSource() {
+	w := ss.Given().Pipeline("@testdata/serving-pipeline-cat.yaml").
+		When().
+		CreatePipelineAndWait()
+	defer w.DeletePipelineAndWait()
+
+	w.Expect().VertexPodsRunning()
+
+	pipelineName := "serving-source"
+	serviceName := "serving-source-serving-in"
+	// Check Service
+	cmd := fmt.Sprintf("kubectl -n %s get svc -lnumaflow.numaproj.io/pipeline-name=%s,numaflow.numaproj.io/vertex-name=%s | grep -v CLUSTER-IP | grep -v headless", Namespace, pipelineName, "serving-in")
+	w.Exec("sh", []string{"-c", cmd}, fixtures.OutputRegexp(serviceName))
+
+	syncResp := fixtures.SendServingMessage(serviceName, "test data", true)
+	assert.Equal(ss.T(), "test data", syncResp)
+
+	asyncRespText := fixtures.SendServingMessage(serviceName, "test data", false)
+	var asyncResp asyncAPIResponse
+	err := json.Unmarshal([]byte(asyncRespText), &asyncResp)
+	require.NoError(ss.T(), err)
+	require.NoError(ss.T(), asyncResp.isValid())
+}
+
+func TestServingSuite(t *testing.T) {
+	suite.Run(t, new(ServingSuite))
+}

--- a/test/serving-e2e/testdata/serving-pipeline-cat.yaml
+++ b/test/serving-e2e/testdata/serving-pipeline-cat.yaml
@@ -1,0 +1,39 @@
+apiVersion: numaflow.numaproj.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: serving-source
+spec:
+  vertices:
+    - name: serving-in
+      servingStoreName: default
+      scale:
+        min: 1
+        max: 1
+      source:
+        serving:
+          service: true
+          msgIDHeaderKey: "X-Numaflow-Id"
+
+    - name: cat
+      scale:
+        min: 1
+        max: 1
+      udf:
+        container:
+          image: quay.io/numaio/numaflow-go/map-forward-message:stable
+
+    - name: serve-sink
+      servingStoreName: default
+      scale:
+        min: 1
+        max: 1
+      sink:
+        udsink:
+          container:
+            image: quay.io/numaio/numaflow-go/sink-serve:stable
+
+  edges:
+    - from: serving-in
+      to: cat
+    - from: cat
+      to: serve-sink


### PR DESCRIPTION
Couldn't make it part of `builtin-sources-e2e` since we need to:
```
kubectl -n numaflow-system set env deploy/numaflow-controller NUMAFLOW_EXECUTE_RUST_BINARY=true
```

The e2e test uses a pipeline with `serving source -> cat vertex -> serve sink`
- Sends a `/sync` request and validates the response
- Sends an `/async` request and validates the response
- Fetches the result of the request sent over `/async` and validates the result.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
