### PR TITLE
fix: Recreate KV watcher if it never returns any events

### DIFF
--- a/rust/serving/src/app.rs
+++ b/rust/serving/src/app.rs
@@ -8,7 +8,7 @@ use axum::response::Response;
 use axum::{body::Body, http::Request, middleware, response::IntoResponse, routing::get, Router};
 use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
-use http::{HeaderName, HeaderValue};
+use http::HeaderName;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
 use serde::Deserialize;
@@ -75,10 +75,10 @@ where
     Ok(())
 }
 
-#[derive(Clone)]
 /// New type to store the TID of a request in Axum's request extensions
 /// Request extensions are like a hashmap with the key as the type of the value we store. https://docs.rs/http/1.2.0/http/struct.Extensions.html
 /// A new type is needed so that the value doesn't get accidentally overwritten by some other middleware.
+#[derive(Clone)]
 struct Tid(String);
 
 #[derive(Deserialize)]

--- a/rust/serving/src/app.rs
+++ b/rust/serving/src/app.rs
@@ -1,16 +1,17 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use axum::extract::{MatchedPath, State};
+use axum::extract::{MatchedPath, Query, State};
 use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::Response;
 use axum::{body::Body, http::Request, middleware, response::IntoResponse, routing::get, Router};
 use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
-use http::HeaderName;
+use http::{HeaderName, HeaderValue};
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
+use serde::Deserialize;
 use tokio::signal;
 use tower::ServiceBuilder;
 use tower_http::classify::ServerErrorsFailureClass;
@@ -76,7 +77,14 @@ where
 
 #[derive(Clone)]
 /// New type to store the TID of a request in Axum's request extensions
+/// Request extensions are like a hashmap with the key as the type of the value we store. https://docs.rs/http/1.2.0/http/struct.Extensions.html
+/// A new type is needed so that the value doesn't get accidentally overwritten by some other middleware.
 struct Tid(String);
+
+#[derive(Deserialize)]
+struct FetchQueryParams {
+    id: String,
+}
 
 pub(crate) async fn router_with_auth<T, U>(app: AppState<T, U>) -> crate::Result<Router>
 where
@@ -89,8 +97,14 @@ where
         .map_request({
             let tid_header = HeaderName::from_bytes(app.settings.tid_header.as_bytes()).unwrap();
             move |mut req: Request<Body>| {
-                if ["/metrics", "/readyz", "/livez", "/sidecar-livez"].contains(&req.uri().path()) {
-                    return req;
+                if req.uri().path() == "/v1/process/fetch" {
+                    // If a valid query parameter `id` is defined, use the same as request id.
+                    // Else, a new UUID v7 is assigned and the request will be rejected within the
+                    // fetch handler since the query parameter is invalid.
+                    if let Ok(query_params) = Query::<FetchQueryParams>::try_from_uri(req.uri())  {
+                        req.headers_mut().insert(tid_header.clone(),HeaderValue::from_str(query_params.id.as_str()).unwrap());
+                        return req;
+                    };
                 }
 
                 let tid = match req.headers().get(&tid_header) {
@@ -106,13 +120,6 @@ where
             TraceLayer::new_for_http()
                 .make_span_with({
                     move |req: &Request<Body>| {
-                        let req_path = req.uri().path();
-                        if ["/metrics", "/readyz", "/livez", "/sidecar-livez"].contains(&req_path) {
-                            // We don't need request ID for these endpoints
-                            return info_span!("request", method=?req.method(), path=req_path);
-                        }
-
-
                         let tid = req.extensions().get::<Tid>().unwrap();
 
                         let matched_path = req
@@ -122,7 +129,7 @@ where
 
                         let span = info_span!("request", tid=tid.0);
                         span.in_scope(|| {
-                            info!(method=?req.method(), path=req_path, matched_path, "Received request");
+                            info!(method=?req.method(), path=req.uri().path(), matched_path, "Received request");
                         });
                         span
                     }

--- a/rust/serving/src/app.rs
+++ b/rust/serving/src/app.rs
@@ -102,7 +102,7 @@ where
                     // Else, a new UUID v7 is assigned and the request will be rejected within the
                     // fetch handler since the query parameter is invalid.
                     if let Ok(query_params) = Query::<FetchQueryParams>::try_from_uri(req.uri())  {
-                        req.headers_mut().insert(tid_header.clone(),HeaderValue::from_str(query_params.id.as_str()).unwrap());
+                        req.extensions_mut().insert(Tid(query_params.0.id));
                         return req;
                     };
                 }

--- a/rust/serving/src/app/jetstream_proxy.rs
+++ b/rust/serving/src/app/jetstream_proxy.rs
@@ -229,7 +229,6 @@ async fn sync_publish<
         ));
     }
 
-    // TODO: add a timeout for waiting on rx. make sure deregister is called if timeout branch is invoked.
     let processing_result = match notify.await {
         Ok(processing_result) => processing_result,
         Err(e) => {

--- a/rust/serving/src/app/jetstream_proxy.rs
+++ b/rust/serving/src/app/jetstream_proxy.rs
@@ -11,14 +11,13 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::{Stream, StreamExt};
 use tracing::error;
 
-use super::Tid;
 use super::{orchestrator, store::datastore::DataStore, AppState};
+use super::{FetchQueryParams, Tid};
 use crate::app::response::{ApiError, ServeResponse};
 use crate::app::store::cbstore::CallbackStore;
 use crate::app::store::datastore::Error as StoreError;
@@ -57,17 +56,12 @@ pub(crate) async fn jetstream_proxy<
     Ok(router)
 }
 
-#[derive(Deserialize)]
-struct ServeQueryParams {
-    id: String,
-}
-
 async fn fetch<
     T: Send + Sync + Clone + DataStore + 'static,
     U: Send + Sync + Clone + CallbackStore + 'static,
 >(
     State(proxy_state): State<Arc<ProxyState<T, U>>>,
-    Query(ServeQueryParams { id }): Query<ServeQueryParams>,
+    Query(FetchQueryParams { id }): Query<FetchQueryParams>,
 ) -> Response {
     let pipeline_result = match proxy_state.orchestrator.clone().retrieve_saved(&id).await {
         Ok(result) => result,

--- a/rust/serving/src/app/store/cbstore/jetstreamstore.rs
+++ b/rust/serving/src/app/store/cbstore/jetstreamstore.rs
@@ -18,6 +18,7 @@
 //! Status Value - JSON serialized [ProcessingStatus] enum
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_nats::jetstream::kv::{CreateErrorKind, Store};
 use async_nats::jetstream::Context;
@@ -26,7 +27,7 @@ use chrono::Utc;
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
-use tracing::info;
+use tracing::{info, Instrument};
 
 use crate::app::store::cbstore::ProcessingStatus;
 use crate::app::store::datastore::{Error as StoreError, Result as StoreResult};
@@ -171,42 +172,94 @@ impl super::CallbackStore for JetStreamCallbackStore {
                 StoreError::StoreRead(format!("Failed to watch request id in kv store: {e:?}"))
             })?;
 
+        let kv_store = self.kv_store.clone();
+
         let (tx, rx) = tokio::sync::mpsc::channel(10);
 
         let callbacks_init_key = format!("cb.{id}.start.processing");
         let callbacks_done_key = format!("cb.{id}.done.processing");
 
-        let handle = tokio::spawn(async move {
+        let span = tracing::Span::current();
+
+        let callback_watcher = async move {
             // FIXME(FMEA): Handle errors from the watcher.
-            while let Some(watch_event) = watcher.next().await {
-                let entry = match watch_event {
-                    Ok(event) => event,
-                    Err(e) => {
-                        tracing::error!(?e, "Received error from Jetstream KV watcher");
+            let mut event_count = 0;
+            let mut attempts = 0;
+            while event_count == 0 && attempts < 5 {
+                attempts += 1;
+                while let Some(watch_event) = watcher.next().await {
+                    event_count += 1;
+                    let entry = match watch_event {
+                        Ok(event) => event,
+                        Err(e) => {
+                            tracing::error!(?e, "Received error from Jetstream KV watcher");
+                            continue;
+                        }
+                    };
+
+                    // init key is used to signal the start of processing, the value will be the timestamp.
+                    if entry.key == callbacks_init_key {
+                        tracing::info!(
+                            callbacks_init_key,
+                            "Received event for the init key. Ignoring it"
+                        );
                         continue;
                     }
-                };
 
-                // init key is used to signal the start of processing, the value will be the timestamp.
-                if entry.key == callbacks_init_key {
-                    continue;
+                    // done key is used to signal the end of processing, we can break the loop
+                    if entry.key == callbacks_done_key {
+                        tracing::info!(
+                            callbacks_done_key,
+                            "Received event for the callback_done_key. Stopping the watcher task"
+                        );
+                        break;
+                    }
+
+                    let cbr: Callback = entry
+                        .value
+                        .try_into()
+                        .inspect_err(|err| tracing::error!(?err, "Failed to deserialize callback"))
+                        .expect("Failed to deserialize callback");
+
+                    tx.send(Arc::new(cbr))
+                        .await
+                        .inspect_err(|err| {
+                            tracing::error!(
+                                ?err,
+                                "Failed to send callback details from watcher task to main task"
+                            )
+                        })
+                        .expect("Failed to send callback");
                 }
-
-                // done key is used to signal the end of processing, we can break the loop
-                if entry.key == callbacks_done_key {
-                    break;
+                if event_count == 0 && attempts < 5 {
+                    tracing::warn!(
+                        callbacks_key,
+                        "Watcher for Jetstream key didn't return any events. Will recreate the watcher in 20ms"
+                    );
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    watcher = kv_store
+                        .watch_from_revision(&callbacks_key, 1)
+                        .await
+                        .map_err(|e| {
+                            StoreError::StoreRead(format!(
+                                "Failed to watch request id in kv store: {e:?}"
+                            ))
+                        })
+                        .inspect_err(|err| {
+                            tracing::error!(?err, callbacks_key, "Failed to recreate the watcher")
+                        })
+                        .expect("Failed to recreate the watcher");
                 }
-
-                let cbr: Callback = entry
-                    .value
-                    .try_into()
-                    .expect("Failed to deserialize callback");
-
-                tx.send(Arc::new(cbr))
-                    .await
-                    .expect("Failed to send callback");
             }
-        });
+            if event_count == 0 {
+                tracing::error!(
+                    callbacks_key,
+                    "Watcher for Jetstream key didn't return any events even after retries"
+                );
+            }
+        };
+
+        let handle = tokio::spawn(callback_watcher.instrument(span));
 
         Ok((ReceiverStream::new(rx), handle))
     }

--- a/rust/serving/src/app/store/cbstore/jetstreamstore.rs
+++ b/rust/serving/src/app/store/cbstore/jetstreamstore.rs
@@ -200,7 +200,7 @@ impl super::CallbackStore for JetStreamCallbackStore {
 
                     // init key is used to signal the start of processing, the value will be the timestamp.
                     if entry.key == callbacks_init_key {
-                        tracing::info!(
+                        tracing::debug!(
                             callbacks_init_key,
                             "Received event for the init key. Ignoring it"
                         );
@@ -209,7 +209,7 @@ impl super::CallbackStore for JetStreamCallbackStore {
 
                     // done key is used to signal the end of processing, we can break the loop
                     if entry.key == callbacks_done_key {
-                        tracing::info!(
+                        tracing::debug!(
                             callbacks_done_key,
                             "Received event for the callback_done_key. Stopping the watcher task"
                         );


### PR DESCRIPTION
## Changes

### Bug fix in handling error from background task
We were not handing the error returned through `notify` channel. We were only handling the [channel receive error](https://github.com/numaproj/numaflow/blob/751f34288c24ee77fa15482c9a90d867040dfd23/rust/serving/src/app/jetstream_proxy.rs#L246), but not the `Result` value sent over the channel. 
 
### Recreating the watcher
Recreate the KV watcher if the watcher for doesn't return any events. Noticed this happening consistently when I sent 10K request (100 connections in parallel). For around 5 requests out of 10K, the `watcher.next()` returns `None`.  With current changes (see `Watcher for Jetstream key didn't return any events`): 
```
$ rg '0195a677-e9ce-77f3-8dc6-e1e06d24a161' serving.log

58658:2025-03-17T23:37:11.374493Z  INFO request{tid="0195a677-e9ce-77f3-8dc6-e1e06d24a161"}: serving::app: Received request method=POST path="/v1/process/sync" matched_path="/v1/process/sync"
58659:2025-03-17T23:37:11.374501Z  INFO request{tid="0195a677-e9ce-77f3-8dc6-e1e06d24a161"}: serving::app::store::cbstore::jetstreamstore: Registering key in Jetstream KV store id="0195a677-e9ce-77f3-8dc6-e1e06d24a161"
58777:2025-03-17T23:37:11.389385Z  WARN request{tid="0195a677-e9ce-77f3-8dc6-e1e06d24a161"}: serving::app::store::cbstore::jetstreamstore: Watcher for Jetstream key didn't return any events. Will retry in 20ms callbacks_key="cb.0195a677-e9ce-77f3-8dc6-e1e06d24a161.*.*"
59070:2025-03-17T23:37:11.415653Z  INFO request{tid="0195a677-e9ce-77f3-8dc6-e1e06d24a161"}: serving::app::store::cbstore::jetstreamstore: Received event for init key. Ignoring it callbacks_init_key="cb.0195a677-e9ce-77f3-8dc6-e1e06d24a161.start.processing"
59071:2025-03-17T23:37:11.415660Z  INFO request{tid="0195a677-e9ce-77f3-8dc6-e1e06d24a161"}: serving::app::orchestrator: Received callback cb=Callback { id: "0195a677-e9ce-77f3-8dc6-e1e06d24a161", vertex: "serving-in", cb_time: 1742254631393, from_vertex: "serving-in", responses: [Response { tags: None }] } msg_id="0195a677-e9ce-77f3-8dc6-e1e06d24a161"
59072:2025-03-17T23:37:11.415662Z  INFO request{tid="0195a677-e9ce-77f3-8dc6-e1e06d24a161"}: serving::app::orchestrator: Received callback cb=Callback { id: "0195a677-e9ce-77f3-8dc6-e1e06d24a161", vertex: "cat", cb_time: 1742254631395, from_vertex: "serving-in", responses: [Response { tags: Some([]) }] } msg_id="0195a677-e9ce-77f3-8dc6-e1e06d24a161"
59138:2025-03-17T23:37:12.410897Z  INFO request{tid="0195a677-e9ce-77f3-8dc6-e1e06d24a161"}: serving::app::orchestrator: Received callback cb=Callback { id: "0195a677-e9ce-77f3-8dc6-e1e06d24a161", vertex: "serve-sink", cb_time: 1742254632408, from_vertex: "cat", responses: [Response { tags: None }] } msg_id="0195a677-e9ce-77f3-8dc6-e1e06d24a161"
59248:2025-03-17T23:37:12.416069Z  INFO request{tid="0195a677-e9ce-77f3-8dc6-e1e06d24a161"}: serving::app::store::cbstore::jetstreamstore: Received event for callback_done_key. Stopping the watcher task callbacks_done_key="cb.0195a677-e9ce-77f3-8dc6-e1e06d24a161.done.processing"
59330:2025-03-17T23:37:12.427248Z  INFO request{tid="0195a677-e9ce-77f3-8dc6-e1e06d24a161"}: serving::app: status=200 latency=1.05275597s
```

### Change in top-level request span
The top-level tracing span created for a request is changed to only include `tid` (this will be prefixed with all tracing events). Earlier we were adding the method and request path.  Instead, a single log line will be emitted (see first line in above snippet) showing request details.

### Attach request specific tracing span to all request scoped spawns. 
Made changes to attach the top-level tracing span for request to all background tasks spawned for that request https://github.com/tokio-rs/tracing/blob/b4868674ba73f3963b125ec38b57efaadc714d90/examples/examples/tokio-spawny-thing.rs#L25. 

### Inspect error before unwrapping
Adding a `.inspect_err(|err| tracing::error!("..."))` before all `.expect()` calls. The `expect`/`unwrap`s are used in scenarios where we don't expect that to happen. In some rare scenarios when it happens (possibly some application bug), we might miss panics as it won't show up if you search with a request tid. A stripped down example without `.inspect_err` where tokio task panics:
```rust
async fn run() {
    info!("Starting main task");
    let span = tracing::span::Span::current();
    let t1 = async {
        tracing::info!("Started background task");
        Err::<(), &str>("some error happened").expect("unexpected error");
    };
    tokio::spawn(t1.instrument(span));
}
```
logs:
```
2025-03-18T03:56:43.396179Z  INFO top-level{tid=10}: t: Starting main task
2025-03-18T03:56:43.396238Z  INFO top-level{tid=10}: t: Started background task

thread 'tokio-runtime-worker' panicked at src/main.rs:18:48:
unexpected error: "some error happened"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

With `.inspect_err`, the change will be:
```rust
Err::<(), &str>("some error happened")
    .inspect_err(|err| tracing::error!(?err, "unexpected error"))
    .expect("unexpected error");
```

```
2025-03-18T04:00:31.670726Z  INFO top-level{tid=10}: t: Starting main task
2025-03-18T04:00:31.670805Z  INFO top-level{tid=10}: t: Started background task
2025-03-18T04:00:31.670822Z ERROR top-level{tid=10}: t: unexpected error err="some error happened"

thread 'tokio-runtime-worker' panicked at src/main.rs:20:14:
unexpected error: "some error happened"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```