### PR TITLE
fix: add active pod function for runtime errors

### DIFF
--- a/pkg/daemon/server/service/runtime/pod_tracker.go
+++ b/pkg/daemon/server/service/runtime/pod_tracker.go
@@ -124,15 +124,11 @@ func (pt *PodTracker) updateActivePodsCount(vertexName string, index int, called
 
 	if calledForActiveIndex {
 		if index >= pt.activePodsCount[vertexName] {
-			pt.log.Debugf("adding index %d to vertex %s", index, vertexName)
 			pt.activePodsCount[vertexName] = index + 1
-			pt.log.Debugf("updated active pods count to %d for vertex %s", pt.activePodsCount[vertexName], vertexName)
 		}
 	} else {
 		if index < pt.activePodsCount[vertexName] {
-			pt.log.Debugf("removing index %d to vertex %s", index, vertexName)
 			pt.activePodsCount[vertexName] = index
-			pt.log.Debugf("updated active pods count to %d for vertex %s", pt.activePodsCount[vertexName], vertexName)
 		}
 	}
 }

--- a/pkg/daemon/server/service/runtime/pod_tracker.go
+++ b/pkg/daemon/server/service/runtime/pod_tracker.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -119,14 +120,15 @@ func (pt *PodTracker) addActivePod(vertexName string, index int) {
 	pt.activePodsMutex.Lock()
 	defer pt.activePodsMutex.Unlock()
 
-	pt.activePods[vertexName] = append(pt.activePods[vertexName], index)
+	if !slices.Contains(pt.activePods[vertexName], index) {
+		pt.activePods[vertexName] = append(pt.activePods[vertexName], index)
+	}
 }
 
 // removeActivePod removes the inactive pod replica for the respective vertex
 func (pt *PodTracker) removeActivePod(vertexName string, index int) {
 	pt.activePodsMutex.Lock()
 	defer pt.activePodsMutex.Unlock()
-
 	pt.activePods[vertexName] = removeValue(pt.activePods[vertexName], index)
 }
 

--- a/pkg/daemon/server/service/runtime/runtime.go
+++ b/pkg/daemon/server/service/runtime/runtime.go
@@ -158,7 +158,7 @@ func (r *pipelineRuntimeCache) fetchAndPersistErrorForPod(vtxName string, podInd
 
 	res, err := r.httpClient.Get(url)
 	if err != nil {
-		r.log.Errorw("Error reading the runtime errors endpoint: %f", err.Error())
+		r.log.Errorf("Error reading the runtime errors endpoint: %s", err.Error())
 		return
 	}
 
@@ -177,7 +177,8 @@ func (r *pipelineRuntimeCache) fetchAndPersistErrorForPod(vtxName string, podInd
 		return
 	}
 
-	if apiResponse.ErrMessage != "" {
+	// return if data array length is 0 or if there is any error in the API call
+	if apiResponse.ErrMessage != "" || len(apiResponse.Data) == 0 {
 		return
 	}
 

--- a/pkg/daemon/server/service/runtime/runtime.go
+++ b/pkg/daemon/server/service/runtime/runtime.go
@@ -158,7 +158,7 @@ func (r *pipelineRuntimeCache) fetchAndPersistErrorForPod(vtxName string, podInd
 
 	res, err := r.httpClient.Get(url)
 	if err != nil {
-		r.log.Errorf("Error reading the runtime errors endpoint: %s", err.Error())
+		r.log.Warnf("[vertex name %s, pod name %s]: failed reading the runtime endpoint, the pod might have been scaled down: %v", vtxName, podName, err.Error())
 		return
 	}
 

--- a/pkg/mvtxdaemon/server/service/runtime/pod_tracker.go
+++ b/pkg/mvtxdaemon/server/service/runtime/pod_tracker.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -117,7 +118,9 @@ func (pt *PodTracker) addActivePod(index int) {
 	pt.activePodsMutex.Lock()
 	defer pt.activePodsMutex.Unlock()
 
-	pt.activePods = append(pt.activePods, index)
+	if !slices.Contains(pt.activePods, index) {
+		pt.activePods = append(pt.activePods, index)
+	}
 }
 
 // removeActivePod removes the inactive pod replica from the respective monoVertex

--- a/pkg/mvtxdaemon/server/service/runtime/pod_tracker.go
+++ b/pkg/mvtxdaemon/server/service/runtime/pod_tracker.go
@@ -121,15 +121,11 @@ func (pt *PodTracker) updateActivePodsCount(index int, calledForActiveIndex bool
 
 	if calledForActiveIndex {
 		if index >= pt.activePodsCount {
-			pt.log.Debugf("adding index %d", index)
 			pt.activePodsCount = index + 1
-			pt.log.Debugf("updated active pods count to %d for monoVertex", pt.activePodsCount)
 		}
 	} else {
 		if index < pt.activePodsCount {
-			pt.log.Debugf("removing index %d", index)
 			pt.activePodsCount = index
-			pt.log.Debugf("updated active pods count to %d for monoVertex", pt.activePodsCount)
 		}
 	}
 }

--- a/pkg/mvtxdaemon/server/service/runtime/pod_tracker_test.go
+++ b/pkg/mvtxdaemon/server/service/runtime/pod_tracker_test.go
@@ -119,7 +119,7 @@ func TestPodTracker_isActive(t *testing.T) {
 	assert.False(t, active)
 }
 
-func TestPodTracker_addActivePod(t *testing.T) {
+func TestPodTracker_updateActivePodsCount(t *testing.T) {
 	ctx := context.Background()
 	mv := &v1alpha1.MonoVertex{
 		ObjectMeta: metav1.ObjectMeta{
@@ -135,6 +135,8 @@ func TestPodTracker_addActivePod(t *testing.T) {
 		lock:      &sync.RWMutex{},
 	}
 	// add one more active pod with index 3
-	pt.updateActivePodsCount(3)
+	pt.updateActivePodsCount(3, true)
 	assert.Equal(t, pt.GetActivePodsCount(), 4)
+	pt.updateActivePodsCount(2, false)
+	assert.Equal(t, pt.GetActivePodsCount(), 2)
 }

--- a/pkg/mvtxdaemon/server/service/runtime/pod_tracker_test.go
+++ b/pkg/mvtxdaemon/server/service/runtime/pod_tracker_test.go
@@ -127,38 +127,14 @@ func TestPodTracker_addActivePod(t *testing.T) {
 			Namespace: "default",
 		},
 	}
+
 	pt := NewPodTracker(ctx, mv)
 	pt.httpClient = &mockHttpClient{
+		// active pods would be 3, from index 0..2
 		podsCount: 3,
 		lock:      &sync.RWMutex{},
 	}
-	pt.addActivePod(10)
-	assert.Equal(t, pt.GetActivePodsCount(), 1)
-
-	pt.updateActivePods()
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, pt.GetActivePodsCount(), 3)
-}
-
-func TestPodTracker_removeActivePod(t *testing.T) {
-	ctx := context.Background()
-	mv := &v1alpha1.MonoVertex{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "p",
-			Namespace: "default",
-		},
-	}
-	pt := NewPodTracker(ctx, mv)
-	pt.httpClient = &mockHttpClient{
-		podsCount: 3,
-		lock:      &sync.RWMutex{},
-	}
-	pt.addActivePod(10)
-	assert.Equal(t, pt.GetActivePodsCount(), 1)
-	pt.removeActivePod(10)
-	assert.Equal(t, pt.GetActivePodsCount(), 0)
-
-	pt.updateActivePods()
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, pt.GetActivePodsCount(), 3)
+	// add one more active pod with index 3
+	pt.updateActivePodsCount(3)
+	assert.Equal(t, pt.GetActivePodsCount(), 4)
 }

--- a/pkg/mvtxdaemon/server/service/runtime/pod_tracker_test.go
+++ b/pkg/mvtxdaemon/server/service/runtime/pod_tracker_test.go
@@ -119,7 +119,7 @@ func TestPodTracker_isActive(t *testing.T) {
 	assert.False(t, active)
 }
 
-func TestPodTracker_updateActivePodsCount(t *testing.T) {
+func TestPodTracker_setActivePodsCount(t *testing.T) {
 	ctx := context.Background()
 	mv := &v1alpha1.MonoVertex{
 		ObjectMeta: metav1.ObjectMeta{
@@ -134,9 +134,7 @@ func TestPodTracker_updateActivePodsCount(t *testing.T) {
 		podsCount: 3,
 		lock:      &sync.RWMutex{},
 	}
-	// add one more active pod with index 3
-	pt.updateActivePodsCount(3, true)
+	// set active pods to 4
+	pt.setActivePodsCount(4)
 	assert.Equal(t, pt.GetActivePodsCount(), 4)
-	pt.updateActivePodsCount(2, false)
-	assert.Equal(t, pt.GetActivePodsCount(), 2)
 }

--- a/pkg/mvtxdaemon/server/service/runtime/runtime.go
+++ b/pkg/mvtxdaemon/server/service/runtime/runtime.go
@@ -156,7 +156,7 @@ func (r *monoVertexRuntimeCache) fetchAndPersistErrorForPod(podIndex int) {
 
 	res, err := r.httpClient.Get(url)
 	if err != nil {
-		r.log.Errorf("Error reading the runtime errors endpoint: %s", err.Error())
+		r.log.Warnf("[MonoVertex %s Index %v]: failed reading the runtime endpoint, the pod might have been scaled down: %v", r.monoVtx.Name, podIndex, err.Error())
 		return
 	}
 

--- a/pkg/mvtxdaemon/server/service/runtime/runtime.go
+++ b/pkg/mvtxdaemon/server/service/runtime/runtime.go
@@ -156,7 +156,7 @@ func (r *monoVertexRuntimeCache) fetchAndPersistErrorForPod(podIndex int) {
 
 	res, err := r.httpClient.Get(url)
 	if err != nil {
-		r.log.Errorw("Error reading the runtime errors endpoint", "error", err.Error())
+		r.log.Errorf("Error reading the runtime errors endpoint: %s", err.Error())
 		return
 	}
 
@@ -175,7 +175,8 @@ func (r *monoVertexRuntimeCache) fetchAndPersistErrorForPod(podIndex int) {
 		return
 	}
 
-	if apiResponse.ErrMessage != "" {
+	// return if data array length is 0 or if there is any error in the API call
+	if apiResponse.ErrMessage != "" || len(apiResponse.Data) == 0 {
 		return
 	}
 

--- a/rust/numaflow-monitor/src/app.rs
+++ b/rust/numaflow-monitor/src/app.rs
@@ -211,7 +211,7 @@ mod tests {
         assert_eq!(api_response.data.len(), 1);
     }
     #[tokio::test]
-    async fn test_handle_runtime_app_errors_internal_error() {
+    async fn test_handle_runtime_app_errors_ok_empty_data() {
         // Initialize runtime and app state
         let runtime = Arc::new(Runtime::new(Some(RuntimeInfoConfig {
             app_error_path: "test-path-error".to_string(),
@@ -236,18 +236,14 @@ mod tests {
         // Call the handler
         let response = router.oneshot(request).await.unwrap();
 
-        // It should throw error since app-error directory doesn't exist
-        // and we are trying to read from it
-        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
             .await
             .unwrap();
         let api_response: ApiResponse = serde_json::from_slice(&body).unwrap();
+        // It should return early since app-error directory doesn't exist
+        // and we are trying to read from it
         assert!(api_response.data.is_empty());
-        assert_eq!(
-            api_response.error_message,
-            Some("file Error - No application errors persisted yet".to_string())
-        );
     }
 }

--- a/rust/numaflow-monitor/src/runtime.rs
+++ b/rust/numaflow-monitor/src/runtime.rs
@@ -163,8 +163,7 @@ impl Runtime {
         let mut errors = Vec::new();
         // if no app errors are persisted, directory wouldn't be created yet
         if !app_err_path.exists() || !app_err_path.is_dir() {
-            let err = Error::File("No application errors persisted yet".to_string());
-            return Err(err);
+            return Ok(errors);
         }
 
         let paths = fs::read_dir(app_err_path)


### PR DESCRIPTION
We were not checking if the index was already present in the slice before appending it to the slice.
Code:
```
func (pt *PodTracker) addActivePod(index int) {
	pt.activePodsMutex.Lock()
	defer pt.activePodsMutex.Unlock()

	pt.activePods = append(pt.activePods, index)
}
```

Logs:

```
{"level":"info","ts":"2025-04-01T08:31:46.191147193Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:121","msg":"Added active pod 0 for MonoVertex simple-mono-vertex","mvtx":"simple-mono-vertex"}
{"level":"info","ts":"2025-04-01T08:31:46.191175475Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:122","msg":"Active Pods Slice now: [0]","mvtx":"simple-mono-vertex"}
{"level":"info","ts":"2025-04-01T08:32:16.185663895Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:121","msg":"Added active pod 0 for MonoVertex simple-mono-vertex","mvtx":"simple-mono-vertex"}
{"level":"info","ts":"2025-04-01T08:32:16.185715045Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:122","msg":"Active Pods Slice now: [0 0]","mvtx":"simple-mono-vertex"}
```

PR Logs:

After scaling  `cat` to 5, then `in` to 16 and `cat` to 6:

```
{"level":"info","ts":"2025-04-02T04:26:05.826024387Z","logger":"numaflow.daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:140","msg":"Setting active pods count for vertex in to 1","pipeline":"simple-pipeline"}
{"level":"info","ts":"2025-04-02T04:26:05.826099512Z","logger":"numaflow.daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:140","msg":"Setting active pods count for vertex cat to 5","pipeline":"simple-pipeline"}

{"level":"info","ts":"2025-04-02T04:26:35.459471448Z","logger":"numaflow.daemon-server","caller":"fetch/processor_manager.go:213","msg":"Successfully added a new fromProcessor","pipeline":"simple-pipeline","fromProcessor":"simple-pipeline-in-8"}
{"level":"info","ts":"2025-04-02T04:26:35.826736257Z","logger":"numaflow.daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:140","msg":"Setting active pods count for vertex in to 16","pipeline":"simple-pipeline"}
{"level":"info","ts":"2025-04-02T04:26:35.826776632Z","logger":"numaflow.daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:140","msg":"Setting active pods count for vertex cat to 6","pipeline":"simple-pipeline"}
{"level":"info","ts":"2025-04-02T04:26:35.826780007Z","logger":"numaflow.daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:140","msg":"Setting active pods count for vertex out to 1","pipeline":"simple-pipeline"}
```

After scaling down back to 1:

```
{"level":"warn","ts":"2025-04-02T04:29:04.592159963Z","logger":"numaflow.daemon-server.pipelineRuntimeCache","caller":"runtime/runtime.go:161","msg":"[vertex name cat, pod name simple-pipeline-cat-1]: failed reading the runtime endpoint, the pod might have been scaled down: Get \"https://simple-pipeline-cat-1.simple-pipeline-cat-headless.default.svc:2470/runtime/errors\": dial tcp: lookup simple-pipeline-cat-1.simple-pipeline-cat-headless.default.svc on 192.168.194.138:53: no such host","pipeline":"simple-pipeline"}
{"level":"info","ts":"2025-04-02T04:29:05.823150554Z","logger":"numaflow.daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:140","msg":"Setting active pods count for vertex in to 1","pipeline":"simple-pipeline"}
{"level":"info","ts":"2025-04-02T04:29:05.823219179Z","logger":"numaflow.daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:140","msg":"Setting active pods count for vertex cat to 1","pipeline":"simple-pipeline"}
```

For MonoVertex:

After scaling to 10 replicas:

```
{"level":"info","ts":"2025-04-02T04:23:35.278476575Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:136","msg":"Setting active pods count to 1","mvtx":"simple-mono-vertex"}
{"level":"info","ts":"2025-04-02T04:24:05.271123489Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:136","msg":"Setting active pods count to 10","mvtx":"simple-mono-vertex"}
```

After scaling down to 5 and then 3:

```
{"level":"warn","ts":"2025-04-02T04:24:33.822688038Z","logger":"numaflow.mvtx-daemon-server.Rater","caller":"rater/rater.go:175","msg":"[Pod name simple-mono-vertex-mv-7]: failed reading the metrics endpoint, the pod might have been scaled down: Get \"https://simple-mono-vertex-mv-7.simple-mono-vertex-mv-headless.default.svc:2469/metrics\": dial tcp: lookup simple-mono-vertex-mv-7.simple-mono-vertex-mv-headless.default.svc on 192.168.194.138:53: no such host","mvtx":"simple-mono-vertex"}
{"level":"info","ts":"2025-04-02T04:24:35.275287818Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:136","msg":"Setting active pods count to 5","mvtx":"simple-mono-vertex"}

{"level":"warn","ts":"2025-04-02T04:26:05.170347416Z","logger":"numaflow.mvtx-daemon-server.monoVertexRuntimeCache","caller":"runtime/runtime.go:159","msg":"[MonoVertex simple-mono-vertex Index 4]: failed reading the runtime endpoint, the pod might have been scaled down: Get \"https://simple-mono-vertex-mv-4.simple-mono-vertex-mv-headless.default.svc:2470/runtime/errors\": dial tcp: lookup simple-mono-vertex-mv-4.simple-mono-vertex-mv-headless.default.svc on 192.168.194.138:53: no such host","mvtx":"simple-mono-vertex"}
{"level":"info","ts":"2025-04-02T04:26:05.269501554Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:136","msg":"Setting active pods count to 3","mvtx":"simple-mono-vertex"}
```





