### PR TITLE
feat: add missing metrics for mvtx

### DIFF
--- a/rust/numaflow-core/src/metrics.rs
+++ b/rust/numaflow-core/src/metrics.rs
@@ -1428,8 +1428,23 @@ mod tests {
             .time
             .get_or_create(&common_labels)
             .observe(5.0);
+        metrics
+            .transformer
+            .dropped_total
+            .get_or_create(&common_labels)
+            .inc_by(2);
 
         metrics.sink.write_total.get_or_create(&common_labels).inc();
+        metrics
+            .sink
+            .write_errors_total
+            .get_or_create(&common_labels)
+            .inc_by(3);
+        metrics
+            .sink
+            .dropped_total
+            .get_or_create(&common_labels)
+            .inc_by(2);
         metrics.sink.time.get_or_create(&common_labels).observe(4.0);
 
         metrics
@@ -1437,6 +1452,11 @@ mod tests {
             .write_total
             .get_or_create(&common_labels)
             .inc();
+        metrics
+            .fb_sink
+            .time
+            .get_or_create(&common_labels)
+            .observe(5.0);
 
         // Validate the metric names
         let state = global_registry().registry.lock();
@@ -1462,11 +1482,17 @@ mod tests {
             r#"monovtx_transformer_time_sum{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 5.0"#,
             r#"monovtx_transformer_time_count{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 1"#,
             r#"monovtx_transformer_time_bucket{le="100.0",mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 1"#,
+            r#"monovtx_transformer_dropped_total{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 2"#,
             r#"monovtx_sink_write_total{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 1"#,
             r#"monovtx_sink_time_sum{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 4.0"#,
             r#"monovtx_sink_time_count{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 1"#,
             r#"monovtx_sink_time_bucket{le="100.0",mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 1"#,
+            r#"monovtx_sink_write_errors_total{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 3"#,
+            r#"monovtx_sink_dropped_total{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 2"#,
             r#"monovtx_fallback_sink_write_total{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 1"#,
+            r#"monovtx_fallback_sink_time_sum{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 5.0"#,
+            r#"monovtx_fallback_sink_time_count{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 1"#,
+            r#"monovtx_fallback_sink_time_bucket{le="100.0",mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 1"#,
         ];
 
         let got = buffer

--- a/rust/numaflow-core/src/metrics.rs
+++ b/rust/numaflow-core/src/metrics.rs
@@ -10,7 +10,6 @@ use axum::http::{Response, StatusCode};
 use axum::response::IntoResponse;
 use axum::{routing::get, Router};
 use axum_server::tls_rustls::RustlsConfig;
-use futures::sink;
 use prometheus_client::encoding::text::encode;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;

--- a/rust/numaflow-core/src/sink.rs
+++ b/rust/numaflow-core/src/sink.rs
@@ -659,7 +659,6 @@ impl SinkWriter {
         // start with the original set of message to be sent.
         // we will overwrite this vec with failed messages and will keep retrying.
         let mut messages_to_send = fallback_msgs;
-        let total_fallback_msgs = fallback_msgs.len();
 
         let default_retry = retry_config
             .sink_default_retry_strategy
@@ -736,7 +735,6 @@ impl SinkWriter {
                 Err(e) => return Err(e),
             }
         }
-
         if !messages_to_send.is_empty() {
             return Err(Error::Sink(format!(
                 "Failed to write messages to fallback sink after {} attempts. Errors: {:?}",

--- a/rust/numaflow-core/src/sink.rs
+++ b/rust/numaflow-core/src/sink.rs
@@ -513,7 +513,7 @@ impl SinkWriter {
                 .sink
                 .write_errors_total
                 .get_or_create(mvtx_forward_metric_labels())
-                .inc_by(write_errors_total as u64)
+                .inc_by((write_errors_total) as u64);
         } else {
             pipeline_metrics()
                 .forwarder

--- a/rust/numaflow-core/src/transformer.rs
+++ b/rust/numaflow-core/src/transformer.rs
@@ -191,6 +191,17 @@ impl Transformer {
                 Err(e) => return Err(Error::Transformer(format!("task join failed: {}", e))),
             }
         }
+        let dropped_messages_count = transformed_messages
+            .iter()
+            .filter(|message| message.dropped())
+            .count();
+        if dropped_messages_count > 0 {
+            monovertex_metrics()
+                .transformer
+                .dropped_total
+                .get_or_create(mvtx_forward_metric_labels())
+                .inc_by(dropped_messages_count as u64);
+        }
         Ok(transformed_messages)
     }
 


### PR DESCRIPTION
fixes #2383 
fixes #1791 

#### Metrics Added for MonoVertex
1. Sink write errors - this will cover Response.Failure cases
2. Sink Dropped total - this will cover drop retry strategy in sink
3. Transformer dropped total - this will cover Drop tag sent in response
4. Fb Sink time - this will cover latency for fallback sink


#### Existing Metrics which are implemented for MonoVertex
1. Read total
2. Read time
3. Ack total
4. Ack time
5. E2E time
6. Transformer time
7. Sink time
8. Sink Write Total
9. Fb Sink Write Total
10. Dropped total at MonoVertex level - **Removed**