### PR TITLE
fix: start persisting errors after first active pods update

### DIFF
--- a/pkg/daemon/server/daemon_server.go
+++ b/pkg/daemon/server/daemon_server.go
@@ -157,10 +157,10 @@ func (ds *daemonServer) Run(ctx context.Context) error {
 		}
 	}()
 
-	// Start the pipelineRuntimeCache
+	// Start the pipeline runtime cache refresher
 	go func() {
 		if err := pipelineRuntimeCache.StartCacheRefresher(ctx); err != nil {
-			log.Panic(fmt.Errorf("failed to start the pipelineRuntimeCache: %w", err))
+			log.Panic(fmt.Errorf("failed to start the pipeline runtime cache refresher: %w", err))
 		}
 	}()
 

--- a/pkg/mvtxdaemon/server/daemon_server.go
+++ b/pkg/mvtxdaemon/server/daemon_server.go
@@ -111,10 +111,10 @@ func (ds *daemonServer) Run(ctx context.Context) error {
 		}
 	}()
 
-	// Start the monoVertexRuntimeCache
+	// Start the MonoVertex Runtime Cache Refresher
 	go func() {
 		if err := monoVertexRuntimeCache.StartCacheRefresher(ctx); err != nil {
-			log.Panic(fmt.Errorf("failed to start the runtime: %w", err))
+			log.Panic(fmt.Errorf("failed to start the MonoVertex runtime cache refresher: %w", err))
 		}
 	}()
 


### PR DESCRIPTION
#### Issue
Even though we immediately call `fetchAndPersistErrors` function when we start runtime cache refresher, we do not see errors in the UI for sometime.

We are starting `podTracker` (which updates active pods) and `persistRuntimeErrors` go routines at the same time. Since initially active pods are not updated, we do not update the daemon local cache. We have to wait for another 60 seconds, for the next API call in `fetchAndPersistErrors`. In the UI, we will see no errors (even if they are persisted in shared store) until then.


#### Fix

Run `persistRuntimeErrors` go routine just after we receive first update for active pods.
 

```
{"level":"info","ts":"2025-04-13T03:39:35.34904206Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:120","msg":"pods updated","mvtx":"simple-mono-vertex"}
{"level":"info","ts":"2025-04-13T03:39:35.349157851Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:72","msg":"updated active pods for the first time","mvtx":"simple-mono-vertex"}
{"level":"info","ts":"2025-04-13T03:39:35.349168185Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:74","msg":"closing the channel now","mvtx":"simple-mono-vertex"}
{"level":"info","ts":"2025-04-13T03:39:35.34943535Z","logger":"numaflow.mvtx-daemon-server.monoVertexRuntimeCache","caller":"runtime/runtime.go:117","msg":"received channel update","mvtx":"simple-mono-vertex"}
{"level":"info","ts":"2025-04-13T03:39:35.349496016Z","logger":"numaflow.mvtx-daemon-server.monoVertexRuntimeCache","caller":"runtime/runtime.go:143","msg":"Persisted error for the first time","mvtx":"simple-mono-vertex"}
{"level":"error","ts":"2025-04-13T03:40:04.350794419Z","logger":"numaflow.mvtx-daemon-server","caller":"service/mvtx_service.go:206","msg":"Failed to MonoVertex data criticality","mvtx":"simple-mono-vertex","error":"cannot check data health, MonoVertex simple-mono-vertex has no rate information","stacktrace":"github.com/numaproj/numaflow/pkg/mvtxdaemon/server/service.(*MonoVertexService).startHealthCheck\n\t/Users/ajain60/Documents/numaflow/pkg/mvtxdaemon/server/service/mvtx_service.go:206\ngithub.com/numaproj/numaflow/pkg/mvtxdaemon/server/service.(*MonoVertexService).StartHealthCheck\n\t/Users/ajain60/Documents/numaflow/pkg/mvtxdaemon/server/service/mvtx_service.go:180\ngithub.com/numaproj/numaflow/pkg/mvtxdaemon/server.(*daemonServer).Run.func4\n\t/Users/ajain60/Documents/numaflow/pkg/mvtxdaemon/server/daemon_server.go:104"}
{"level":"info","ts":"2025-04-13T03:40:05.39671876Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:120","msg":"pods updated","mvtx":"simple-mono-vertex"}
{"level":"info","ts":"2025-04-13T03:40:35.398312552Z","logger":"numaflow.mvtx-daemon-server.RuntimePodTracker","caller":"runtime/pod_tracker.go:120","msg":"pods updated","mvtx":"simple-mono-vertex"}
```
