### PR TITLE
chore: Upgrade sccache action to fix nightly build failures

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -57,7 +57,7 @@ jobs:
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.5
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Build binary
@@ -98,7 +98,7 @@ jobs:
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.5
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Install dependenices
         run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu protobuf-compiler
       - name: Build binary


### PR DESCRIPTION
Nightly builds are failing Rust binary building stages: https://github.com/numaproj/numaflow/actions/runs/14554004245/job/40828487229

```
Run RUSTFLAGS='-C target-feature=+crt-static -C linker=aarch64-linux-gnu-gcc' cargo build --release --target aarch64-unknown-linux-gnu
error: process didn't exit successfully: `sccache /home/runner/.rustup/toolchains/1.84-x86_64-unknown-linux-gnu/bin/rustc -vV` (exit status: 2)
--- stderr
sccache: error: Server startup failed: cache storage failed to read: Unexpected (permanent) at read => {"$id":"1","innerException":null,"message":"This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset","typeName":"Microsoft.Azure.DevOps.ArtifactCache.WebApi.ArtifactCacheServiceDecommissionedException, Microsoft.Azure.DevOps.ArtifactCache.WebApi","typeKey":"ArtifactCacheServiceDecommissionedException","errorCode":0,"eventId":3000}

Context:
   uri: https://acghubeus1.actions.githubusercontent.com/iE3LacUkp5Q4CAWJkDP3NEb01weqV8GN7t93BBu0U4qMTOqygs/_apis/artifactcache/cache?keys=sccache/.sccache_check&version=sccache-v0.10.0
   response: Parts { status: 422, version: HTTP/1.1, headers: {"content-length": "426", "content-type": "application/json; charset=utf-8", "date": "Sat, 19 Apr 2025 23:59:52 GMT", "server": "Kestrel", "cache-control": "no-store,no-cache", "pragma": "no-cache", "strict-transport-security": "max-age=2592000", "x-tfs-processid": "70ee823c-f032-44ff-8c49-4b20bbe1d283", "activityid": "428ddd80-a86a-4799-b395-5ea98d559575", "x-tfs-session": "428ddd80-a86a-4799-b395-5ea98d559575", "x-vss-e2eid": "428ddd80-a86a-4799-b395-5ea98d559575", "x-vss-senderdeploymentid": "e3de3c8c-fa12-318e-3301-e1d3e326b2e8", "x-frame-options": "SAMEORIGIN"} }
   service: ghac
   path: .sccache_check
   range: 0-

Backtrace:
   0: <unknown>
   1: <unknown>
   2: <unknown>
   3: <unknown>
   4: <unknown>
   5: <unknown>
   6: <unknown>
   7: <unknown>
   8: <unknown>
   9: <unknown>
  10: <unknown>
  11: <unknown>
  12: <unknown>
  13: <unknown>


Run with SCCACHE_LOG=debug SCCACHE_NO_DAEMON=1 to get more information
```

Working fine in CI builds https://github.com/numaproj/numaflow/actions/runs/14546137804/job/40811817557
The `mozilla-actions/sccache-action` was upgraded in CI build pipeline in https://github.com/numaproj/numaflow/pull/2510

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
