### PR TITLE
chore: use server side apply for status update and more

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gin-contrib/cors v1.7.1
 	github.com/gin-contrib/static v0.0.2-0.20220606235426-ae09b2ea7e39
 	github.com/gin-gonic/gin v1.9.1
+	github.com/go-logr/zapr v1.3.0
 	github.com/go-openapi/inflect v0.21.0
 	github.com/go-swagger/go-swagger v0.31.0
 	github.com/goccy/go-json v0.10.2
@@ -100,7 +101,6 @@ require (
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/pkg/apis/numaflow/v1alpha1/mono_vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/mono_vertex_types.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	appv1 "k8s.io/api/apps/v1"
@@ -130,7 +131,14 @@ func (mv MonoVertex) GetServiceObjs() []*corev1.Service {
 
 func (mv MonoVertex) getServiceObj(name string, headless bool, ports map[string]int32) *corev1.Service {
 	var servicePorts []corev1.ServicePort
-	for name, port := range ports {
+	portNames := make([]string, 0, len(ports))
+	for k := range ports {
+		portNames = append(portNames, k)
+	}
+	// Sort by name instead of iterating the map directly to make sure the genereated spec is consistent
+	sort.Strings(portNames)
+	for _, name := range portNames {
+		port := ports[name]
 		servicePorts = append(servicePorts, corev1.ServicePort{
 			Port:       port,
 			TargetPort: intstr.FromInt32(port),

--- a/pkg/apis/numaflow/v1alpha1/vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/vertex_types.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -148,7 +149,14 @@ func (v Vertex) GetServiceObjs() []*corev1.Service {
 
 func (v Vertex) getServiceObj(name string, headless bool, ports map[string]int32) *corev1.Service {
 	var servicePorts []corev1.ServicePort
-	for name, port := range ports {
+	portNames := make([]string, 0, len(ports))
+	for k := range ports {
+		portNames = append(portNames, k)
+	}
+	// Sort by name instead of iterating the map directly to make sure the genereated spec is consistent
+	sort.Strings(portNames)
+	for _, name := range portNames {
+		port := ports[name]
 		servicePorts = append(servicePorts, corev1.ServicePort{
 			Port:       port,
 			TargetPort: intstr.FromInt32(port),

--- a/pkg/reconciler/cmd/start.go
+++ b/pkg/reconciler/cmd/start.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -53,6 +55,8 @@ import (
 
 func Start(namespaced bool, managedNamespace string) {
 	logger := logging.NewLogger().Named("controller-manager")
+	log.SetLogger(zapr.NewLogger(logger.Desugar()))
+
 	config, err := reconciler.LoadConfig(func(err error) {
 		logger.Errorw("Failed to reload global configuration file", zap.Error(err))
 	})

--- a/pkg/reconciler/monovertex/controller_test.go
+++ b/pkg/reconciler/monovertex/controller_test.go
@@ -152,7 +152,6 @@ func TestReconcile(t *testing.T) {
 		}
 		_, err = r.Reconcile(context.TODO(), req)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "not found")
 	})
 }
 

--- a/pkg/reconciler/pipeline/controller_test.go
+++ b/pkg/reconciler/pipeline/controller_test.go
@@ -369,7 +369,6 @@ func TestReconcile(t *testing.T) {
 		}
 		_, err = r.Reconcile(context.TODO(), req)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "not found")
 	})
 }
 

--- a/pkg/reconciler/vertex/controller_test.go
+++ b/pkg/reconciler/vertex/controller_test.go
@@ -227,7 +227,6 @@ func TestReconcile(t *testing.T) {
 		}
 		_, err = r.Reconcile(context.TODO(), req)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "not found")
 	})
 }
 


### PR DESCRIPTION
1. No logger set for the controller runtime, nil pointer error on controller startup;
2. There are cases that the CR status not being updated, which are caused by client-side update. Switch to [server side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) to address the problem. [More](https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/) to read.
3. Fixed a bug introduced by https://github.com/numaproj/numaflow/pull/2499, that the generated headless object has inconsistent spec (ports in different orders).


<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
