### PR TITLE
chore: extend compactor to write to tx on replay

### DIFF
--- a/rust/numaflow-core/src/reduce/wal/segment.rs
+++ b/rust/numaflow-core/src/reduce/wal/segment.rs
@@ -161,7 +161,7 @@ mod tests {
             .unwrap();
 
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some(Offset::String(StringOffset::new("gc".to_string(), 0))),
+            offset: Some(Offset::String(StringOffset::new("gc".to_string(), 0))),
             data: bytes::Bytes::from(prost::Message::encode_to_vec(&gc_event)),
         })
         .await
@@ -204,7 +204,7 @@ mod tests {
 
             let proto_message: Bytes = message.try_into().unwrap();
             tx.send(SegmentWriteMessage::WriteData {
-                id: Some(Offset::String(StringOffset::new(format!("msg-{}", i), 0))),
+                offset: Some(Offset::String(StringOffset::new(format!("msg-{}", i), 0))),
                 data: proto_message,
             })
             .await
@@ -297,14 +297,14 @@ mod tests {
 
         // Send both GC events
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some(Offset::String(StringOffset::new("gc1".to_string(), 0))),
+            offset: Some(Offset::String(StringOffset::new("gc1".to_string(), 0))),
             data: bytes::Bytes::from(prost::Message::encode_to_vec(&gc_event1)),
         })
         .await
         .unwrap();
 
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some(Offset::String(StringOffset::new("gc2".to_string(), 0))),
+            offset: Some(Offset::String(StringOffset::new("gc2".to_string(), 0))),
             data: bytes::Bytes::from(prost::Message::encode_to_vec(&gc_event2)),
         })
         .await
@@ -352,7 +352,7 @@ mod tests {
 
             let proto_message: Bytes = message.try_into().unwrap();
             tx.send(SegmentWriteMessage::WriteData {
-                id: Some(Offset::String(StringOffset::new(format!("msg-{}", i), 0))),
+                offset: Some(Offset::String(StringOffset::new(format!("msg-{}", i), 0))),
                 data: proto_message,
             })
             .await

--- a/rust/numaflow-core/src/reduce/wal/segment.rs
+++ b/rust/numaflow-core/src/reduce/wal/segment.rs
@@ -118,7 +118,7 @@ impl From<GcEventEntry> for GcEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::message::{Message, MessageID};
+    use crate::message::{Message, MessageID, Offset, StringOffset};
     use crate::reduce::wal::segment::WalType;
     use crate::reduce::wal::segment::append::{AppendOnlyWal, SegmentWriteMessage};
     use crate::reduce::wal::segment::compactor::{Compactor, WindowKind};
@@ -161,7 +161,7 @@ mod tests {
             .unwrap();
 
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some("gc".to_string()),
+            id: Some(Offset::String(StringOffset::new("gc".to_string(), 0))),
             data: bytes::Bytes::from(prost::Message::encode_to_vec(&gc_event)),
         })
         .await
@@ -204,7 +204,7 @@ mod tests {
 
             let proto_message: Bytes = message.try_into().unwrap();
             tx.send(SegmentWriteMessage::WriteData {
-                id: Some(format!("msg-{}", i)),
+                id: Some(Offset::String(StringOffset::new(format!("msg-{}", i), 0))),
                 data: proto_message,
             })
             .await
@@ -297,14 +297,14 @@ mod tests {
 
         // Send both GC events
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some("gc1".to_string()),
+            id: Some(Offset::String(StringOffset::new("gc1".to_string(), 0))),
             data: bytes::Bytes::from(prost::Message::encode_to_vec(&gc_event1)),
         })
         .await
         .unwrap();
 
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some("gc2".to_string()),
+            id: Some(Offset::String(StringOffset::new("gc2".to_string(), 0))),
             data: bytes::Bytes::from(prost::Message::encode_to_vec(&gc_event2)),
         })
         .await
@@ -352,7 +352,7 @@ mod tests {
 
             let proto_message: Bytes = message.try_into().unwrap();
             tx.send(SegmentWriteMessage::WriteData {
-                id: Some(format!("msg-{}", i)),
+                id: Some(Offset::String(StringOffset::new(format!("msg-{}", i), 0))),
                 data: proto_message,
             })
             .await

--- a/rust/numaflow-core/src/reduce/wal/segment.rs
+++ b/rust/numaflow-core/src/reduce/wal/segment.rs
@@ -225,7 +225,7 @@ mod tests {
         .await
         .unwrap();
 
-        compactor.compact().await.unwrap();
+        compactor.compact(None).await.unwrap();
 
         // Verify compacted data
         let compaction_wal = ReplayWal::new(WalType::Compact, test_path);
@@ -373,7 +373,7 @@ mod tests {
         .await
         .unwrap();
 
-        compactor.compact().await.unwrap();
+        compactor.compact(None).await.unwrap();
 
         // Verify compacted data
         let compaction_wal = ReplayWal::new(WalType::Compact, test_path);

--- a/rust/numaflow-core/src/reduce/wal/segment/append.rs
+++ b/rust/numaflow-core/src/reduce/wal/segment/append.rs
@@ -463,13 +463,17 @@ mod tests {
 
         // We can't sort Offset values directly, so we'll just check that we received the same number of IDs
         assert_eq!(
-            received_ids.len(), expected_ids.len(),
+            received_ids.len(),
+            expected_ids.len(),
             "Mismatch between expected and received successful IDs count"
         );
 
         // Check that each expected ID is in the received IDs
         for expected_id in expected_ids {
-            assert!(received_ids.contains(&expected_id), "Missing expected ID in received IDs");
+            assert!(
+                received_ids.contains(&expected_id),
+                "Missing expected ID in received IDs"
+            );
         }
 
         let mut files: Vec<_> = fs::read_dir(&base_path)
@@ -537,7 +541,10 @@ mod tests {
             .await
             .expect("Failed to start WAL service");
 
-        let id1 = Some(Offset::String(StringOffset::new("flush-test-1".to_string(), 0)));
+        let id1 = Some(Offset::String(StringOffset::new(
+            "flush-test-1".to_string(),
+            0,
+        )));
         let data1 = Bytes::from("Data to be flushed");
         wal_tx
             .send(SegmentWriteMessage::WriteData {

--- a/rust/numaflow-core/src/reduce/wal/segment/append.rs
+++ b/rust/numaflow-core/src/reduce/wal/segment/append.rs
@@ -1,3 +1,4 @@
+use crate::message::Offset;
 use crate::reduce::wal::error::WalResult;
 use crate::reduce::wal::segment::WalType;
 use bytes::Bytes;
@@ -24,7 +25,7 @@ pub(crate) enum SegmentWriteMessage {
     /// Writes the given payload to the WAL.
     WriteData {
         /// Unique ID of the payload. Useful to detect write failures.
-        id: Option<String>,
+        id: Option<Offset>,
         /// Data to be written on do the WAL.
         data: Bytes,
     },
@@ -56,7 +57,7 @@ struct SegmentWriteActor {
     /// Maximum file size per segment.
     max_file_size: u64,
     /// The result of [SegmentWriteMessage] operation.
-    result_tx: Sender<String>,
+    result_tx: Sender<Offset>,
 }
 
 impl Drop for SegmentWriteActor {
@@ -76,7 +77,7 @@ impl SegmentWriteActor {
         current_file: BufWriter<File>,
         max_file_size: u64,
         flush_interval: Duration,
-        result_tx: Sender<String>,
+        result_tx: Sender<Offset>,
     ) -> Self {
         Self {
             wal_type,
@@ -304,11 +305,11 @@ impl AppendOnlyWal {
     pub(crate) async fn streaming_write(
         self,
         stream: ReceiverStream<SegmentWriteMessage>,
-    ) -> WalResult<(ReceiverStream<String>, JoinHandle<WalResult<()>>)> {
+    ) -> WalResult<(ReceiverStream<Offset>, JoinHandle<WalResult<()>>)> {
         let (file_name, file_buf) =
             SegmentWriteActor::open_segment(&self.wal_type, &self.base_path, 0).await?;
 
-        let (result_tx, result_rx) = mpsc::channel::<String>(self.channel_buffer_size);
+        let (result_tx, result_rx) = mpsc::channel::<Offset>(self.channel_buffer_size);
 
         let max_file_size_bytes = self.max_file_size_mb * 1024 * 1024;
         let flush_duration = Duration::from_millis(self.flush_interval_ms);
@@ -341,10 +342,12 @@ impl AppendOnlyWal {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::message::{Offset, StringOffset};
     use crate::reduce::wal::segment::WalType;
     use bytes::{Bytes, BytesMut};
     use futures::stream::StreamExt;
     use std::fs;
+    use std::mem::size_of;
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -374,7 +377,7 @@ mod tests {
         let mut expected_ids = Vec::new();
         let mut received_results = Vec::new();
 
-        let id1 = "msg-001".to_string();
+        let id1 = Offset::String(StringOffset::new("msg-001".to_string(), 0));
         let data1 = Bytes::from("some initial data");
         expected_ids.push(id1.clone());
         wal_tx
@@ -385,7 +388,7 @@ mod tests {
             .await
             .unwrap();
 
-        let id2 = "msg-002".to_string();
+        let id2 = Offset::String(StringOffset::new("msg-002".to_string(), 0));
         let data2 = Bytes::from(" more data here");
         expected_ids.push(id2.clone());
         wal_tx
@@ -398,7 +401,7 @@ mod tests {
 
         let large_data_size = (0.6 * 1024.0 * 1024.0) as usize;
         let large_data1 = Bytes::from(vec![b'A'; large_data_size]);
-        let id3 = "msg-large-1".to_string();
+        let id3 = Offset::String(StringOffset::new("msg-large-1".to_string(), 0));
         expected_ids.push(id3.clone());
         wal_tx
             .send(SegmentWriteMessage::WriteData {
@@ -409,7 +412,7 @@ mod tests {
             .unwrap();
 
         let large_data2 = Bytes::from(vec![b'B'; large_data_size]);
-        let id4 = "msg-large-2".to_string();
+        let id4 = Offset::String(StringOffset::new("msg-large-2".to_string(), 0));
         expected_ids.push(id4.clone());
         wal_tx
             .send(SegmentWriteMessage::WriteData {
@@ -419,7 +422,7 @@ mod tests {
             .await
             .unwrap();
 
-        let id5 = "msg-005-rotated".to_string();
+        let id5 = Offset::String(StringOffset::new("msg-005-rotated".to_string(), 0));
         let data5 = Bytes::from("data after rotation");
         expected_ids.push(id5.clone());
         wal_tx
@@ -430,7 +433,7 @@ mod tests {
             .await
             .unwrap();
 
-        let id6 = "msg-006-rotated".to_string();
+        let id6 = Offset::String(StringOffset::new("msg-006-rotated".to_string(), 0));
         let data6 = Bytes::from(" more data after rotation");
         expected_ids.push(id6.clone());
         wal_tx
@@ -458,12 +461,16 @@ mod tests {
             received_ids.push(result);
         }
 
-        received_ids.sort();
-        expected_ids.sort();
+        // We can't sort Offset values directly, so we'll just check that we received the same number of IDs
         assert_eq!(
-            received_ids, expected_ids,
-            "Mismatch between expected and received successful IDs"
+            received_ids.len(), expected_ids.len(),
+            "Mismatch between expected and received successful IDs count"
         );
+
+        // Check that each expected ID is in the received IDs
+        for expected_id in expected_ids {
+            assert!(received_ids.contains(&expected_id), "Missing expected ID in received IDs");
+        }
 
         let mut files: Vec<_> = fs::read_dir(&base_path)
             .unwrap()
@@ -530,7 +537,7 @@ mod tests {
             .await
             .expect("Failed to start WAL service");
 
-        let id1 = Some("flush-test-1".to_string());
+        let id1 = Some(Offset::String(StringOffset::new("flush-test-1".to_string(), 0)));
         let data1 = Bytes::from("Data to be flushed");
         wal_tx
             .send(SegmentWriteMessage::WriteData {
@@ -600,7 +607,7 @@ mod tests {
             .expect("Failed to start WAL service");
 
         // Send some data to the WAL
-        let id1 = Some("msg-001".to_string());
+        let id1 = Some(Offset::String(StringOffset::new("msg-001".to_string(), 0)));
         let data1 = Bytes::from("data before rotation");
         wal_tx
             .send(SegmentWriteMessage::WriteData {
@@ -617,7 +624,7 @@ mod tests {
             .unwrap();
 
         // Send more data after rotation
-        let id2 = Some("msg-002".to_string());
+        let id2 = Some(Offset::String(StringOffset::new("msg-002".to_string(), 0)));
         let data2 = Bytes::from("data after rotation");
         wal_tx
             .send(SegmentWriteMessage::WriteData {

--- a/rust/numaflow-core/src/reduce/wal/segment/append.rs
+++ b/rust/numaflow-core/src/reduce/wal/segment/append.rs
@@ -24,8 +24,8 @@ const ROTATE_IF_STALE_DURATION: chrono::Duration = chrono::Duration::seconds(30)
 pub(crate) enum SegmentWriteMessage {
     /// Writes the given payload to the WAL.
     WriteData {
-        /// Unique ID of the payload. Useful to detect write failures.
-        id: Option<Offset>,
+        /// Unique offset of the payload. Useful to detect write failures.
+        offset: Option<Offset>,
         /// Data to be written on do the WAL.
         data: Bytes,
     },
@@ -133,7 +133,7 @@ impl SegmentWriteActor {
     /// we should exit upon errors.
     async fn handle_message(&mut self, msg: SegmentWriteMessage) -> WalResult<()> {
         match msg {
-            SegmentWriteMessage::WriteData { id, data } => {
+            SegmentWriteMessage::WriteData { offset: id, data } => {
                 self.write_data(data).await?;
                 // we need to respond only if ID is provided
                 if let Some(id) = id {
@@ -382,7 +382,7 @@ mod tests {
         expected_ids.push(id1.clone());
         wal_tx
             .send(SegmentWriteMessage::WriteData {
-                id: Some(id1),
+                offset: Some(id1),
                 data: data1.clone(),
             })
             .await
@@ -393,7 +393,7 @@ mod tests {
         expected_ids.push(id2.clone());
         wal_tx
             .send(SegmentWriteMessage::WriteData {
-                id: Some(id2),
+                offset: Some(id2),
                 data: data2.clone(),
             })
             .await
@@ -405,7 +405,7 @@ mod tests {
         expected_ids.push(id3.clone());
         wal_tx
             .send(SegmentWriteMessage::WriteData {
-                id: Some(id3),
+                offset: Some(id3),
                 data: large_data1.clone(),
             })
             .await
@@ -416,7 +416,7 @@ mod tests {
         expected_ids.push(id4.clone());
         wal_tx
             .send(SegmentWriteMessage::WriteData {
-                id: Some(id4),
+                offset: Some(id4),
                 data: large_data2.clone(),
             })
             .await
@@ -427,7 +427,7 @@ mod tests {
         expected_ids.push(id5.clone());
         wal_tx
             .send(SegmentWriteMessage::WriteData {
-                id: Some(id5),
+                offset: Some(id5),
                 data: data5.clone(),
             })
             .await
@@ -438,7 +438,7 @@ mod tests {
         expected_ids.push(id6.clone());
         wal_tx
             .send(SegmentWriteMessage::WriteData {
-                id: Some(id6),
+                offset: Some(id6),
                 data: data6.clone(),
             })
             .await
@@ -548,7 +548,7 @@ mod tests {
         let data1 = Bytes::from("Data to be flushed");
         wal_tx
             .send(SegmentWriteMessage::WriteData {
-                id: id1.clone(),
+                offset: id1.clone(),
                 data: data1.clone(),
             })
             .await
@@ -618,7 +618,7 @@ mod tests {
         let data1 = Bytes::from("data before rotation");
         wal_tx
             .send(SegmentWriteMessage::WriteData {
-                id: id1.clone(),
+                offset: id1.clone(),
                 data: data1.clone(),
             })
             .await
@@ -635,7 +635,7 @@ mod tests {
         let data2 = Bytes::from("data after rotation");
         wal_tx
             .send(SegmentWriteMessage::WriteData {
-                id: id2.clone(),
+                offset: id2.clone(),
                 data: data2.clone(),
             })
             .await

--- a/rust/numaflow-core/src/reduce/wal/segment/compactor.rs
+++ b/rust/numaflow-core/src/reduce/wal/segment/compactor.rs
@@ -446,7 +446,7 @@ impl ShouldRetain for UnalignedCompaction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::message::{Message, MessageID};
+    use crate::message::{Message, MessageID, Offset, StringOffset};
     use crate::shared::grpc::prost_timestamp_from_utc;
     use bytes::Bytes;
     use chrono::TimeZone;
@@ -690,14 +690,14 @@ mod tests {
             .unwrap();
 
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some("gc1".to_string()),
+            id: Some(Offset::String(StringOffset::new("gc1".to_string(), 0))),
             data: bytes::Bytes::from(prost::Message::encode_to_vec(&gc_event_1)),
         })
         .await
         .unwrap();
 
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some("gc2".to_string()),
+            id: Some(Offset::String(StringOffset::new("gc2".to_string(), 0))),
             data: bytes::Bytes::from(prost::Message::encode_to_vec(&gc_event_2)),
         })
         .await
@@ -748,7 +748,7 @@ mod tests {
 
             let proto_message: Bytes = message.try_into().unwrap();
             tx.send(SegmentWriteMessage::WriteData {
-                id: Some(format!("msg-{}", i)),
+                id: Some(Offset::String(StringOffset::new(format!("msg-{}", i), 0))),
                 data: proto_message,
             })
             .await
@@ -899,7 +899,7 @@ mod tests {
         // Write the messages to the WAL
         let before_proto: Bytes = before_message.try_into().unwrap();
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some("msg-1".to_string()),
+            id: Some(Offset::String(StringOffset::new("msg-1".to_string(), 0))),
             data: before_proto,
         })
         .await
@@ -907,7 +907,7 @@ mod tests {
 
         let after_proto: Bytes = after_message.try_into().unwrap();
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some("msg-2".to_string()),
+            id: Some(Offset::String(StringOffset::new("msg-2".to_string(), 0))),
             data: after_proto,
         })
         .await
@@ -1098,7 +1098,10 @@ mod tests {
         {
             let proto: Bytes = message.clone().try_into().unwrap();
             tx.send(SegmentWriteMessage::WriteData {
-                id: Some(format!("msg-{}", i + 1)),
+                id: Some(Offset::String(StringOffset::new(
+                    format!("msg-{}", i + 1),
+                    0,
+                ))),
                 data: proto,
             })
             .await

--- a/rust/numaflow-core/src/reduce/wal/segment/compactor.rs
+++ b/rust/numaflow-core/src/reduce/wal/segment/compactor.rs
@@ -808,4 +808,371 @@ mod tests {
             "Expected 980 messages to remain after compaction"
         );
     }
+
+    #[tokio::test]
+    async fn test_compact_with_replay_aligned() -> WalResult<()> {
+        // Create a temporary directory for the test
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().to_path_buf();
+
+        // Create WAL directories
+        fs::create_dir_all(path.join(WalType::Gc.to_string())).unwrap();
+        fs::create_dir_all(path.join(WalType::Data.to_string())).unwrap();
+        fs::create_dir_all(path.join(WalType::Compact.to_string())).unwrap();
+
+        // Create GC WAL with test events
+        let gc_wal = AppendOnlyWal::new(
+            WalType::Gc,
+            path.clone(),
+            100,  // max_file_size_mb
+            1000, // flush_interval_ms
+            100,  // channel_buffer_size
+        )
+        .await?;
+
+        // Create a GC event with a specific end time
+        let gc_end = Utc.with_ymd_and_hms(2025, 4, 1, 1, 0, 10).unwrap();
+        let gc_event = GcEvent {
+            end_time: Some(prost_timestamp_from_utc(gc_end)),
+            ..Default::default()
+        };
+
+        // Write the GC event to the WAL
+        let (tx, rx) = mpsc::channel(100);
+        let (_result_rx, writer_handle) = gc_wal.streaming_write(ReceiverStream::new(rx)).await?;
+
+        let mut buf = Vec::new();
+        prost::Message::encode(&gc_event, &mut buf)
+            .map_err(|e| format!("Failed to encode GC event: {e}"))?;
+        tx.send(SegmentWriteMessage::WriteData {
+            id: None,
+            data: Bytes::from(buf),
+        })
+        .await
+        .map_err(|e| format!("Failed to send data: {e}"))?;
+
+        // Drop the sender to close the channel
+        drop(tx);
+        writer_handle
+            .await
+            .map_err(|e| format!("Writer failed: {e}"))??;
+
+        // Create segment WAL with test messages
+        let segment_wal = AppendOnlyWal::new(
+            WalType::Data,
+            path.clone(),
+            100,  // max_file_size_mb
+            1000, // flush_interval_ms
+            100,  // channel_buffer_size
+        )
+        .await?;
+
+        // Create messages with different event times
+        let (tx, rx) = mpsc::channel(100);
+        let (_result_rx, writer_handle) =
+            segment_wal.streaming_write(ReceiverStream::new(rx)).await?;
+
+        // Message with event time before the GC end time (should be filtered out)
+        let before_time = Utc.with_ymd_and_hms(2025, 4, 1, 0, 59, 0).unwrap();
+        let mut before_message = Message::default();
+        before_message.event_time = before_time;
+        before_message.keys = Arc::from(vec!["test-key".to_string()]);
+        before_message.value = bytes::Bytes::from(vec![1, 2, 3]);
+        before_message.id = MessageID {
+            vertex_name: "test-vertex".to_string().into(),
+            offset: "1".to_string().into(),
+            index: 0,
+        };
+
+        // Message with event time after the GC end time (should be retained)
+        let after_time = Utc.with_ymd_and_hms(2025, 4, 1, 1, 30, 0).unwrap();
+        let mut after_message = Message::default();
+        after_message.event_time = after_time;
+        after_message.keys = Arc::from(vec!["test-key".to_string()]);
+        after_message.value = bytes::Bytes::from(vec![4, 5, 6]);
+        after_message.id = MessageID {
+            vertex_name: "test-vertex".to_string().into(),
+            offset: "2".to_string().into(),
+            index: 0,
+        };
+
+        // Write the messages to the WAL
+        let before_proto: Bytes = before_message.try_into().unwrap();
+        tx.send(SegmentWriteMessage::WriteData {
+            id: Some("msg-1".to_string()),
+            data: before_proto,
+        })
+        .await
+        .map_err(|e| format!("Failed to send data: {e}"))?;
+
+        let after_proto: Bytes = after_message.try_into().unwrap();
+        tx.send(SegmentWriteMessage::WriteData {
+            id: Some("msg-2".to_string()),
+            data: after_proto,
+        })
+        .await
+        .map_err(|e| format!("Failed to send data: {e}"))?;
+
+        // Drop the sender to close the channel
+        drop(tx);
+        writer_handle
+            .await
+            .map_err(|e| format!("Writer failed: {e}"))??;
+
+        // Create a compactor with aligned window kind
+        let compactor = Compactor::new(
+            path.clone(),
+            WindowKind::Aligned,
+            100,  // max_file_size_mb
+            1000, // flush_interval_ms
+            100,  // channel_buffer_size
+        )
+        .await?;
+
+        // Create a channel to receive replayed messages
+        let (replay_tx, mut replay_rx) = mpsc::channel(100);
+
+        // Call compact_with_replay
+        let handle = compactor.compact_with_replay(replay_tx).await?;
+
+        // Wait for compaction to complete
+        handle
+            .await
+            .map_err(|e| format!("Compaction failed: {e}"))??;
+
+        // Count the number of messages received through the replay channel
+        let mut replayed_count = 0;
+        while let Ok(data) = replay_rx.try_recv() {
+            let msg: numaflow_pb::objects::isb::Message = prost::Message::decode(data)
+                .map_err(|e| format!("Failed to decode message: {e}"))?;
+
+            // Verify that the message has an event time after the GC end time
+            if let Some(header) = msg.header {
+                if let Some(message_info) = header.message_info {
+                    let event_time = utc_from_timestamp(message_info.event_time);
+                    assert!(
+                        event_time > gc_end,
+                        "Found message with event_time <= gc_end"
+                    );
+                }
+            }
+            replayed_count += 1;
+        }
+
+        // Verify that only one message was replayed (the one with event time after GC end time)
+        assert_eq!(
+            replayed_count, 1,
+            "Expected only one message to be replayed"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compact_with_replay_unaligned() -> WalResult<()> {
+        // Create a temporary directory for the test
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().to_path_buf();
+
+        // Create WAL directories
+        fs::create_dir_all(path.join(WalType::Gc.to_string())).unwrap();
+        fs::create_dir_all(path.join(WalType::Data.to_string())).unwrap();
+        fs::create_dir_all(path.join(WalType::Compact.to_string())).unwrap();
+
+        // Create GC WAL with test events
+        let gc_wal = AppendOnlyWal::new(
+            WalType::Gc,
+            path.clone(),
+            100,  // max_file_size_mb
+            1000, // flush_interval_ms
+            100,  // channel_buffer_size
+        )
+        .await?;
+
+        // Create GC events with different keys and end times
+        let (tx, rx) = mpsc::channel(100);
+        let (_result_rx, writer_handle) = gc_wal.streaming_write(ReceiverStream::new(rx)).await?;
+
+        // GC event for key1:key2 with end time
+        let gc_end_1 = Utc.with_ymd_and_hms(2025, 4, 1, 1, 0, 10).unwrap();
+        let gc_event_1 = GcEvent {
+            end_time: Some(prost_timestamp_from_utc(gc_end_1)),
+            keys: vec!["key1".to_string(), "key2".to_string()],
+            ..Default::default()
+        };
+
+        // GC event for key3:key4 with a different end time
+        let gc_end_2 = Utc.with_ymd_and_hms(2025, 4, 1, 2, 0, 0).unwrap();
+        let gc_event_2 = GcEvent {
+            end_time: Some(prost_timestamp_from_utc(gc_end_2)),
+            keys: vec!["key3".to_string(), "key4".to_string()],
+            ..Default::default()
+        };
+
+        // Write the GC events to the WAL
+        for event in [gc_event_1, gc_event_2] {
+            let mut buf = Vec::new();
+            prost::Message::encode(&event, &mut buf)
+                .map_err(|e| format!("Failed to encode GC event: {e}"))?;
+            tx.send(SegmentWriteMessage::WriteData {
+                id: None,
+                data: Bytes::from(buf),
+            })
+            .await
+            .map_err(|e| format!("Failed to send data: {e}"))?;
+        }
+
+        // Drop the sender to close the channel
+        drop(tx);
+        writer_handle
+            .await
+            .map_err(|e| format!("Writer failed: {e}"))??;
+
+        // Create segment WAL with test messages
+        let segment_wal = AppendOnlyWal::new(
+            WalType::Data,
+            path.clone(),
+            100,  // max_file_size_mb
+            1000, // flush_interval_ms
+            100,  // channel_buffer_size
+        )
+        .await?;
+
+        // Create messages with different keys and event times
+        let (tx, rx) = mpsc::channel(100);
+        let (_result_rx, writer_handle) =
+            segment_wal.streaming_write(ReceiverStream::new(rx)).await?;
+
+        // Message 1: key1:key2 with event time before gc_end_1 (should be filtered out)
+        let before_time_1 = Utc.with_ymd_and_hms(2025, 4, 1, 0, 59, 0).unwrap();
+        let mut message_1 = Message::default();
+        message_1.event_time = before_time_1;
+        message_1.keys = Arc::from(vec!["key1".to_string(), "key2".to_string()]);
+        message_1.value = bytes::Bytes::from(vec![1, 2, 3]);
+        message_1.id = MessageID {
+            vertex_name: "test-vertex".to_string().into(),
+            offset: "1".to_string().into(),
+            index: 0,
+        };
+
+        // Message 2: key1:key2 with event time after gc_end_1 (should be retained)
+        let after_time_1 = Utc.with_ymd_and_hms(2025, 4, 1, 1, 30, 0).unwrap();
+        let mut message_2 = Message::default();
+        message_2.event_time = after_time_1;
+        message_2.keys = Arc::from(vec!["key1".to_string(), "key2".to_string()]);
+        message_2.value = bytes::Bytes::from(vec![4, 5, 6]);
+        message_2.id = MessageID {
+            vertex_name: "test-vertex".to_string().into(),
+            offset: "2".to_string().into(),
+            index: 0,
+        };
+
+        // Message 3: key3:key4 with event time before gc_end_2 (should be filtered out)
+        let before_time_2 = Utc.with_ymd_and_hms(2025, 4, 1, 1, 30, 0).unwrap();
+        let mut message_3 = Message::default();
+        message_3.event_time = before_time_2;
+        message_3.keys = Arc::from(vec!["key3".to_string(), "key4".to_string()]);
+        message_3.value = bytes::Bytes::from(vec![7, 8, 9]);
+        message_3.id = MessageID {
+            vertex_name: "test-vertex".to_string().into(),
+            offset: "3".to_string().into(),
+            index: 0,
+        };
+
+        // Message 4: key3:key4 with event time after gc_end_2 (should be retained)
+        let after_time_2 = Utc.with_ymd_and_hms(2025, 4, 1, 2, 30, 0).unwrap();
+        let mut message_4 = Message::default();
+        message_4.event_time = after_time_2;
+        message_4.keys = Arc::from(vec!["key3".to_string(), "key4".to_string()]);
+        message_4.value = bytes::Bytes::from(vec![10, 11, 12]);
+        message_4.id = MessageID {
+            vertex_name: "test-vertex".to_string().into(),
+            offset: "4".to_string().into(),
+            index: 0,
+        };
+
+        // Write the messages to the WAL
+        for (i, message) in [message_1, message_2, message_3, message_4]
+            .iter()
+            .enumerate()
+        {
+            let proto: Bytes = message.clone().try_into().unwrap();
+            tx.send(SegmentWriteMessage::WriteData {
+                id: Some(format!("msg-{}", i + 1)),
+                data: proto,
+            })
+            .await
+            .map_err(|e| format!("Failed to send data: {e}"))?;
+        }
+
+        // Drop the sender to close the channel
+        drop(tx);
+        writer_handle
+            .await
+            .map_err(|e| format!("Writer failed: {e}"))??;
+
+        // Create a compactor with unaligned window kind
+        let compactor = Compactor::new(
+            path.clone(),
+            WindowKind::Unaligned,
+            100,  // max_file_size_mb
+            1000, // flush_interval_ms
+            100,  // channel_buffer_size
+        )
+        .await?;
+
+        // Create a channel to receive replayed messages
+        let (replay_tx, mut replay_rx) = mpsc::channel(100);
+
+        // Call compact_with_replay
+        let handle = compactor.compact_with_replay(replay_tx).await?;
+
+        // Wait for compaction to complete
+        handle
+            .await
+            .map_err(|e| format!("Compaction failed: {e}"))??;
+
+        // Count the number of messages received through the replay channel
+        let mut replayed_count = 0;
+        let mut key1_key2_count = 0;
+        let mut key3_key4_count = 0;
+
+        while let Ok(data) = replay_rx.try_recv() {
+            let msg: numaflow_pb::objects::isb::Message = prost::Message::decode(data)
+                .map_err(|e| format!("Failed to decode message: {e}"))?;
+
+            // Verify that the message has an event time after the appropriate GC end time
+            if let Some(header) = msg.header {
+                let key_str = header.keys.join(WAL_KEY_SEPERATOR);
+
+                if key_str == "key1:key2" {
+                    key1_key2_count += 1;
+                    if let Some(message_info) = header.message_info.as_ref() {
+                        let event_time = utc_from_timestamp(message_info.event_time);
+                        assert!(
+                            event_time > gc_end_1,
+                            "Found key1:key2 message with event_time <= gc_end_1"
+                        );
+                    }
+                } else if key_str == "key3:key4" {
+                    key3_key4_count += 1;
+                    if let Some(message_info) = header.message_info.as_ref() {
+                        let event_time = utc_from_timestamp(message_info.event_time);
+                        assert!(
+                            event_time > gc_end_2,
+                            "Found key3:key4 message with event_time <= gc_end_2"
+                        );
+                    }
+                }
+            }
+            replayed_count += 1;
+        }
+
+        // Verify that only two messages were replayed (one for each key combination)
+        assert_eq!(replayed_count, 2, "Expected two messages to be replayed");
+        assert_eq!(key1_key2_count, 1, "Expected one key1:key2 message");
+        assert_eq!(key3_key4_count, 1, "Expected one key3:key4 message");
+
+        Ok(())
+    }
 }

--- a/rust/numaflow-core/src/reduce/wal/segment/compactor.rs
+++ b/rust/numaflow-core/src/reduce/wal/segment/compactor.rs
@@ -228,7 +228,7 @@ impl Compactor {
                         // Send the message to the compaction WAL
                         wal_tx
                             .send(SegmentWriteMessage::WriteData {
-                                id: None,
+                                offset: None,
                                 data: data.clone(),
                             })
                             .await
@@ -238,7 +238,7 @@ impl Compactor {
 
                         // if replay_tx is provided, send the message to it.
                         // This is used to replay the compacted data during boot up
-                        if let Some(tx) = replay_tx.clone() {
+                        if let Some(tx) = &replay_tx {
                             tx.send(data).await.map_err(|e| {
                                 format!("Failed to send message to replay channel: {}", e)
                             })?;
@@ -517,7 +517,7 @@ mod tests {
             prost::Message::encode(&event, &mut buf)
                 .map_err(|e| format!("Failed to encode GC event: {e}"))?;
             tx.send(SegmentWriteMessage::WriteData {
-                id: None,
+                offset: None,
                 data: Bytes::from(buf),
             })
             .await
@@ -612,7 +612,7 @@ mod tests {
             prost::Message::encode(&event, &mut buf)
                 .map_err(|e| format!("Failed to encode GC event: {e}"))?;
             tx.send(SegmentWriteMessage::WriteData {
-                id: None,
+                offset: None,
                 data: Bytes::from(buf),
             })
             .await
@@ -690,14 +690,14 @@ mod tests {
             .unwrap();
 
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some(Offset::String(StringOffset::new("gc1".to_string(), 0))),
+            offset: Some(Offset::String(StringOffset::new("gc1".to_string(), 0))),
             data: bytes::Bytes::from(prost::Message::encode_to_vec(&gc_event_1)),
         })
         .await
         .unwrap();
 
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some(Offset::String(StringOffset::new("gc2".to_string(), 0))),
+            offset: Some(Offset::String(StringOffset::new("gc2".to_string(), 0))),
             data: bytes::Bytes::from(prost::Message::encode_to_vec(&gc_event_2)),
         })
         .await
@@ -748,7 +748,7 @@ mod tests {
 
             let proto_message: Bytes = message.try_into().unwrap();
             tx.send(SegmentWriteMessage::WriteData {
-                id: Some(Offset::String(StringOffset::new(format!("msg-{}", i), 0))),
+                offset: Some(Offset::String(StringOffset::new(format!("msg-{}", i), 0))),
                 data: proto_message,
             })
             .await
@@ -854,7 +854,7 @@ mod tests {
         prost::Message::encode(&gc_event, &mut buf)
             .map_err(|e| format!("Failed to encode GC event: {e}"))?;
         tx.send(SegmentWriteMessage::WriteData {
-            id: None,
+            offset: None,
             data: Bytes::from(buf),
         })
         .await
@@ -908,7 +908,7 @@ mod tests {
         // Write the messages to the WAL
         let before_proto: Bytes = before_message.try_into().unwrap();
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some(Offset::String(StringOffset::new("msg-1".to_string(), 0))),
+            offset: Some(Offset::String(StringOffset::new("msg-1".to_string(), 0))),
             data: before_proto,
         })
         .await
@@ -916,7 +916,7 @@ mod tests {
 
         let after_proto: Bytes = after_message.try_into().unwrap();
         tx.send(SegmentWriteMessage::WriteData {
-            id: Some(Offset::String(StringOffset::new("msg-2".to_string(), 0))),
+            offset: Some(Offset::String(StringOffset::new("msg-2".to_string(), 0))),
             data: after_proto,
         })
         .await
@@ -1036,7 +1036,7 @@ mod tests {
             prost::Message::encode(&event, &mut buf)
                 .map_err(|e| format!("Failed to encode GC event: {e}"))?;
             tx.send(SegmentWriteMessage::WriteData {
-                id: None,
+                offset: None,
                 data: Bytes::from(buf),
             })
             .await
@@ -1122,7 +1122,7 @@ mod tests {
         {
             let proto: Bytes = message.clone().try_into().unwrap();
             tx.send(SegmentWriteMessage::WriteData {
-                id: Some(Offset::String(StringOffset::new(
+                offset: Some(Offset::String(StringOffset::new(
                     format!("msg-{}", i + 1),
                     0,
                 ))),

--- a/rust/numaflow-core/src/reduce/wal/segment/replay.rs
+++ b/rust/numaflow-core/src/reduce/wal/segment/replay.rs
@@ -17,7 +17,7 @@ use tracing::{debug, info};
 
 /// Segment Entry as recorded in the WAL.
 #[derive(Debug)]
-pub(crate) enum SegmentEntry {
+pub(super) enum SegmentEntry {
     /// Data entry in the Segment
     DataEntry { size: u64, data: Bytes },
     /// The file has been switched
@@ -30,14 +30,14 @@ pub(crate) enum SegmentEntry {
 
 /// Replay the WAL in-order.
 #[derive(Debug, Clone)]
-pub(crate) struct ReplayWal {
+pub(super) struct ReplayWal {
     wal_type: WalType,
     base_path: PathBuf,
 }
 
 impl ReplayWal {
     /// Creates a new Replayer for the WAL.
-    pub(crate) fn new(wal_type: WalType, base_path: PathBuf) -> Self {
+    pub(super) fn new(wal_type: WalType, base_path: PathBuf) -> Self {
         Self {
             wal_type,
             base_path,
@@ -46,7 +46,7 @@ impl ReplayWal {
 
     /// Reads the WAL files and streams it via the stream. Stream will be closed once all the
     /// entries are read.
-    pub(crate) fn streaming_read(
+    pub(super) fn streaming_read(
         self,
     ) -> WalResult<(ReceiverStream<SegmentEntry>, JoinHandle<WalResult<()>>)> {
         let mut files: Vec<PathBuf> = list_files(&self.wal_type, self.base_path.clone());


### PR DESCRIPTION
To avoid an extra read after replay on bootup, we can replay while compacting.

- [x] create a new method called compact_with_replay and take an Option<tx>
- [x] make replay_wal private
- [x] make Offset bytes
