### PR TITLE
fix: honour retry config in case of Pipeline in Rust

### DIFF
--- a/rust/numaflow-core/src/config/pipeline.rs
+++ b/rust/numaflow-core/src/config/pipeline.rs
@@ -386,7 +386,7 @@ impl PipelineConfig {
             VertexType::Sink(SinkVtxConfig {
                 sink_config: SinkConfig {
                     sink_type: SinkType::primary_sinktype(&sink)?,
-                    retry_config: None,
+                    retry_config: sink.retry_strategy.clone().map(|retry| retry.into()),
                 },
                 fb_sink_config,
                 serving_store_config,

--- a/rust/numaflow-core/src/config/pipeline.rs
+++ b/rust/numaflow-core/src/config/pipeline.rs
@@ -666,7 +666,7 @@ mod tests {
     use numaflow_pulsar::source::PulsarSourceConfig;
 
     use super::*;
-    use crate::config::components::sink::{BlackholeConfig, LogConfig, SinkType};
+    use crate::config::components::sink::{BlackholeConfig, LogConfig, RetryConfig, SinkType};
     use crate::config::components::source::{GeneratorConfig, SourceType};
     use crate::config::pipeline::map::{MapType, UserDefinedConfig};
 
@@ -753,7 +753,7 @@ mod tests {
             vertex_type_config: VertexType::Sink(SinkVtxConfig {
                 sink_config: SinkConfig {
                     sink_type: SinkType::Blackhole(BlackholeConfig {}),
-                    retry_config: None,
+                    retry_config: Some(RetryConfig::default()),
                 },
                 fb_sink_config: None,
                 serving_store_config: Some(ServingStoreType::Nats(NatsStoreConfig {


### PR DESCRIPTION
fixes #2637 


```
    - name: out
      containerTemplate:
        env:
          - name: NUMAFLOW_RUNTIME
            value: "rust"
      scale:
        min: 1
      sink:
        retryStrategy:
          backoff:
            interval: 1s
            steps: 100
        udsink:

```
```
    vertex_type_config: Sink(
        SinkVtxConfig {
            sink_config: SinkConfig {
                sink_type: UserDefined(
                    UserDefinedConfig {
                        grpc_max_message_size: 67108864,
                        socket_path: "/var/run/numaflow/sink.sock",
                        server_info_path: "/var/run/numaflow/sinker-server-info",
                    },
                ),
                retry_config: Some(
                    RetryConfig {
                        sink_max_retry_attempts: 100,
                        sink_retry_interval_in_ms: 1000,
                        sink_retry_on_fail_strategy: Retry,
                        sink_default_retry_strategy: RetryStrategy {
                            backoff: Some(
                                Backoff {
                                    interval: Some(
                                        1ms,
                                    ),
                                    steps: Some(
                                        65535,
                                    ),
                                },
                            ),
                            on_failure: Some(
                                "retry",
                            ),
                        },
                    },
                ),         
            },
            fb_sink_config: None,
            serving_store_config: None,
        },
    ),
```