### PR TITLE
chore: enhance error logging when the server is not started in `udcontainer`

### DIFF
--- a/docs/user-guide/FAQ.md
+++ b/docs/user-guide/FAQ.md
@@ -1,0 +1,35 @@
+# Frequently Asked Questions
+
+Welcome to the Numaflow FAQ! Here you'll find answers to common questions about getting started, compatibility, troubleshooting, and more.
+
+---
+
+## 1. How do I get started with Numaflow?
+
+To get started, follow the [Quickstart Guide](../quick-start.md). It provides step-by-step instructions for setting up a basic Numaflow pipeline.
+
+---
+
+## 2. How can I check SDK compatibility with Numaflow versions?
+
+Refer to the compatibility matrix [here](../user-guide/sdks/compatibility.md) to ensure your SDK version works with your Numaflow deployment.
+
+---
+
+## 3. Where can I learn about the latest releases of Numaflow?
+
+- Visit the [Numaflow Releases page](https://github.com/numaproj/numaflow/releases) for the latest updates.
+- Join our [Slack channel](https://join.slack.com/t/numaproj/shared_invite/zt-19svuv47m-YKHhsQ~~KK9mBv1E7pNzfg) to stay up to date with announcements and community discussions.
+
+---
+
+## 4. I see `Server Info File not ready` log in the numa container. What does this mean?
+
+This message indicates that the server has not started yet. Common reasons include:
+
+- The server was not started correctly in the `udcontainer`.
+- The server is still initializing (for example, the application code is downloading cache files or performing setup tasks).
+
+---
+
+If you have additional questions, please refer to the [documentation](../README.md) or reach out on Slack!

--- a/rust/numaflow-core/src/shared/server_info.rs
+++ b/rust/numaflow-core/src/shared/server_info.rs
@@ -351,7 +351,12 @@ async fn read_server_info(
     // Infinite loop to keep checking until the file is ready
     loop {
         if cln_token.is_cancelled() {
-            return Err(Error::ServerInfo("Operation cancelled".to_string()));
+            return Err(Error::ServerInfo(format!(
+                "Server info file {:?} is not ready. \
+                This indicates that the server is not started correctly in the user-code. \
+            Eg (simple sink in Java, similarly you can refer language specific SDK examples) https://github.com/numaproj/numaflow-java/blob/2aeaafff1c6dec7fd66e018b142ef6fe4ffcf0a9/examples/src/main/java/io/numaproj/numaflow/examples/sink/simple/SimpleSink.java#L23",
+                file_path
+            )));
         }
 
         // Check if the file exists and has content
@@ -390,9 +395,10 @@ async fn read_server_info(
         retry += 1;
         if retry >= 10 {
             // Return an error if the retry limit is reached
-            return Err(Error::ServerInfo(
-                "server-info reading retry exceeded".to_string(),
-            ));
+            return Err(Error::ServerInfo(format!(
+                "server-info reading retry exceeded for file: {:?}",
+                file_path
+            )));
         }
 
         sleep(Duration::from_millis(100)).await; // Sleep before retrying

--- a/rust/numaflow-core/src/shared/server_info.rs
+++ b/rust/numaflow-core/src/shared/server_info.rs
@@ -354,7 +354,7 @@ async fn read_server_info(
             return Err(Error::ServerInfo(format!(
                 "Server info file {:?} is not ready. \
                 This indicates that the server has not started. \
-                For more details https://github.com/numaproj/numaflow/discussions/2655",
+                For more details https://numaflow.numaproj.io/user-guide/FAQ/#4-i-see-server-info-file-not-ready-log-in-the-numa-container-what-does-this-mean",
                 file_path
             )));
         }

--- a/rust/numaflow-core/src/shared/server_info.rs
+++ b/rust/numaflow-core/src/shared/server_info.rs
@@ -353,8 +353,8 @@ async fn read_server_info(
         if cln_token.is_cancelled() {
             return Err(Error::ServerInfo(format!(
                 "Server info file {:?} is not ready. \
-                This indicates that the server is not started correctly in the user-code. \
-            Eg (simple sink in Java, similarly you can refer language specific SDK examples) https://github.com/numaproj/numaflow-java/blob/2aeaafff1c6dec7fd66e018b142ef6fe4ffcf0a9/examples/src/main/java/io/numaproj/numaflow/examples/sink/simple/SimpleSink.java#L23",
+                This indicates that the server has not started. \
+                For more details https://github.com/numaproj/numaflow/discussions/2655",
                 file_path
             )));
         }

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/partials/CollapsableError/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/partials/CollapsableError/index.tsx
@@ -24,7 +24,7 @@ const cleanText = (text: string) => {
 
 const highlightFilePaths = (rawText: string) => {
   const text = cleanText(rawText);
-  // highlights path part of URL including {http,https} protocols and line anchors as well
+  // highlights file paths including {http,https} protocols and line anchors of URLs
   const filePathRegex = /(https?:\/\/[^\s]+(?:#[^\s]+)?)|((?:\/[^\s]+)+\.[a-zA-Z0-9:]+(?:#[^\s]+)?)|(\bat\s+[^\n]+)/g;
   const exclusionList = ["/google.rpc.DebugInfo", "/debug.Stack"];
 

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/partials/CollapsableError/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/partials/CollapsableError/index.tsx
@@ -24,8 +24,14 @@ const cleanText = (text: string) => {
 
 const highlightFilePaths = (rawText: string) => {
   const text = cleanText(rawText);
-  // highlights file paths including {http,https} protocols and line anchors of URLs
-  const filePathRegex = /(https?:\/\/[^\s]+(?:#[^\s]+)?)|((?:\/[^\s]+)+\.[a-zA-Z0-9:]+(?:#[^\s]+)?)|(\bat\s+[^\n]+)/g;
+  // Note: this regex may not cover all edge cases
+  // but it should work for most common cases
+  // It matches:
+  // - URLs (http/https) with or without anchors
+  // - file paths (e.g. /path/to/file) with or without extensions
+  // - lines starting with "at" (e.g. stack traces)
+  const filePathRegex =
+    /(https?:\/\/[^\s]+(?:#[^\s]+)?)|((?:\/[^\s]+)+)|(\bat\s+[^\n]+)/g;
   const exclusionList = ["/google.rpc.DebugInfo", "/debug.Stack"];
 
   return text.split(filePathRegex).map((part, index) => {

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/partials/CollapsableError/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/partials/CollapsableError/index.tsx
@@ -24,7 +24,8 @@ const cleanText = (text: string) => {
 
 const highlightFilePaths = (rawText: string) => {
   const text = cleanText(rawText);
-  const filePathRegex = /((?:\/[^\s]+)+\.[a-zA-Z0-9:]+)|(\bat\s+[^\n]+)/g;
+  // highlights path part of URL including {http,https} protocols and line anchors as well
+  const filePathRegex = /(https?:\/\/[^\s]+(?:#[^\s]+)?)|((?:\/[^\s]+)+\.[a-zA-Z0-9:]+(?:#[^\s]+)?)|(\bat\s+[^\n]+)/g;
   const exclusionList = ["/google.rpc.DebugInfo", "/debug.Stack"];
 
   return text.split(filePathRegex).map((part, index) => {

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/partials/CollapsableError/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/partials/CollapsableError/index.tsx
@@ -30,8 +30,7 @@ const highlightFilePaths = (rawText: string) => {
   // - URLs (http/https) with or without anchors
   // - file paths (e.g. /path/to/file) with or without extensions
   // - lines starting with "at" (e.g. stack traces)
-  const filePathRegex =
-    /(https?:\/\/[^\s]+(?:#[^\s]+)?)|((?:\/[^\s]+)+)|(\bat\s+[^\n]+)/g;
+  const filePathRegex = /(https?:\/\/[^\s]+(?:#[^\s]+)?)|((?:\/[^\s]+)+)|(\bat\s+[^\n]+)/g;
   const exclusionList = ["/google.rpc.DebugInfo", "/debug.Stack"];
 
   return text.split(filePathRegex).map((part, index) => {


### PR DESCRIPTION
fixes #2634 

### Changes
1. Error message mentions that the server is not started correctly
2. Include `http/s` protocols, line anchors in URLs, and file paths without extensions as well while highlighting in the UI


### Testing

#### UI Logs Tab

```
2025-05-19T06:49:53.043111Z ERROR numaflow_core: Error running monovertex e=ServerInfo("Server info file \"/var/run/numaflow/sinker-server-info\" is not ready. This indicates that the server is not started correctly in the user-code. Eg (simple sink in Java, similarly you can refer language specific SDK examples) https://github.com/numaproj/numaflow-java/blob/2aeaafff1c6dec7fd66e018b142ef6fe4ffcf0a9/examples/src/main/java/io/numaproj/numaflow/examples/sink/simple/SimpleSink.java#L23")
2025-05-19T06:49:53.043491Z INFO numaflow_core: Gracefully Exiting...
2025-05-19T06:49:53.043598Z INFO numaflow: Exiting...
```

Search `Error running monovertex` or` user-code` for debugging after selecting `Show previous terminated container`

<img width="802" alt="Screenshot 2025-05-19 at 12 23 44 PM" src="https://github.com/user-attachments/assets/5367c7a1-4eba-4401-abbb-9a9821b4aa32" />



#### UI Errors Tab

<img width="1378" alt="Screenshot 2025-05-19 at 3 37 41 PM" src="https://github.com/user-attachments/assets/d36326b2-10a2-4e4c-a623-d71883a268e7" />

