### PR TITLE
chore: Use arm runner for building arm binary in release pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,20 +160,16 @@ jobs:
 
   build-rust-amd64:
     runs-on: ubuntu-24.04
-    defaults:
-      run:
-        working-directory: ./rust
     steps:
       - uses: actions/checkout@v4
       # TODO: Use actions/cache@v4 to cache target/ directory
       - name: Build binary
         run: |
-          cd ../
           docker run -v ./rust/:/app/ -w /app --rm ubuntu:24.04 bash build.sh amd64
       - name: Rename binaries
         run: |
-          cp -pv target/x86_64-unknown-linux-gnu/release/numaflow ./numaflow-rs-linux-amd64
-          cp -pv target/x86_64-unknown-linux-gnu/release/entrypoint ./entrypoint-linux-amd64
+          cp -pv rust/target/x86_64-unknown-linux-gnu/release/numaflow ./numaflow-rs-linux-amd64
+          cp -pv rust/target/x86_64-unknown-linux-gnu/release/entrypoint ./entrypoint-linux-amd64
       - name: Verify numaflow binary is Statically Linked
         run: |
           file ./numaflow-rs-linux-amd64
@@ -186,13 +182,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: numaflow-rs-linux-amd64
-          path: rust/numaflow-rs-linux-amd64
+          path: numaflow-rs-linux-amd64
           if-no-files-found: error
       - name: Upload entrypoint binary
         uses: actions/upload-artifact@v4
         with:
           name: entrypoint-linux-amd64
-          path: rust/entrypoint-linux-amd64
+          path: entrypoint-linux-amd64
           if-no-files-found: error
 
   e2e-tests:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -42,20 +42,16 @@ jobs:
 
   build-rust-amd64:
     runs-on: ubuntu-24.04
-    defaults:
-      run:
-        working-directory: ./rust
     steps:
       - uses: actions/checkout@v4
       # TODO: Use actions/cache@v4 to cache target/ directory
       - name: Build binary
         run: |
-          cd ../
           docker run -v ./rust/:/app/ -w /app --rm ubuntu:24.04 bash build.sh amd64
       - name: Rename binaries
         run: |
-          cp -pv target/x86_64-unknown-linux-gnu/release/numaflow ./numaflow-rs-linux-amd64
-          cp -pv target/x86_64-unknown-linux-gnu/release/entrypoint ./entrypoint-linux-amd64
+          cp -pv rust/target/x86_64-unknown-linux-gnu/release/numaflow ./numaflow-rs-linux-amd64
+          cp -pv rust/target/x86_64-unknown-linux-gnu/release/entrypoint ./entrypoint-linux-amd64
       - name: Verify numaflow binary is Statically Linked
         run: |
           file ./numaflow-rs-linux-amd64
@@ -68,43 +64,39 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: numaflow-rs-linux-amd64
-          path: rust/numaflow-rs-linux-amd64
+          path: numaflow-rs-linux-amd64
           if-no-files-found: error
       - name: Upload entrypoint binary
         uses: actions/upload-artifact@v4
         with:
           name: entrypoint-linux-amd64
-          path: rust/entrypoint-linux-amd64
+          path: entrypoint-linux-amd64
           if-no-files-found: error
 
   build-rust-arm64:
     runs-on: ubuntu-24.04-arm
-    defaults:
-      run:
-        working-directory: ./rust
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust Toolchain Target
         run: |
-          echo "targets = ['aarch64-unknown-linux-gnu']" >> rust-toolchain.toml
+          echo "targets = ['aarch64-unknown-linux-gnu']" >> rust/rust-toolchain.toml
       - name: Build binary
         run: |
-          cd ../
           docker run -v ./rust/:/app/ -w /app --rm ubuntu:24.04 bash build.sh aarch64
       - name: Rename binary
         run: |
-          cp -pv target/aarch64-unknown-linux-gnu/release/numaflow numaflow-rs-linux-arm64
-          cp -pv target/aarch64-unknown-linux-gnu/release/entrypoint entrypoint-linux-arm64
+          cp -pv rust/target/aarch64-unknown-linux-gnu/release/numaflow numaflow-rs-linux-arm64
+          cp -pv rust/target/aarch64-unknown-linux-gnu/release/entrypoint entrypoint-linux-arm64
       - name: Upload numaflow binary
         uses: actions/upload-artifact@v4
         with:
           name: numaflow-rs-linux-arm64
-          path: rust/numaflow-rs-linux-arm64
+          path: numaflow-rs-linux-arm64
       - name: Upload entrypoint binary
         uses: actions/upload-artifact@v4
         with:
           name: entrypoint-linux-arm64
-          path: rust/entrypoint-linux-arm64
+          path: entrypoint-linux-arm64
 
   build-push-linux-multi:
     name: Build & push linux/amd64 and linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,23 +45,28 @@ jobs:
         working-directory: ./rust
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
-        with:
-          rustflags: ""
-      - name: Install dependencies
-        run: sudo apt-get install -y protobuf-compiler
       - name: Build binary
-        run: RUSTFLAGS='-C target-feature=+crt-static' cargo build --release --target x86_64-unknown-linux-gnu
-      - name: Rename binary
         run: |
-          cp -pv target/x86_64-unknown-linux-gnu/release/numaflow numaflow-rs-linux-amd64
-          cp -pv target/x86_64-unknown-linux-gnu/release/entrypoint entrypoint-linux-amd64
+          cd ../
+          docker run -v ./rust/:/app/ -w /app --rm ubuntu:24.04 bash build.sh amd64
+      - name: Rename binaries
+        run: |
+          cp -pv target/x86_64-unknown-linux-gnu/release/numaflow ./numaflow-rs-linux-amd64
+          cp -pv target/x86_64-unknown-linux-gnu/release/entrypoint ./entrypoint-linux-amd64
+      - name: Verify numaflow binary is Statically Linked
+        run: |
+          file ./numaflow-rs-linux-amd64
+          file ./numaflow-rs-linux-amd64 | grep -q 'static-pie linked'
+      - name: Verify entrypoint binary is Statically Linked
+        run: |
+          file ./entrypoint-linux-amd64
+          file ./entrypoint-linux-amd64 | grep -q 'static-pie linked'
       - name: Upload numaflow binary
         uses: actions/upload-artifact@v4
         with:
           name: numaflow-rs-linux-amd64
           path: rust/numaflow-rs-linux-amd64
+          if-no-files-found: error
       - name: Upload entrypoint binary
         uses: actions/upload-artifact@v4
         with:
@@ -70,7 +75,7 @@ jobs:
           if-no-files-found: error
 
   build-rust-arm64:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     defaults:
       run:
         working-directory: ./rust
@@ -79,14 +84,10 @@ jobs:
       - name: Update Rust Toolchain Target
         run: |
           echo "targets = ['aarch64-unknown-linux-gnu']" >> rust-toolchain.toml
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
-        with:
-          rustflags: ""
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu protobuf-compiler
       - name: Build binary
-        run: RUSTFLAGS='-C target-feature=+crt-static -C linker=aarch64-linux-gnu-gcc' cargo build --release --target aarch64-unknown-linux-gnu
+        run: |
+          cd ../
+          docker run -v ./rust/:/app/ -w /app --rm ubuntu:24.04 bash build.sh aarch64
       - name: Rename binary
         run: |
           cp -pv target/aarch64-unknown-linux-gnu/release/numaflow numaflow-rs-linux-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,19 +40,15 @@ jobs:
 
   build-rust-amd64:
     runs-on: ubuntu-24.04
-    defaults:
-      run:
-        working-directory: ./rust
     steps:
       - uses: actions/checkout@v4
       - name: Build binary
         run: |
-          cd ../
           docker run -v ./rust/:/app/ -w /app --rm ubuntu:24.04 bash build.sh amd64
       - name: Rename binaries
         run: |
-          cp -pv target/x86_64-unknown-linux-gnu/release/numaflow ./numaflow-rs-linux-amd64
-          cp -pv target/x86_64-unknown-linux-gnu/release/entrypoint ./entrypoint-linux-amd64
+          cp -pv rust/target/x86_64-unknown-linux-gnu/release/numaflow ./numaflow-rs-linux-amd64
+          cp -pv rust/target/x86_64-unknown-linux-gnu/release/entrypoint ./entrypoint-linux-amd64
       - name: Verify numaflow binary is Statically Linked
         run: |
           file ./numaflow-rs-linux-amd64
@@ -65,43 +61,40 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: numaflow-rs-linux-amd64
-          path: rust/numaflow-rs-linux-amd64
+          path: numaflow-rs-linux-amd64
           if-no-files-found: error
       - name: Upload entrypoint binary
         uses: actions/upload-artifact@v4
         with:
           name: entrypoint-linux-amd64
-          path: rust/entrypoint-linux-amd64
+          path: entrypoint-linux-amd64
           if-no-files-found: error
 
   build-rust-arm64:
     runs-on: ubuntu-24.04-arm
-    defaults:
-      run:
-        working-directory: ./rust
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust Toolchain Target
         run: |
-          echo "targets = ['aarch64-unknown-linux-gnu']" >> rust-toolchain.toml
+          echo "targets = ['aarch64-unknown-linux-gnu']" >> rust/rust-toolchain.toml
       - name: Build binary
         run: |
           cd ../
           docker run -v ./rust/:/app/ -w /app --rm ubuntu:24.04 bash build.sh aarch64
       - name: Rename binary
         run: |
-          cp -pv target/aarch64-unknown-linux-gnu/release/numaflow numaflow-rs-linux-arm64
-          cp -pv target/aarch64-unknown-linux-gnu/release/entrypoint entrypoint-linux-arm64
+          cp -pv rust/target/aarch64-unknown-linux-gnu/release/numaflow numaflow-rs-linux-arm64
+          cp -pv rust/target/aarch64-unknown-linux-gnu/release/entrypoint entrypoint-linux-arm64
       - name: Upload numaflow binary
         uses: actions/upload-artifact@v4
         with:
           name: numaflow-rs-linux-arm64
-          path: rust/numaflow-rs-linux-arm64
+          path: numaflow-rs-linux-arm64
       - name: Upload entrypoint binary
         uses: actions/upload-artifact@v4
         with:
           name: entrypoint-linux-arm64
-          path: rust/entrypoint-linux-arm64
+          path: entrypoint-linux-arm64
 
   build-push-linux-multi:
     name: Build & push linux/amd64 and linux/arm64


### PR DESCRIPTION
Fix release pipeline: https://github.com/numaproj/numaflow/actions/runs/15129096355/job/42526511087

- Use docker container to build binaries instead of running directly on github action runner.
- Use arm action runner for building arm binary
Copied from nightly build pipeline which was changed in https://github.com/numaproj/numaflow/pull/2636
<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
