### PR TITLE
chore: remove pod as dimension for `vertex_pending_messages` metric

### DIFF
--- a/config/advanced-install/namespaced-numaflow-server.yaml
+++ b/config/advanced-install/namespaced-numaflow-server.yaml
@@ -152,18 +152,15 @@ data:
     \     display_name: Vertex Pending Messages\n      metric_description: This gauge
     metric keeps track of the total number of messages that are waiting to be processed
     over varying time frames of 1min, 5min, 15min and default period of 2min. \n      required_filters:\n
-    \       - namespace\n        - pipeline\n        - vertex\n      dimensions:\n
-    \       - name: pod\n          # expr: optional expression for prometheus query\n
-    \         # overrides the default expression\n          filters:\n            -
-    name: pod\n              required: false\n            - name: period\n              required:
-    false\n        - name: vertex\n          # expr: optional expression for prometheus
-    query\n          # overrides the default expression\n          filters:\n            -
-    name: period\n              required: false\n\n- name: mono_vertex_gauge\n  objects:
-    \n    - mono-vertex\n  title: MonoVertex Gauge Metrics\n  description: This pattern
-    represents the gauge metrics for a mono-vertex across different dimensions\n  expr:
-    |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n    - name:
-    start_time\n      required: false\n    - name: end_time\n      required: false\n
-    \ metrics:\n    - metric_name: monovtx_pending\n      display_name: MonoVertex
+    \       - namespace\n        - pipeline\n        - vertex\n        - replica\n
+    \     dimensions:\n        - name: vertex\n          # expr: optional expression
+    for prometheus query\n          # overrides the default expression\n          filters:\n
+    \           - name: period\n              required: false\n\n- name: mono_vertex_gauge\n
+    \ objects: \n    - mono-vertex\n  title: MonoVertex Gauge Metrics\n  description:
+    This pattern represents the gauge metrics for a mono-vertex across different dimensions\n
+    \ expr: |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n
+    \   - name: start_time\n      required: false\n    - name: end_time\n      required:
+    false\n  metrics:\n    - metric_name: monovtx_pending\n      display_name: MonoVertex
     Pending Messages\n      metric_description: This gauge metric keeps track of the
     total number of messages that are waiting to be processed over varying time frames
     of 1min, 5min, 15min and default period of 2min. \n      required_filters:\n        -

--- a/config/advanced-install/numaflow-server.yaml
+++ b/config/advanced-install/numaflow-server.yaml
@@ -159,18 +159,15 @@ data:
     \     display_name: Vertex Pending Messages\n      metric_description: This gauge
     metric keeps track of the total number of messages that are waiting to be processed
     over varying time frames of 1min, 5min, 15min and default period of 2min. \n      required_filters:\n
-    \       - namespace\n        - pipeline\n        - vertex\n      dimensions:\n
-    \       - name: pod\n          # expr: optional expression for prometheus query\n
-    \         # overrides the default expression\n          filters:\n            -
-    name: pod\n              required: false\n            - name: period\n              required:
-    false\n        - name: vertex\n          # expr: optional expression for prometheus
-    query\n          # overrides the default expression\n          filters:\n            -
-    name: period\n              required: false\n\n- name: mono_vertex_gauge\n  objects:
-    \n    - mono-vertex\n  title: MonoVertex Gauge Metrics\n  description: This pattern
-    represents the gauge metrics for a mono-vertex across different dimensions\n  expr:
-    |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n    - name:
-    start_time\n      required: false\n    - name: end_time\n      required: false\n
-    \ metrics:\n    - metric_name: monovtx_pending\n      display_name: MonoVertex
+    \       - namespace\n        - pipeline\n        - vertex\n        - replica\n
+    \     dimensions:\n        - name: vertex\n          # expr: optional expression
+    for prometheus query\n          # overrides the default expression\n          filters:\n
+    \           - name: period\n              required: false\n\n- name: mono_vertex_gauge\n
+    \ objects: \n    - mono-vertex\n  title: MonoVertex Gauge Metrics\n  description:
+    This pattern represents the gauge metrics for a mono-vertex across different dimensions\n
+    \ expr: |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n
+    \   - name: start_time\n      required: false\n    - name: end_time\n      required:
+    false\n  metrics:\n    - metric_name: monovtx_pending\n      display_name: MonoVertex
     Pending Messages\n      metric_description: This gauge metric keeps track of the
     total number of messages that are waiting to be processed over varying time frames
     of 1min, 5min, 15min and default period of 2min. \n      required_filters:\n        -

--- a/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
+++ b/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
@@ -29,15 +29,8 @@ data:
             - namespace
             - pipeline
             - vertex
+            - replica
           dimensions:
-            - name: pod
-              # expr: optional expression for prometheus query
-              # overrides the default expression
-              filters:
-                - name: pod
-                  required: false
-                - name: period
-                  required: false
             - name: vertex
               # expr: optional expression for prometheus query
               # overrides the default expression

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -41995,18 +41995,15 @@ data:
     \     display_name: Vertex Pending Messages\n      metric_description: This gauge
     metric keeps track of the total number of messages that are waiting to be processed
     over varying time frames of 1min, 5min, 15min and default period of 2min. \n      required_filters:\n
-    \       - namespace\n        - pipeline\n        - vertex\n      dimensions:\n
-    \       - name: pod\n          # expr: optional expression for prometheus query\n
-    \         # overrides the default expression\n          filters:\n            -
-    name: pod\n              required: false\n            - name: period\n              required:
-    false\n        - name: vertex\n          # expr: optional expression for prometheus
-    query\n          # overrides the default expression\n          filters:\n            -
-    name: period\n              required: false\n\n- name: mono_vertex_gauge\n  objects:
-    \n    - mono-vertex\n  title: MonoVertex Gauge Metrics\n  description: This pattern
-    represents the gauge metrics for a mono-vertex across different dimensions\n  expr:
-    |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n    - name:
-    start_time\n      required: false\n    - name: end_time\n      required: false\n
-    \ metrics:\n    - metric_name: monovtx_pending\n      display_name: MonoVertex
+    \       - namespace\n        - pipeline\n        - vertex\n        - replica\n
+    \     dimensions:\n        - name: vertex\n          # expr: optional expression
+    for prometheus query\n          # overrides the default expression\n          filters:\n
+    \           - name: period\n              required: false\n\n- name: mono_vertex_gauge\n
+    \ objects: \n    - mono-vertex\n  title: MonoVertex Gauge Metrics\n  description:
+    This pattern represents the gauge metrics for a mono-vertex across different dimensions\n
+    \ expr: |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n
+    \   - name: start_time\n      required: false\n    - name: end_time\n      required:
+    false\n  metrics:\n    - metric_name: monovtx_pending\n      display_name: MonoVertex
     Pending Messages\n      metric_description: This gauge metric keeps track of the
     total number of messages that are waiting to be processed over varying time frames
     of 1min, 5min, 15min and default period of 2min. \n      required_filters:\n        -

--- a/config/namespace-install.yaml
+++ b/config/namespace-install.yaml
@@ -41874,18 +41874,15 @@ data:
     \     display_name: Vertex Pending Messages\n      metric_description: This gauge
     metric keeps track of the total number of messages that are waiting to be processed
     over varying time frames of 1min, 5min, 15min and default period of 2min. \n      required_filters:\n
-    \       - namespace\n        - pipeline\n        - vertex\n      dimensions:\n
-    \       - name: pod\n          # expr: optional expression for prometheus query\n
-    \         # overrides the default expression\n          filters:\n            -
-    name: pod\n              required: false\n            - name: period\n              required:
-    false\n        - name: vertex\n          # expr: optional expression for prometheus
-    query\n          # overrides the default expression\n          filters:\n            -
-    name: period\n              required: false\n\n- name: mono_vertex_gauge\n  objects:
-    \n    - mono-vertex\n  title: MonoVertex Gauge Metrics\n  description: This pattern
-    represents the gauge metrics for a mono-vertex across different dimensions\n  expr:
-    |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n    - name:
-    start_time\n      required: false\n    - name: end_time\n      required: false\n
-    \ metrics:\n    - metric_name: monovtx_pending\n      display_name: MonoVertex
+    \       - namespace\n        - pipeline\n        - vertex\n        - replica\n
+    \     dimensions:\n        - name: vertex\n          # expr: optional expression
+    for prometheus query\n          # overrides the default expression\n          filters:\n
+    \           - name: period\n              required: false\n\n- name: mono_vertex_gauge\n
+    \ objects: \n    - mono-vertex\n  title: MonoVertex Gauge Metrics\n  description:
+    This pattern represents the gauge metrics for a mono-vertex across different dimensions\n
+    \ expr: |\n    sum($metric_name{$filters}) by ($dimension, period)\n  params:\n
+    \   - name: start_time\n      required: false\n    - name: end_time\n      required:
+    false\n  metrics:\n    - metric_name: monovtx_pending\n      display_name: MonoVertex
     Pending Messages\n      metric_description: This gauge metric keeps track of the
     total number of messages that are waiting to be processed over varying time frames
     of 1min, 5min, 15min and default period of 2min. \n      required_filters:\n        -

--- a/docs/user-guide/UI/metrics-tab.md
+++ b/docs/user-guide/UI/metrics-tab.md
@@ -59,13 +59,8 @@ data:
                   - namespace
                   - pipeline
                   - vertex
+                  - replica
                 dimensions:
-                  - name: pod
-                    filters:
-                      - name: pod
-                        required: false
-                      - name: period
-                        required: false
                   - name: vertex
                     filters:
                       - name: period

--- a/server/apis/v1/promql_service_test.go
+++ b/server/apis/v1/promql_service_test.go
@@ -403,9 +403,10 @@ func Test_PromQueryBuilder(t *testing.T) {
 					"pipeline":  "test_pipeline",
 					"vertex":    "test_vertex",
 					"period":    "5m",
+					"replica":   "0",
 				},
 			},
-			expectedQuery: `sum(vertex_pending_messages{namespace= "test_namespace", pipeline= "test_pipeline", vertex= "test_vertex", period= "5m"}) by (vertex, period)`,
+			expectedQuery: `sum(vertex_pending_messages{namespace= "test_namespace", pipeline= "test_pipeline", vertex= "test_vertex", period= "5m", replica= "0"}) by (vertex, period)`,
 		},
 		{
 			name: "Missing metric name in service config",
@@ -517,7 +518,7 @@ func Test_QueryPrometheus(t *testing.T) {
 				Api: mockAPI,
 			},
 		}
-		query := `sum(vertex_pending_messages{namespace="default", pipeline="test-pipeline", vertex="test-vertex", period="5m"}) by (vertex, period)`
+		query := `sum(vertex_pending_messages{namespace="default", pipeline="test-pipeline", vertex="test-vertex", period="5m", replica="0"}) by (vertex, period)`
 		startTime := time.Now().Add(-30 * time.Minute)
 		endTime := time.Now()
 

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
@@ -304,6 +304,9 @@ const LineChartComponent = ({
           } else {
             return pod?.name;
           }
+        case "replica":
+          // in case of pending messages, we calculate only for replica 0
+          return "0";
         default:
           return "";
       }


### PR DESCRIPTION
**Merge this PR only after #2675 is closed.**

- pending is calculated only for replica 0. Added replica as required filter for `vertex_pending_messages` metric
- removed `pod` as dimension