### PR TITLE
chore(ci): with more tests being added it is timing out

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     services:
       redis:
         image: redis:6.2


### PR DESCRIPTION
Increase timeout by 5 mins, now it is 15 mins
