### PR TITLE
chore: added more metrics in the UI

### DIFF
--- a/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
+++ b/config/base/numaflow-server/numaflow-server-metrics-proxy-config.yaml
@@ -122,6 +122,51 @@ data:
                 - name: pod
                   required: false
 
+
+    - name: vertex_histogram
+      objects: 
+        - vertex
+      title: Pipeline Histogram Metrics
+      description: This pattern is for P99, P95, P90 and P50 quantiles for a vertex across different dimensions
+      expr: |
+        histogram_quantile($quantile, sum by($dimension,le) (rate($metric_name{$filters}[$duration])))
+      params:
+        - name: quantile
+          required: true
+        - name: duration
+          required: true
+        - name: start_time
+          required: false
+        - name: end_time
+          required: false
+      metrics:
+        - metric_name: forwarder_write_processing_time_bucket
+          display_name: Vertex Write Processing Time Latency
+          metric_description: This metric represents a histogram to keep track of the total time taken to write a message.
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: vertex
+            - name: pod
+              filters:
+                - name: pod
+                  required: false
+        - metric_name: forwarder_read_processing_time_bucket
+          display_name: Vertex Read Processing Time Latency
+          metric_description: This metric represents a histogram to keep track of the total time taken to read messages.
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: vertex
+            - name: pod
+              filters:
+                - name: pod
+                  required: false
+
     - name: vertex_throughput
       objects: 
         - vertex
@@ -139,6 +184,45 @@ data:
         - metric_name: forwarder_data_read_total
           display_name: Vertex Read Processing Rate
           metric_description: This metric represents the total number of data messages read per second.
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: vertex
+            - name: pod
+              filters:
+                - name: pod
+                  required: false
+        - metric_name: forwarder_write_total
+          display_name: Vertex Write Processing Rate
+          metric_description: This metric represents the total number of messages written per second.
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: vertex
+            - name: pod
+              filters:
+                - name: pod
+                  required: false
+        - metric_name: forwarder_udf_read_total
+          display_name: UDF Read Processing Rate
+          metric_description: This metric represents the total number of messages read per second.
+          required_filters:
+            - namespace
+            - pipeline
+            - vertex
+          dimensions:
+            - name: vertex
+            - name: pod
+              filters:
+                - name: pod
+                  required: false
+        - metric_name: forwarder_udf_write_total
+          display_name: UDF Write Processing Rate
+          metric_description: This metric represents the total number of messages written per second.
           required_filters:
             - namespace
             - pipeline
@@ -167,6 +251,18 @@ data:
         - metric_name: monovtx_read_total
           display_name: MonoVertex Read Processing Rate
           metric_description: This metric represents the total number of data messages read per second.
+          required_filters:
+            - namespace
+            - mvtx_name
+          dimensions:
+            - name: mono-vertex
+            - name: pod
+              filters:
+                - name: pod
+                  required: false
+        - metric_name: monovtx_sink_write_total
+          display_name: MonoVertex Sink Write Processing Rate
+          metric_description: This metric represents the total number of data messages written by sink per second.
           required_filters:
             - namespace
             - mvtx_name

--- a/server/apis/v1/handler.go
+++ b/server/apis/v1/handler.go
@@ -1356,6 +1356,9 @@ func (h *handler) DiscoverMetrics(c *gin.Context) {
 			for _, metric := range pattern.Metrics {
 				var requiredFilters []Filter
 				// Populate the required filters
+				// TODO (ajain): check at required filters, if filter is vertex skip mono-vertex object and vice-versa
+				// This way more patterns can be clubbed, currently checking at dimension level for cpu/memory metrics
+				// OR implement metric based configuration for next release which has already been tested
 				for _, filter := range metric.Filters {
 					requiredFilters = append(requiredFilters, Filter{
 						Name:     filter,

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/index.tsx
@@ -15,6 +15,8 @@ import { useMetricsDiscoveryDataFetch } from "../../../../../../../../../../../.
 import {
   dimensionReverseMap,
   VERTEX_PENDING_MESSAGES,
+  UDF_READ_PROCESSING_RATE,
+  UDF_WRITE_PROCESSING_RATE,
 } from "./utils/constants";
 import {
   VertexDetailsContext,
@@ -126,6 +128,8 @@ export function Metrics({
           type === "source" &&
           metric?.display_name === VERTEX_PENDING_MESSAGES
         )
+          return null;
+        if (type !== "udf" && (metric?.display_name === UDF_READ_PROCESSING_RATE || metric?.display_name === UDF_WRITE_PROCESSING_RATE))
           return null;
         const panelId = `${metric?.metric_name}-panel`;
         return (

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/partials/LineChart/index.tsx
@@ -304,6 +304,11 @@ const LineChartComponent = ({
           } else {
             return pod?.name;
           }
+        case "replica":
+          // currently not used in any of the metrics
+          // if used in future for pending metrics, it is to ensure replica is taken 
+          // as 0, if it is a required filter.
+          return "0";
         default:
           return "";
       }

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/Metrics/utils/constants.ts
@@ -34,6 +34,8 @@ export const dimensionReverseMap: { [p: string]: string } = {
 };
 
 export const VERTEX_PENDING_MESSAGES = "Vertex Pending Messages";
+export const UDF_READ_PROCESSING_RATE = "UDF Read Processing Rate";
+export const UDF_WRITE_PROCESSING_RATE = "UDF Write Processing Rate";
 export const VERTEX_PROCESSING_RATE = "Vertex Read Processing Rate";
 export const MONO_VERTEX_PENDING_MESSAGES = "MonoVertex Pending Messages";
 export const MONO_VERTEX_PROCESSING_RATE = "MonoVertex Read Processing Rate";


### PR DESCRIPTION
## Following metrics are added in the Config

### Pipeline

- Forwarder Write Processing Latency [`forwarder_write_processing_time_bucket`]
- Forwarder Read Processing Latency [`forwarder_read_processing_time_bucket`]
- Forwarder Write Processing Rate [`forwarder_write_total`]
- UDF Read Processing Rate [`forwarder_udf_read_total`]
- UDF Write Processing Rate [`forwarder_udf_write_total`]
- **E2E Processing Latency to be added after #2692 is merged.**


### MonoVertex
- Sink Write Processing Rate [`monovtx_sink_write_total`]


### Any Code/UI Changes Required?

One change to ensure UDF metrics are displayed only for UDF vertex.



