### PR TITLE
fix: mount runtime path for pipeline/vertex

### DIFF
--- a/pkg/apis/numaflow/v1alpha1/vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/vertex_types.go
@@ -277,7 +277,10 @@ func (v Vertex) GetPodSpec(req GetVertexPodSpecReq) (*corev1.PodSpec, error) {
 		},
 	}
 
-	volumeMounts := []corev1.VolumeMount{{Name: varVolumeName, MountPath: PathVarRun}}
+	volumeMounts := []corev1.VolumeMount{
+		{Name: varVolumeName, MountPath: PathVarRun},
+		{Name: RuntimeDirVolume, MountPath: RuntimeDirMountPath},
+	}
 	containerRequest := getContainerReq{
 		isbSvcType:      req.ISBSvcType,
 		env:             envVars,

--- a/pkg/apis/numaflow/v1alpha1/vertex_types_test.go
+++ b/pkg/apis/numaflow/v1alpha1/vertex_types_test.go
@@ -295,7 +295,7 @@ func TestGetPodSpec(t *testing.T) {
 		assert.Contains(t, s.Containers[0].Args, "--type="+string(VertexTypeSource))
 		assert.Equal(t, 2, len(s.InitContainers))
 		assert.Equal(t, 2, len(s.Volumes))
-		assert.Equal(t, 1, len(s.Containers[0].VolumeMounts))
+		assert.Equal(t, 2, len(s.Containers[0].VolumeMounts))
 		assert.Equal(t, CtrInit, s.InitContainers[0].Name)
 		assert.Equal(t, CtrMonitor, s.InitContainers[1].Name)
 		assert.Equal(t, "200m", s.Containers[0].Resources.Requests.Cpu().String())
@@ -330,7 +330,7 @@ func TestGetPodSpec(t *testing.T) {
 		assert.Equal(t, 1, len(s.Containers))
 		assert.Equal(t, CtrMain, s.Containers[0].Name)
 		assert.Equal(t, 2, len(s.Volumes))
-		assert.Equal(t, 1, len(s.Containers[0].VolumeMounts))
+		assert.Equal(t, 2, len(s.Containers[0].VolumeMounts))
 		assert.Equal(t, testFlowImage, s.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, s.Containers[0].ImagePullPolicy)
 		assert.NotNil(t, s.Containers[0].ReadinessProbe)
@@ -402,7 +402,7 @@ func TestGetPodSpec(t *testing.T) {
 		assert.Contains(t, sidecarEnvNames, EnvCPURequest)
 		assert.Contains(t, sidecarEnvNames, EnvMemoryRequest)
 		assert.Equal(t, 2, len(s.Volumes))
-		assert.Equal(t, 1, len(s.Containers[0].VolumeMounts))
+		assert.Equal(t, 2, len(s.Containers[0].VolumeMounts))
 	})
 
 	t.Run("test user-defined source, with a source transformer", func(t *testing.T) {
@@ -512,9 +512,9 @@ func TestGetPodSpec(t *testing.T) {
 		assert.Equal(t, "runtime-vol", s.InitContainers[2].VolumeMounts[0].Name)
 		// udf container
 		assert.Equal(t, CtrUdf, s.InitContainers[3].Name)
-		assert.Equal(t, 2, len(s.InitContainers[3].VolumeMounts))
-		assert.Equal(t, "var-run-side-inputs", s.InitContainers[3].VolumeMounts[1].Name)
-		assert.True(t, s.InitContainers[3].VolumeMounts[1].ReadOnly)
+		assert.Equal(t, 3, len(s.InitContainers[3].VolumeMounts))
+		assert.Equal(t, "var-run-side-inputs", s.InitContainers[3].VolumeMounts[2].Name)
+		assert.True(t, s.InitContainers[3].VolumeMounts[2].ReadOnly)
 
 		assert.Equal(t, 1, len(s.Containers[1].VolumeMounts))
 		assert.Equal(t, "var-run-side-inputs", s.Containers[1].VolumeMounts[0].Name)


### PR DESCRIPTION
At the start, MonoVertex was targeted for surfacing application errors. 
But the functionality was developed for pipeline as well, so runtime path had to be mounted for surfacing the errors in case of vertices of pipelines.

Below is screenshot when `udf` vertex is in panic state.

<img width="1414" alt="image" src="https://github.com/user-attachments/assets/9922d84c-b1b9-403a-bbd0-d94c3fd4f9fc" />
