### PR TITLE
fix: Wrong usage of get_consumer_from_stream

### DIFF
--- a/rust/extns/numaflow-jetstream/Cargo.toml
+++ b/rust/extns/numaflow-jetstream/Cargo.toml
@@ -11,7 +11,7 @@ tracing.workspace = true
 thiserror.workspace = true
 bytes.workspace = true
 rustls.workspace = true
-tokio-stream = "0.1.15"
+tokio-stream.workspace = true
 rustls-pki-types = "1.11.0"
 rustls-native-certs = "0.8.1"
 

--- a/rust/extns/numaflow-jetstream/src/lib.rs
+++ b/rust/extns/numaflow-jetstream/src/lib.rs
@@ -154,7 +154,7 @@ impl JetstreamActor {
 
         let js_ctx = async_nats::jetstream::new(client);
         let consumer: PullConsumer = js_ctx
-            .get_consumer_from_stream(&config.stream, &config.consumer)
+            .get_consumer_from_stream(&config.consumer, &config.stream)
             .await
             .map_err(|err| {
                 Error::Jetstream(format!(

--- a/rust/numaflow-core/src/source/jetstream.rs
+++ b/rust/numaflow-core/src/source/jetstream.rs
@@ -142,11 +142,12 @@ mod tests {
             .await
             .unwrap();
 
+        let consumer = format!("{}_consumer", stream_name);
         stream
             .get_or_create_consumer(
-                stream_name,
+                &consumer,
                 async_nats::jetstream::consumer::pull::Config {
-                    durable_name: Some(stream_name.to_string()),
+                    durable_name: Some(consumer.clone()),
                     ..Default::default()
                 },
             )
@@ -164,7 +165,7 @@ mod tests {
         let config = numaflow_jetstream::JetstreamSourceConfig {
             addr: "localhost".to_string(),
             stream: stream_name.to_string(),
-            consumer: stream_name.to_string(),
+            consumer,
             auth: None,
             tls: None,
         };


### PR DESCRIPTION
fixes https://github.com/numaproj/numaflow/issues/2723

We only allow specifying stream name as a user option when Jetstream source is used. We expect a consumer with same name as the stream name to be present.

Tested by running the pipeline:
```yml
apiVersion: numaflow.numaproj.io/v1alpha1
kind: Pipeline
metadata:
  name: simple-pipeline
spec:
  vertices:
    - name: in
      scale:
        min: 1
      containerTemplate:
        image:
        env:
          - name: NUMAFLOW_RUNTIME
            value: "rust"
      source:
        jetstream:
          url: host.lima.internal
          stream: test-stream
    - name: out
      containerTemplate:
        image:
        env:
          - name: NUMAFLOW_RUNTIME
            value: "rust"
      scale:
        min: 1
      sink:
        log: {}
  edges:
    - from: in
      to: out
```

Created stream and consumer:
```sh
nats str add test-stream
nats con add test-stream test-stream
```
Published messages:
```sh
nats pub test.abcd "This is a new message"
```

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
