### PR TITLE
fix: set childrenHealthStatus of external redis isbsvc

### DIFF
--- a/pkg/reconciler/isbsvc/installer/external_redis.go
+++ b/pkg/reconciler/isbsvc/installer/external_redis.go
@@ -53,5 +53,6 @@ func (eri *externalRedisInstaller) Uninstall(ctx context.Context) error {
 }
 
 func (eri *externalRedisInstaller) CheckChildrenResourceStatus(ctx context.Context) error {
+	eri.isbSvc.Status.MarkChildrenResourceHealthy("Healthy", "External redis is assumed healthy")
 	return nil
 }


### PR DESCRIPTION
External redis isbsvc resources had condition 
```
Type: childrenHealthStatus
Status: Unknown
```
this made it impossible to use it as pipelines would fail to deploy saying the isbsvc was unhealthy. 

This marks it's children as healthy when checked.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
