### PR TITLE
fix: Generator source - Base64 decode user specified blob

### DIFF
--- a/rust/numaflow-core/src/config/components.rs
+++ b/rust/numaflow-core/src/config/components.rs
@@ -15,6 +15,8 @@ pub(crate) mod source {
     use crate::Result;
     use crate::config::get_vertex_name;
     use crate::error::Error;
+    use base64::Engine;
+    use base64::prelude::BASE64_STANDARD;
     use bytes::Bytes;
     use numaflow_jetstream::{JetstreamSourceConfig, NatsAuth, TlsClientAuthCerts, TlsConfig};
     use numaflow_kafka::source::KafkaSourceConfig;
@@ -52,12 +54,20 @@ pub(crate) mod source {
         Http(numaflow_http::HttpSourceConfig),
     }
 
-    impl From<Box<GeneratorSource>> for SourceType {
-        fn from(generator: Box<GeneratorSource>) -> Self {
+    impl TryFrom<Box<GeneratorSource>> for SourceType {
+        type Error = Error;
+
+        fn try_from(generator: Box<GeneratorSource>) -> Result<Self> {
             let mut generator_config = GeneratorConfig::default();
 
             if let Some(value_blob) = &generator.value_blob {
-                generator_config.content = Bytes::from(value_blob.clone());
+                let value_blob = BASE64_STANDARD.decode(value_blob.as_bytes()).map_err(|e| {
+                    Error::Config(format!(
+                        "Failed to base64 decode generator value blob: {:?}",
+                        e
+                    ))
+                })?;
+                generator_config.content = Bytes::from(value_blob);
             }
 
             if let Some(msg_size) = generator.msg_size {
@@ -81,7 +91,7 @@ pub(crate) mod source {
                 .jitter
                 .map_or(Duration::from_secs(0), std::time::Duration::from);
 
-            SourceType::Generator(generator_config)
+            Ok(SourceType::Generator(generator_config))
         }
     }
 
@@ -342,7 +352,7 @@ pub(crate) mod source {
 
         fn try_from(mut source: Box<Source>) -> Result<Self> {
             if let Some(generator) = source.generator.take() {
-                return Ok(generator.into());
+                return Ok(generator.try_into()?);
             }
 
             if source.udsource.is_some() {

--- a/rust/numaflow-core/src/config/pipeline.rs
+++ b/rust/numaflow-core/src/config/pipeline.rs
@@ -160,8 +160,6 @@ pub(crate) struct SourceVtxConfig {
 }
 
 pub(crate) mod map {
-    use std::collections::HashMap;
-
     use numaflow_models::models::Udf;
 
     use crate::config::pipeline::{


### PR DESCRIPTION
Closes https://github.com/numaproj/numaflow/issues/2737

Tested by running:
```yaml
apiVersion: numaflow.numaproj.io/v1alpha1
kind: MonoVertex
metadata:
  name: simple-mono-vertex
spec:
  source:
    generator:
      rpu: 1
      duration: 1s
      valueBlob: "aGVsbG8gd29ybGQK"
  sink:
    log: {}
```

Logs:
```
2025-06-27T03:40:38.587336Z  INFO numaflow_core::source: Processed 1 messages in 2025-06-27T03:40:38.587333180Z
2025-06-27T03:40:39.588202Z  INFO numaflow_core::sink::log: Payload - hello world
 Keys -  EventTime - 1750995638587 Headers -  ID - simple-mono-vertex-1750995638587304138-0-0
2025-06-27T03:40:39.588407Z  INFO numaflow_core::source: Processed 1 messages in 2025-06-27T03:40:39.588405780Z
2025-06-27T03:40:40.589568Z  INFO numaflow_core::sink::log: Payload - hello world
 Keys -  EventTime - 1750995639588 Headers -  ID - simple-mono-vertex-1750995639588374988-0-0
```
<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
