### PR TITLE
chore: grpc error type instead of reduce for tonic status

### DIFF
--- a/rust/numaflow-core/src/reduce/reducer/aligned/user_defined.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/user_defined.rs
@@ -189,7 +189,7 @@ impl UserDefinedAlignedReduce {
             // Wait for the gRPC call to complete
             result = self.client.reduce_fn(ReceiverStream::new(req_rx)) => {
                 result
-                    .map_err(|e| crate::Error::Reduce(format!("failed to call reduce_fn: {}", e)))?
+                    .map_err(|e| crate::Error::Grpc(e))?
                     .into_inner()
             }
 


### PR DESCRIPTION
`tonic::Status` was getting wrapped as `Error::reduce`
Changing error type to `Error::Grpc` from `Error::Reduce` so that status details, code, message are bubbled up correctly.