### PR TITLE
chore: grpc error instead of reduce for reduce streamer

### DIFF
--- a/rust/numaflow-core/src/reduce/reducer/aligned/user_defined.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/user_defined.rs
@@ -216,7 +216,7 @@ impl UserDefinedAlignedReduce {
 
                 // Process next response
                 response = response_stream.message() => {
-                    let response = response.map_err(|e| crate::Error::Reduce(format!("failed to receive response: {}", e)))?;
+                    let response = response.map_err(|e| crate::Error::Grpc(e))?;
                     let Some(response) = response else {
                         break;
                     };


### PR DESCRIPTION
Changing error type to `Error::Grpc` from `Error::Reduce` so that status details, code, message are bubbled up correctly for reduce in streaming mode (aligned window)
