### PR TITLE
fix: cli parsing using clap

### DIFF
--- a/pkg/apis/numaflow/v1alpha1/mono_vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/mono_vertex_types.go
@@ -513,7 +513,7 @@ func (mvspec MonoVertexSpec) DeepCopyWithoutReplicas() MonoVertexSpec {
 
 func (mvspec MonoVertexSpec) getMainContainer(req getContainerReq) corev1.Container {
 	return containerBuilder{}.
-		init(req).command(NumaflowRustBinary).args("--rust").build()
+		init(req).command(NumaflowRustBinary).args("processor").build()
 }
 
 // buildContainers builds the sidecar containers and main containers for the mono vertex.

--- a/rust/numaflow/src/bin/entrypoint.rs
+++ b/rust/numaflow/src/bin/entrypoint.rs
@@ -10,16 +10,16 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Determine the runtime based on the NUMAFLOW_RUNTIME environment variable
     let runtime = env::var("NUMAFLOW_RUNTIME").unwrap_or_else(|_| "golang".to_string());
 
-    // Collect arguments, skipping the first one (binary name) because we will replace the process
-    // with the chosen binary.
-    let args: Vec<String> = env::args().skip(1).collect();
-
     // Choose the appropriate binary to execute
     let binary = if runtime == "rust" {
         NUMAFLOW_RUST
     } else {
         NUMAFLOW_GOLANG
     };
+
+    // Collect arguments, skipping the first one (binary name) because we will replace the process
+    // with the chosen binary.
+    let args: Vec<String> = env::args().skip(1).collect();
 
     // Replace the current process with the chosen binary
     let mut cmd = Command::new(binary);

--- a/rust/numaflow/src/cmdline.rs
+++ b/rust/numaflow/src/cmdline.rs
@@ -8,8 +8,6 @@ pub(super) fn root_cli() -> Command {
         .arg_required_else_help(true)
         .subcommand(add_monitor_subcommand())
         .subcommand(add_serving_subcommand())
-        // TODO: remove after moving e2e to Rust, this is a hack
-        .allow_external_subcommands(true)
 }
 
 fn add_monitor_subcommand() -> Command {

--- a/rust/numaflow/src/cmdline.rs
+++ b/rust/numaflow/src/cmdline.rs
@@ -8,6 +8,11 @@ pub(super) fn root_cli() -> Command {
         .arg_required_else_help(true)
         .subcommand(add_monitor_subcommand())
         .subcommand(add_serving_subcommand())
+        .subcommand(add_processor_subcommand())
+}
+
+fn add_processor_subcommand() -> Command {
+    Command::new("processor").about("Processor for Numaflow (Pipeline/MonoVertex)")
 }
 
 fn add_monitor_subcommand() -> Command {

--- a/rust/numaflow/src/main.rs
+++ b/rust/numaflow/src/main.rs
@@ -49,11 +49,14 @@ async fn run(cli: clap::Command) -> Result<(), Box<dyn Error>> {
             let cfg: serving::Settings = vars.try_into().unwrap();
             serving::run(cfg).await?;
         }
-        _ => {
+        Some(("processor", _)) => {
             info!("Starting processing pipeline");
             numaflow_core::run()
                 .await
                 .map_err(|e| format!("Error running core binary: {e:?}"))?;
+        }
+        others => {
+            return Err(format!("Invalid subcommand {others:?}").into());
         }
     }
 


### PR DESCRIPTION
- added `processor` (replaced `--rust`) for mvtx (semantically same with pipeline) (
- added processor sub-command