### PR TITLE
fix: failures in e2e tests ignored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ docs-serve: docs
 
 .PHONY: docs-linkcheck
 docs-linkcheck: /usr/local/bin/lychee
-	lychee --exclude-path=CHANGELOG.md --exclude-path=./docs/APIs.md --exclude "https://localhost:*" --exclude "https://www.intuit.com/" --exclude "http://localhost:*" --exclude "http://127.0.0.1*" *.md $(shell find ./docs -name '*.md') $(shell find ./examples -name '*.yaml')
+	lychee --exclude-path=CHANGELOG.md --exclude-path=./docs/APIs.md --exclude "https://localhost:*" --exclude "http://localhost:*" --exclude "http://127.0.0.1*" *.md $(shell find ./docs -name '*.md') $(shell find ./examples -name '*.yaml') --accept 200,429
 
 # pre-push checks
 

--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ docs-serve: docs
 
 .PHONY: docs-linkcheck
 docs-linkcheck: /usr/local/bin/lychee
-	lychee --exclude-path=CHANGELOG.md --exclude-path=./docs/APIs.md --exclude "https://localhost:*" --exclude "http://localhost:*" --exclude "http://127.0.0.1*" *.md $(shell find ./docs -name '*.md') $(shell find ./examples -name '*.yaml')
+	lychee --exclude-path=CHANGELOG.md --exclude-path=./docs/APIs.md --exclude "https://localhost:*" --exclude "https://www.intuit.com/" --exclude "http://localhost:*" --exclude "http://127.0.0.1*" *.md $(shell find ./docs -name '*.md') $(shell find ./examples -name '*.yaml')
 
 # pre-push checks
 

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ endif
 	$(MAKE) restart-control-plane-components
 	cat test/manifests/e2e-api-pod.yaml | sed 's@quay.io/numaproj/@$(IMAGE_NAMESPACE)/@' | sed 's/:latest/:$(VERSION)/' | kubectl -n numaflow-system apply -f -
 	go generate $(shell find ./test/$* -name '*.go')
-	-go test -v -timeout 15m -count 1 --tags test -p 1 ./test/$*
+	go test -v -timeout 15m -count 1 --tags test -p 1 ./test/$*
 	$(MAKE) cleanup-e2e
 
 image-restart:

--- a/rust/numaflow/src/cmdline.rs
+++ b/rust/numaflow/src/cmdline.rs
@@ -1,4 +1,4 @@
-use clap::{Arg, Command, arg};
+use clap::{Command, arg};
 
 pub(super) fn root_cli() -> Command {
     Command::new("numaflow")


### PR DESCRIPTION
Fix(Makefile): remove dash(`-`) before `go test` to ensure e2e failures are not ignored
introduced in #2529 


```
--- FAIL: TestMonoVertexSuite (281.14s)
    --- FAIL: TestMonoVertexSuite/TestExponentialBackoffRetryStrategy (122.49s)
    --- FAIL: TestMonoVertexSuite/TestMonoVertexWithAllContainers (122.46s)
FAIL
FAIL	github.com/numaproj/numaflow/test/monovertex-e2e	281.150s
FAIL
make: [Makefile:138: test-monovertex-e2e] Error 1 (ignored)
make cleanup-e2e
```