### PR TITLE
chore: delete unused server_info

### DIFF
--- a/rust/numaflow-core/src/shared.rs
+++ b/rust/numaflow-core/src/shared.rs
@@ -1,6 +1,3 @@
-/// All SDKs have to provide server info for all gRPC endpoints, so there is a lot of share.
-pub(crate) mod server_info;
-
 /// All utilities related to gRPC.
 pub(crate) mod grpc;
 

--- a/rust/numaflow-core/src/shared/server_info.rs
+++ b/rust/numaflow-core/src/shared/server_info.rs
@@ -1,1 +1,0 @@
-pub use numaflow_shared::server_info::*;


### PR DESCRIPTION
I removed the `pub use` (which was hack to keep it going) and now is directly referencing the shared mod. I forgot to delete this in the previous PR.