### PR TITLE
fix: aligned and unaligned reduce in Rust runtime

### DIFF
--- a/rust/numaflow-core/src/pipeline.rs
+++ b/rust/numaflow-core/src/pipeline.rs
@@ -763,10 +763,12 @@ async fn start_unaligned_reduce_forwarder(
             health_checks: ComponentHealthChecks::Pipeline(Box::new(PipelineComponents::Reduce(
                 UserDefinedReduce::Unaligned(reducer_client.clone()),
             ))),
-            watermark_fetcher_state: watermark_handle.map(|handle| WatermarkFetcherState {
-                watermark_handle: WatermarkHandle::ISB(handle),
-                partition_count: 1, // Reduce vertices always read from single partition (partition 0)
-            }),
+            watermark_fetcher_state: watermark_handle
+                .clone()
+                .map(|handle| WatermarkFetcherState {
+                    watermark_handle: WatermarkHandle::ISB(handle),
+                    partition_count: 1, // Reduce vertices always read from single partition (partition 0)
+                }),
         },
     )
     .await;
@@ -779,7 +781,9 @@ async fn start_unaligned_reduce_forwarder(
             unaligned_config.window_config.allowed_lateness,
             gc_wal,
             config.graceful_shutdown_time,
+            config.read_timeout,
             reduce_vtx_config.keyed,
+            watermark_handle,
         )
         .await,
     );

--- a/rust/numaflow-core/src/pipeline.rs
+++ b/rust/numaflow-core/src/pipeline.rs
@@ -592,10 +592,12 @@ async fn start_aligned_reduce_forwarder(
             health_checks: ComponentHealthChecks::Pipeline(Box::new(PipelineComponents::Reduce(
                 UserDefinedReduce::Aligned(reducer_client.clone()),
             ))),
-            watermark_fetcher_state: watermark_handle.map(|handle| WatermarkFetcherState {
-                watermark_handle: WatermarkHandle::ISB(handle),
-                partition_count: 1, // Reduce vertices always read from single partition (partition 0)
-            }),
+            watermark_fetcher_state: watermark_handle
+                .clone()
+                .map(|handle| WatermarkFetcherState {
+                    watermark_handle: WatermarkHandle::ISB(handle),
+                    partition_count: 1, // Reduce vertices always read from single partition (partition 0)
+                }),
         },
     )
     .await;
@@ -608,7 +610,9 @@ async fn start_aligned_reduce_forwarder(
             gc_wal,
             aligned_config.window_config.allowed_lateness,
             config.graceful_shutdown_time,
+            config.read_timeout,
             reduce_vtx_config.keyed,
+            watermark_handle,
         )
         .await,
     );

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/reader.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/reader.rs
@@ -380,6 +380,13 @@ impl JetStreamReader {
                 let watermark = watermark_handle
                     .fetch_watermark(message.offset.clone())
                     .await;
+                if message.event_time < watermark {
+                    warn!(
+                        event_time = ?message.event_time.timestamp_millis(),
+                        watermark = ?watermark.timestamp_millis(),
+                        "Event time is before the watermark, message will be dropped"
+                    );
+                }
                 message.watermark = Some(watermark);
             }
 

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/reader.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/reader.rs
@@ -380,13 +380,6 @@ impl JetStreamReader {
                 let watermark = watermark_handle
                     .fetch_watermark(message.offset.clone())
                     .await;
-                if message.event_time < watermark {
-                    warn!(
-                        event_time = ?message.event_time.timestamp_millis(),
-                        watermark = ?watermark.timestamp_millis(),
-                        "Event time is before the watermark, message will be dropped"
-                    );
-                }
                 message.watermark = Some(watermark);
             }
 

--- a/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
@@ -6,6 +6,7 @@ use crate::reduce::reducer::aligned::windower::{
     AlignedWindowManager, AlignedWindowMessage, AlignedWindowOperation, Window,
 };
 use crate::reduce::wal::segment::append::{AppendOnlyWal, SegmentWriteMessage};
+use crate::watermark::isb::ISBWatermarkHandle;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use numaflow_pb::objects::wal::GcEvent;
@@ -19,6 +20,7 @@ use tokio_stream::StreamExt;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
+
 const DEFAULT_KEY_FOR_NON_KEYED_STREAM: &str = "NON_KEYED_STREAM";
 
 /// Represents an active reduce stream for a window.
@@ -299,7 +301,7 @@ impl AlignedReduceActor {
         let Some(active_stream) = self.active_streams.get(window_id) else {
             // windows may not be found during replay, because the windower doesn't send the open
             // message for the active windows that got replayed, hence we create a new one.
-            // this happens because of out-of-order messages and we have to ensure that the (t+1)th
+            // this happens because of out-of-order messages, and we have to ensure that the (t+1)th
             // message is sent to the window that could be created by (t)th message iff (t+1)th message
             // belongs to that window created by (t)th message.
             self.window_open(window_msg).await;
@@ -362,9 +364,14 @@ pub(crate) struct AlignedReducer {
     keyed: bool,
     /// Graceful shutdown timeout duration.
     graceful_timeout: Duration,
+    idle_timeout: Duration,
+    /// Watermark handle for fetching head idle wmb to check if any windows can be closed,
+    /// when there is no data.
+    watermark_handle: Option<ISBWatermarkHandle>,
 }
 
 impl AlignedReducer {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
         client: UserDefinedAlignedReduce,
         window_manager: AlignedWindowManager,
@@ -372,19 +379,23 @@ impl AlignedReducer {
         gc_wal: Option<AppendOnlyWal>,
         allowed_lateness: Duration,
         graceful_timeout: Duration,
+        idle_timeout: Duration,
         keyed: bool,
+        watermark_handle: Option<ISBWatermarkHandle>,
     ) -> Self {
         Self {
             client,
             window_manager,
             js_writer,
-            final_result: Ok(()),
-            shutting_down_on_err: false,
             gc_wal,
             allowed_lateness,
             current_watermark: DateTime::from_timestamp_millis(-1).expect("Invalid timestamp"),
             keyed,
             graceful_timeout,
+            idle_timeout,
+            watermark_handle,
+            shutting_down_on_err: false,
+            final_result: Ok(()),
         }
     }
 
@@ -446,52 +457,37 @@ impl AlignedReducer {
                         self.handle_error(err, &cln_token);
                     }
 
-                    // Process input messages
-                    read_msg = input_stream.next() => {
-                        let Some(mut msg) = read_msg else {
-                            break;
-                        };
+                    // read input messages with timeout
+                    read_msg = tokio::time::timeout(self.idle_timeout, input_stream.next()) => {
+                        match read_msg {
+                            Ok(Some(mut msg)) => {
+                                // If shutting down, drain the stream
+                                if self.shutting_down_on_err {
+                                    info!("Reduce component is shutting down due to an error, not accepting the message");
+                                    continue;
+                                }
 
-                        // if the stream is not keyed, then we need to set all the messages to have the same key
-                        // so that all the messages go to the same reduce task.
-                        if !keyed {
-                            msg.keys = Arc::new([DEFAULT_KEY_FOR_NON_KEYED_STREAM.to_string()]);
-                        }
+                                // If the stream is not keyed, set all messages to have the same key
+                                if !keyed {
+                                    msg.keys = Arc::new([DEFAULT_KEY_FOR_NON_KEYED_STREAM.to_string()]);
+                                }
 
-                        // If shutting down, drain the stream
-                        if self.shutting_down_on_err {
-                            info!("Reduce component is shutting down due to an error, not accepting the message");
-                            continue;
-                        }
+                                // Update the watermark - use max to ensure it never regresses
+                                self.current_watermark = self
+                                    .current_watermark
+                                    .max(msg.watermark.unwrap_or_default());
 
-                        // update the watermark.
-                        // we cannot simply assign incoming message's watermark as the current watermark,
-                        // because it can be -1. watermark will never regress, so use max.
-                        self.current_watermark = self.current_watermark.max(msg.watermark.unwrap_or_default());
-
-                        // only drop the message if it is late and the event time is before the watermark - allowed lateness
-                        if msg.is_late && msg.event_time < self.current_watermark.sub(self.allowed_lateness) {
-                            // TODO(ajain): add a metric for this
-                            continue;
-                        }
-
-                        if self.current_watermark > msg.event_time {
-                            error!(current_watermark=?self.current_watermark.timestamp_millis(), message_event_time=?msg.event_time.timestamp_millis(), is_late=?msg.is_late, offset=?msg.offset, "Old message popped up, Watermark is behind the event time");
-                            continue;
-                        }
-
-                        // check if any windows can be closed
-                        let window_messages = self.window_manager.close_windows(self.current_watermark.sub(self.allowed_lateness));
-                        for window_msg in window_messages {
-                            actor_tx.send(window_msg).await.expect("Receiver dropped");
-                        }
-
-                        // assign windows to the message
-                        let window_messages = self.window_manager.assign_windows(msg);
-
-                        // Send each window message to the actor for processing
-                        for window_msg in window_messages {
-                            actor_tx.send(window_msg).await.expect("Receiver dropped");
+                                self.assign_and_close_windows(msg, &actor_tx).await;
+                            }
+                            Ok(None) => {
+                                // Stream ended
+                                break;
+                            }
+                            Err(_timeout) => {
+                                // watermark can still progress when there is no data, because of idle watermark
+                                // so we need to check if any windows can be closed based on the idle watermark.
+                                self.close_windows_by_idle_wm(&actor_tx).await;
+                            }
                         }
                     }
                 }
@@ -545,6 +541,79 @@ impl AlignedReducer {
             cln_token.cancel();
             self.final_result = Err(error);
             self.shutting_down_on_err = true;
+        }
+    }
+
+    /// Closes windows based on the provided watermark and sends close messages to the actor.
+    async fn close_windows_with_watermark(
+        &self,
+        watermark: DateTime<Utc>,
+        actor_tx: &mpsc::Sender<AlignedWindowMessage>,
+    ) {
+        let window_messages = self
+            .window_manager
+            .close_windows(watermark.sub(self.allowed_lateness));
+
+        for window_msg in window_messages {
+            actor_tx.send(window_msg).await.expect("Receiver dropped");
+        }
+    }
+
+    /// Assigns windows to the message and sends the messages to the actor, also closes any windows
+    /// that can be closed based on the current watermark.
+    async fn assign_and_close_windows(
+        &mut self,
+        msg: Message,
+        actor_tx: &mpsc::Sender<AlignedWindowMessage>,
+    ) {
+        // Drop late messages
+        if msg.is_late && msg.event_time < self.current_watermark.sub(self.allowed_lateness) {
+            // TODO(ajain): add a metric for this
+            return;
+        }
+
+        // Validate message event time against current watermark
+        if self.current_watermark > msg.event_time {
+            error!(
+                current_watermark = ?self.current_watermark.timestamp_millis(),
+                message_event_time = ?msg.event_time.timestamp_millis(),
+                is_late = ?msg.is_late,
+                offset = ?msg.offset,
+                "Old message popped up, Watermark is behind the event time"
+            );
+            return;
+        }
+
+        // Close windows based on current watermark
+        self.close_windows_with_watermark(self.current_watermark, actor_tx)
+            .await;
+
+        // Assign windows to the message
+        let window_messages = self.window_manager.assign_windows(msg);
+
+        // Send each window message to the actor for processing
+        for window_msg in window_messages {
+            actor_tx.send(window_msg).await.expect("Receiver dropped");
+        }
+    }
+
+    /// Closes windows based on the idle watermark.
+    async fn close_windows_by_idle_wm(&mut self, actor_tx: &mpsc::Sender<AlignedWindowMessage>) {
+        if self.shutting_down_on_err {
+            return;
+        }
+
+        let Some(watermark_handle) = self.watermark_handle.as_mut() else {
+            return;
+        };
+
+        let idle_watermark = watermark_handle.fetch_head_idle_watermark().await;
+
+        // Only close windows if the idle watermark is greater than the current watermark
+        if idle_watermark > self.current_watermark {
+            self.current_watermark = idle_watermark;
+            self.close_windows_with_watermark(idle_watermark, actor_tx)
+                .await;
         }
     }
 }
@@ -706,7 +775,9 @@ mod tests {
             None, // No GC WAL for testing
             Duration::from_secs(0),
             Duration::from_millis(50),
+            Duration::from_secs(1),
             true,
+            None,
         )
         .await;
 
@@ -953,7 +1024,9 @@ mod tests {
             None, // No GC WAL for testing
             Duration::from_secs(0),
             Duration::from_millis(50),
+            Duration::from_secs(1),
             true,
+            None,
         )
         .await;
 
@@ -1203,7 +1276,9 @@ mod tests {
             None, // No GC WAL for testing
             Duration::from_secs(0),
             Duration::from_millis(50),
+            Duration::from_secs(1),
             true,
+            None,
         )
         .await;
 

--- a/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
@@ -512,6 +512,8 @@ impl AlignedReducer {
                 }
             }
 
+            // abort the shutdown handle since we are done processing, no need to wait for the
+            // hard shutdown.
             shutdown_handle.abort();
 
             info!(status=?self.final_result, "Aligned Reduce component successfully completed");

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
@@ -8,7 +8,7 @@ use crate::reduce::reducer::unaligned::windower::{
     UnalignedWindowManager, UnalignedWindowMessage, Window,
 };
 use crate::reduce::wal::segment::append::{AppendOnlyWal, SegmentWriteMessage};
-use crate::watermark::WatermarkHandle;
+use crate::watermark::isb::ISBWatermarkHandle;
 
 use chrono::{DateTime, Utc};
 use numaflow_pb::clients::accumulator::AccumulatorRequest;
@@ -518,9 +518,15 @@ pub(crate) struct UnalignedReducer {
     keyed: bool,
     /// Graceful shutdown timeout duration.
     graceful_timeout: Duration,
+    /// Idle timeout duration for reading messages.
+    idle_timeout: Duration,
+    /// Watermark handle for fetching head idle wmb to check if any windows can be closed,
+    /// when there is no data.
+    watermark_handle: Option<ISBWatermarkHandle>,
 }
 
 impl UnalignedReducer {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
         client: UserDefinedUnalignedReduce,
         window_manager: UnalignedWindowManager,
@@ -528,7 +534,9 @@ impl UnalignedReducer {
         allowed_lateness: Duration,
         gc_wal: Option<AppendOnlyWal>,
         graceful_timeout: Duration,
+        idle_timeout: Duration,
         keyed: bool,
+        watermark_handle: Option<ISBWatermarkHandle>,
     ) -> Self {
         Self {
             client,
@@ -541,13 +549,15 @@ impl UnalignedReducer {
             current_watermark: DateTime::from_timestamp_millis(-1).expect("Invalid timestamp"),
             keyed,
             graceful_timeout,
+            idle_timeout,
+            watermark_handle,
         }
     }
 
     /// Starts the reduce component and returns a handle to the main task.
     pub(crate) async fn start(
         mut self,
-        mut input_stream: ReceiverStream<Message>,
+        input_stream: ReceiverStream<Message>,
         cln_token: CancellationToken,
     ) -> crate::Result<JoinHandle<crate::Result<()>>> {
         // Set up error and GC channels
@@ -591,75 +601,58 @@ impl UnalignedReducer {
             actor.run().await;
         });
 
+        // Start the main task
         let handle = tokio::spawn(async move {
+            let mut input_stream = input_stream;
+
             loop {
                 tokio::select! {
-                    // listen for errors from any running tasks
-                    Some(error) = error_rx.recv() => {
-                        self.handle_error(error, &cln_token);
+                    // Check for errors from reduce tasks
+                    Some(err) = error_rx.recv() => {
+                        self.handle_error(err, &cln_token);
                     }
 
-                    read_msg = input_stream.next() => {
-                        if self.shutting_down_on_err {
-                            info!("Unaligned reducer is in shutdown mode, ignoring the message");
-                            continue;
-                        }
+                    // Process input messages with timeout
+                    read_msg = tokio::time::timeout(self.idle_timeout, input_stream.next()) => {
+                        match read_msg {
+                            Ok(Some(mut msg)) => {
+                                // If shutting down, drain the stream
+                                if self.shutting_down_on_err {
+                                    info!("Unaligned reducer is in shutdown mode, ignoring the message");
+                                    continue;
+                                }
 
-                        let Some(mut msg) = read_msg else {
-                            // end of stream we can exit
-                            break;
-                        };
+                                // If the stream is not keyed, set all messages to have the same key
+                                if !keyed {
+                                    msg.keys = Arc::new([DEFAULT_KEY_FOR_NON_KEYED_STREAM.to_string()]);
+                                }
 
-                        // if the stream is not keyed, then we need to set all the messages to have the same key
-                        // so that all the messages go to the same reduce task.
-                        if !keyed {
-                            msg.keys = Arc::new([DEFAULT_KEY_FOR_NON_KEYED_STREAM.to_string()]);
-                        }
+                                // Update the watermark - use max to ensure it never regresses
+                                self.current_watermark = self
+                                    .current_watermark
+                                    .max(msg.watermark.unwrap_or_default());
 
-                         // update the watermark.
-                        // we cannot simply assign incoming message's watermark as the current watermark,
-                        // because it can be -1. watermark will never regress, so use max.
-                        self.current_watermark = self.current_watermark.max(msg.watermark.unwrap_or_default());
-
-                        // check if any windows can be closed based on the current watermark
-                        let close_window_messages = self.window_manager.close_windows(self.current_watermark);
-                        for window_msg in close_window_messages {
-                            actor_tx
-                                .send(window_msg)
-                                .await
-                                .expect("failed to send message to actor");
-                        }
-
-                        // only drop the message if it is late and the event time is before the watermark - allowed lateness
-                        if msg.is_late && msg.event_time < self.current_watermark.sub(self.allowed_lateness) {
-                            debug!(event_time = ?msg.event_time.timestamp_millis(), watermark = ?self.current_watermark.timestamp_millis(), "Late message detected, dropping");
-                            // TODO(ajain): add a metric for this
-                            continue;
-                        }
-
-                        if  self.current_watermark > msg.event_time {
-                            error!(current_watermark=?self.current_watermark.timestamp_millis(), message_event_time=?msg.event_time.timestamp_millis(), is_late=?msg.is_late, offset=?msg.offset, "Old message popped up, Watermark is behind the event time");
-                            continue;
-                        }
-
-                        // Convert the message to UnalignedWindowMessage
-                        let window_messages = self.window_manager.assign_windows(msg);
-                        for window_msg in window_messages {
-                            // Send the message to the actor
-                            actor_tx
-                                .send(window_msg)
-                                .await
-                                .expect("failed to send message to actor");
+                                self.assign_and_close_windows(msg, &actor_tx).await;
+                            }
+                            Ok(None) => {
+                                // Stream ended
+                                break;
+                            }
+                            Err(_timeout) => {
+                                // watermark can still progress when there is no data, because of idle watermark
+                                // so we need to check if any windows can be closed based on the idle watermark.
+                                self.close_windows_by_idle_wm(&actor_tx).await;
+                            }
                         }
                     }
                 }
             }
 
             // Drop the sender to signal the actor to stop
-            drop(actor_tx);
             info!(
                 "Unaligned Reduce component is shutting down, waiting for active reduce tasks to complete"
             );
+            drop(actor_tx);
 
             // Wait for the actor to complete
             if let Err(e) = actor_handle.await {
@@ -670,7 +663,7 @@ impl UnalignedReducer {
             // hard shutdown.
             shutdown_handle.abort();
 
-            info!(status=?self.final_result, "UnalignedReduce component successfully completed");
+            info!(status=?self.final_result, "Unaligned Reduce component successfully completed");
             self.final_result
         });
 
@@ -691,10 +684,92 @@ impl UnalignedReducer {
     /// handle errors from the reduce tasks by cancelling token so that upstream knows there is an
     /// issue and stops sending new messages.
     fn handle_error(&mut self, error: Error, cln_token: &CancellationToken) {
-        error!(?error, "Error in reduce component");
-        self.final_result = Err(error);
-        self.shutting_down_on_err = true;
-        cln_token.cancel();
+        if self.final_result.is_ok() {
+            error!(?error, "Error received while performing reduce operation");
+            cln_token.cancel();
+            self.final_result = Err(error);
+            self.shutting_down_on_err = true;
+        }
+    }
+
+    /// Closes windows based on the provided watermark and sends close messages to the actor.
+    async fn close_windows_by_wm(
+        &self,
+        watermark: DateTime<Utc>,
+        actor_tx: &mpsc::Sender<UnalignedWindowMessage>,
+    ) {
+        let window_messages = self
+            .window_manager
+            .close_windows(watermark.sub(self.allowed_lateness));
+
+        for window_msg in window_messages {
+            actor_tx
+                .send(window_msg)
+                .await
+                .expect("Failed to send close window message");
+        }
+    }
+
+    /// Assigns windows to a message and sends the messages to the actor, also closes any windows
+    /// that can be closed based on the current watermark.
+    async fn assign_and_close_windows(
+        &mut self,
+        msg: Message,
+        actor_tx: &mpsc::Sender<UnalignedWindowMessage>,
+    ) {
+        // Drop late messages
+        if msg.is_late && msg.event_time < self.current_watermark.sub(self.allowed_lateness) {
+            debug!(event_time = ?msg.event_time.timestamp_millis(), watermark = ?self.current_watermark.timestamp_millis(), "Late message detected, dropping");
+            // TODO(ajain): add a metric for this
+            return;
+        }
+
+        // Validate message event time against current watermark
+        if self.current_watermark > msg.event_time {
+            error!(
+                current_watermark = ?self.current_watermark.timestamp_millis(),
+                message_event_time = ?msg.event_time.timestamp_millis(),
+                is_late = ?msg.is_late,
+                offset = ?msg.offset,
+                "Old message popped up, Watermark is behind the event time"
+            );
+            return;
+        }
+
+        // Close windows based on current watermark
+        self.close_windows_by_wm(self.current_watermark, actor_tx)
+            .await;
+
+        // Assign windows to the message
+        let window_messages = self.window_manager.assign_windows(msg);
+
+        // Send each window message to the actor for processing
+        for window_msg in window_messages {
+            actor_tx
+                .send(window_msg)
+                .await
+                .expect("Failed to send window message");
+        }
+    }
+
+    /// Closes windows based on the idle watermark.
+    async fn close_windows_by_idle_wm(&mut self, actor_tx: &mpsc::Sender<UnalignedWindowMessage>) {
+        if self.shutting_down_on_err {
+            return;
+        }
+
+        let Some(ref mut watermark_handle) = self.watermark_handle else {
+            return;
+        };
+
+        // Only fetch idle watermark if we have a watermark handle
+        let idle_watermark = watermark_handle.fetch_head_idle_watermark().await;
+
+        // Only close windows if the idle watermark is greater than the current watermark
+        if idle_watermark > self.current_watermark {
+            self.current_watermark = idle_watermark;
+            self.close_windows_by_wm(idle_watermark, actor_tx).await;
+        }
     }
 }
 
@@ -936,7 +1011,9 @@ mod tests {
             Duration::from_secs(0), // No allowed lateness for testing
             None,                   // No GC WAL for testing
             Duration::from_millis(50),
+            Duration::from_secs(1), // Idle timeout
             true,
+            None, // No watermark handle for testing
         )
         .await;
 
@@ -1159,7 +1236,9 @@ mod tests {
             Duration::from_secs(0), // No allowed lateness for testing
             None,                   // No GC WAL for testing
             Duration::from_millis(50),
+            Duration::from_secs(1), // Idle timeout
             true,
+            None, // No watermark handle for testing
         )
         .await;
 
@@ -1439,7 +1518,9 @@ mod tests {
             Duration::from_secs(0), // No allowed lateness for testing
             None,                   // No GC WAL for testing
             Duration::from_millis(50),
+            Duration::from_secs(1),
             true,
+            None,
         )
         .await;
 
@@ -1639,7 +1720,9 @@ mod tests {
             Duration::from_secs(0), // No allowed lateness for testing
             None,                   // No GC WAL for testing
             Duration::from_millis(50),
+            Duration::from_secs(1),
             true,
+            None,
         )
         .await;
 
@@ -1871,7 +1954,9 @@ mod tests {
             Duration::from_secs(0), // No allowed lateness for testing
             None,                   // No GC WAL for testing
             Duration::from_millis(50),
+            Duration::from_secs(1),
             true,
+            None,
         )
         .await;
 

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
@@ -8,6 +8,7 @@ use crate::reduce::reducer::unaligned::windower::{
     UnalignedWindowManager, UnalignedWindowMessage, Window,
 };
 use crate::reduce::wal::segment::append::{AppendOnlyWal, SegmentWriteMessage};
+use crate::watermark::WatermarkHandle;
 
 use chrono::{DateTime, Utc};
 use numaflow_pb::clients::accumulator::AccumulatorRequest;

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
@@ -636,8 +636,8 @@ impl UnalignedReducer {
                             continue;
                         }
 
-                        if self.current_watermark > msg.event_time {
-                            error!(current_watermark=?self.current_watermark, message_event_time=?msg.event_time, "Old message popped up, Watermark is behind the event time");
+                        if  self.current_watermark > msg.event_time {
+                            error!(current_watermark=?self.current_watermark.timestamp_millis(), message_event_time=?msg.event_time.timestamp_millis(), is_late=?msg.is_late, offset=?msg.offset, "Old message popped up, Watermark is behind the event time");
                             continue;
                         }
 

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/windower/session.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/windower/session.rs
@@ -639,11 +639,11 @@ mod tests {
         // (sorted by end time descending, so window3 comes first)
         assert_eq!(merged_groups.len(), 2);
 
-        // First group should have 1 window (window3)
-        assert_eq!(merged_groups[0].len(), 1);
+        // First group should have 2 windows (window2 and window1)
+        assert_eq!(merged_groups[0].len(), 2);
 
-        // Second group should have 2 windows (window2 and window1)
-        assert_eq!(merged_groups[1].len(), 2);
+        // Second group should  have 1 window (window3)
+        assert_eq!(merged_groups[1].len(), 1);
     }
 
     #[test]
@@ -770,60 +770,6 @@ mod tests {
         let expected_oldest =
             msg2.event_time + chrono::Duration::from_std(windower.timeout).unwrap();
         assert_eq!(oldest_time, expected_oldest);
-    }
-
-    #[test]
-    fn test_windows_that_can_be_merged_go_style_algorithm() {
-        // Test the optimized Go-style algorithm with the same example from Go documentation
-        let now = Utc::now();
-
-        // Create windows matching the Go example: (75, 85), (60, 90), (80, 100) and (110, 120)
-        let window1 = Window::new(
-            now + chrono::Duration::seconds(75),
-            now + chrono::Duration::seconds(85),
-            Arc::from(vec!["test_key".to_string()]),
-        );
-        let window2 = Window::new(
-            now + chrono::Duration::seconds(60),
-            now + chrono::Duration::seconds(90),
-            Arc::from(vec!["test_key".to_string()]),
-        );
-        let window3 = Window::new(
-            now + chrono::Duration::seconds(80),
-            now + chrono::Duration::seconds(100),
-            Arc::from(vec!["test_key".to_string()]),
-        );
-        let window4 = Window::new(
-            now + chrono::Duration::seconds(110),
-            now + chrono::Duration::seconds(120),
-            Arc::from(vec!["test_key".to_string()]),
-        );
-
-        // Input windows sorted by end time (ascending): (85, 90, 100, 120)
-        let windows = vec![window1, window2, window3, window4];
-
-        // Test merging
-        let merged_groups = SessionWindowManager::windows_that_can_be_merged(&windows);
-
-        // Should have 2 groups: one with the first three overlapping windows, one with the standalone window
-        assert_eq!(merged_groups.len(), 2);
-
-        // First group should have 1 window (the standalone window4 with end time 120)
-        assert_eq!(merged_groups[0].len(), 1);
-        assert_eq!(
-            merged_groups[0][0].end_time,
-            now + chrono::Duration::seconds(120)
-        );
-
-        // Second group should have 3 windows (the overlapping windows)
-        assert_eq!(merged_groups[1].len(), 3);
-
-        // Verify the windows in the second group are the overlapping ones
-        let second_group_end_times: Vec<_> = merged_groups[1].iter().map(|w| w.end_time).collect();
-
-        assert!(second_group_end_times.contains(&(now + chrono::Duration::seconds(85))));
-        assert!(second_group_end_times.contains(&(now + chrono::Duration::seconds(90))));
-        assert!(second_group_end_times.contains(&(now + chrono::Duration::seconds(100))));
     }
 
     #[test]

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/windower/session.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/windower/session.rs
@@ -402,6 +402,8 @@ impl SessionWindowManager {
             merged_groups.push(merged_group);
         }
 
+        // reverse so that the smaller windows gets merged and closed first
+        merged_groups.reverse();
         merged_groups
     }
 

--- a/rust/numaflow-core/src/watermark/isb/wm_publisher.rs
+++ b/rust/numaflow-core/src/watermark/isb/wm_publisher.rs
@@ -185,7 +185,7 @@ impl ISBWatermarkPublisher {
         // Supposed publish watermark offset=3605637 watermark=1750758998480 last_published_offset=3605147 last_published_watermark=1750758997480
         // Actual published watermark offset=3605637 watermark=1750758998480
         // We should've published watermark for offset 3605646 and skipped publishing for offset 3605637
-        if watermark <= last_state.watermark {
+        if watermark == -1 || watermark == last_state.watermark {
             last_state.offset = last_state.offset.max(offset);
             return;
         }

--- a/rust/numaflow-core/src/watermark/isb/wm_publisher.rs
+++ b/rust/numaflow-core/src/watermark/isb/wm_publisher.rs
@@ -172,7 +172,8 @@ impl ISBWatermarkPublisher {
         // NOTE: in idling case since we reuse the control message offset, we can have the same offset
         // with larger watermark (we should publish it).
         let last_state = &mut last_published_wm_state[stream.partition as usize];
-        if offset < last_state.offset || watermark < last_state.watermark {
+        if offset < last_state.offset {
+            last_state.watermark = last_state.watermark.max(watermark);
             return;
         }
 
@@ -184,8 +185,8 @@ impl ISBWatermarkPublisher {
         // Supposed publish watermark offset=3605637 watermark=1750758998480 last_published_offset=3605147 last_published_watermark=1750758997480
         // Actual published watermark offset=3605637 watermark=1750758998480
         // We should've published watermark for offset 3605646 and skipped publishing for offset 3605637
-        if watermark == last_state.watermark {
-            last_state.offset = offset;
+        if watermark <= last_state.watermark {
+            last_state.offset = last_state.offset.max(offset);
             return;
         }
 

--- a/test/reduce-two-e2e/testdata/session-reduce/simple-session-keyed-counter-pipeline-go.yaml
+++ b/test/reduce-two-e2e/testdata/session-reduce/simple-session-keyed-counter-pipeline-go.yaml
@@ -7,11 +7,21 @@ spec:
     maxDelay: 30s
   vertices:
     - name: in
+      limits:
+        readBatchSize: 1
+      containerTemplate:
+        env:
+          - name: NUMAFLOW_RUNTIME
+            value: "rust"
       scale:
         min: 1
       source:
         http: {}
     - name: even-odd
+      containerTemplate:
+        env:
+          - name: NUMAFLOW_RUNTIME
+            value: "rust"
       scale:
         min: 1
       udf:
@@ -19,6 +29,10 @@ spec:
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
           imagePullPolicy: Always
     - name: compute-count
+      containerTemplate:
+        env:
+          - name: NUMAFLOW_RUNTIME
+            value: "rust"
       partitions: 1
       udf:
         container:
@@ -35,6 +49,10 @@ spec:
               volumeSize: 2Gi
               accessMode: ReadWriteOnce
     - name: sink
+      containerTemplate:
+        env:
+          - name: NUMAFLOW_RUNTIME
+            value: "rust"
       scale:
         min: 1
       sink:

--- a/test/reduce-two-e2e/testdata/session-reduce/simple-session-keyed-counter-pipeline-java.yaml
+++ b/test/reduce-two-e2e/testdata/session-reduce/simple-session-keyed-counter-pipeline-java.yaml
@@ -7,11 +7,19 @@ spec:
     maxDelay: 30s
   vertices:
     - name: in
+      containerTemplate:
+        env:
+          - name: NUMAFLOW_RUNTIME
+            value: "rust"
       scale:
         min: 1
       source:
         http: {}
     - name: even-odd
+      containerTemplate:
+        env:
+          - name: NUMAFLOW_RUNTIME
+            value: "rust"
       scale:
         min: 1
       udf:
@@ -19,6 +27,10 @@ spec:
           image: quay.io/numaio/numaflow-go/map-even-odd:stable
           imagePullPolicy: Always
     - name: compute-count
+      containerTemplate:
+        env:
+          - name: NUMAFLOW_RUNTIME
+            value: "rust"
       partitions: 1
       udf:
         container:
@@ -32,14 +44,13 @@ spec:
           keyed: true
           storage:
             persistentVolumeClaim:
-              volumeSize: 2Gi
+              volumeSize: 1Gi
               accessMode: ReadWriteOnce
-    - name: log-sink
-      scale:
-        min: 1
-      sink:
-        log: {}
     - name: sink
+      containerTemplate:
+        env:
+          - name: NUMAFLOW_RUNTIME
+            value: "rust"
       scale:
         min: 1
       sink:
@@ -59,5 +70,3 @@ spec:
       to: compute-count
     - from: compute-count
       to: sink
-    - from: compute-count
-      to: log-sink


### PR DESCRIPTION
* Update last publish offset to larger value even when the watermark is -1 to avoid watermark regression
* Fix session merge edge cases
* Add keys to message id to avoid duplicates in session windows
* Refactored aligned and unaligned reducer to make it more readable
* Close windows when there is no input data(idling)