### PR TITLE
fix: handle stream already existing when making consumer

### DIFF
--- a/pkg/isbsvc/jetstream_service.go
+++ b/pkg/isbsvc/jetstream_service.go
@@ -191,6 +191,14 @@ func (jss *jetStreamSvc) CreateBuffersAndBuckets(ctx context.Context, buffers, b
 				return fmt.Errorf("failed to create stream %q and buffers, %w", streamName, err)
 			}
 			log.Infow("Succeeded to create a stream", zap.String("stream", streamName))
+		}
+
+		_, err = jss.js.ConsumerInfo(streamName, streamName)
+		if err != nil {
+			if !errors.Is(err, nats.ErrConsumerNotFound) {
+				return fmt.Errorf("failed to query information of consumer for stream %q, %w", streamName, err)
+			}
+
 			if _, err := jss.js.AddConsumer(streamName, &nats.ConsumerConfig{
 				Durable:       streamName,
 				DeliverPolicy: nats.DeliverAllPolicy,


### PR DESCRIPTION
We had been experiencing issues where sometimes the ISBSvc was not initialised correctly for a pipeline.

This changes initialisation to not assume consumers exist if streams exist.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
