### PR TITLE
chore: make watermark operations blocking

### DIFF
--- a/rust/numaflow-core/src/config/components.rs
+++ b/rust/numaflow-core/src/config/components.rs
@@ -634,7 +634,10 @@ pub(crate) mod sink {
                     .split('\n')
                     .map(|s| s.split(':').collect::<Vec<&str>>())
                     .filter(|parts| parts.len() == 2)
-                    .map(|parts| (parts[0].trim().to_string(), parts[1].trim().to_string()))
+                    .map(|parts| (
+                        parts.first().expect("should have first part").trim().to_string(),
+                        parts.get(1).expect("should have second part").trim().to_string()
+                    ))
                     .collect::<HashMap<String, String>>(),
             })))
         }

--- a/rust/numaflow-core/src/config/components.rs
+++ b/rust/numaflow-core/src/config/components.rs
@@ -299,7 +299,12 @@ pub(crate) mod source {
                     .split('\n')
                     .map(|s| s.split(':').collect::<Vec<&str>>())
                     .filter(|parts| parts.len() == 2)
-                    .map(|parts| (parts[0].trim().to_string(), parts[1].trim().to_string()))
+                    .map(|parts| {
+                        (
+                            parts.first().unwrap().trim().to_string(),
+                            parts.get(1).unwrap().trim().to_string(),
+                        )
+                    })
                     .collect::<HashMap<String, String>>(),
             };
             Ok(SourceType::Kafka(Box::new(kafka_config)))

--- a/rust/numaflow-core/src/config/components.rs
+++ b/rust/numaflow-core/src/config/components.rs
@@ -634,10 +634,20 @@ pub(crate) mod sink {
                     .split('\n')
                     .map(|s| s.split(':').collect::<Vec<&str>>())
                     .filter(|parts| parts.len() == 2)
-                    .map(|parts| (
-                        parts.first().expect("should have first part").trim().to_string(),
-                        parts.get(1).expect("should have second part").trim().to_string()
-                    ))
+                    .map(|parts| {
+                        (
+                            parts
+                                .first()
+                                .expect("should have first part")
+                                .trim()
+                                .to_string(),
+                            parts
+                                .get(1)
+                                .expect("should have second part")
+                                .trim()
+                                .to_string(),
+                        )
+                    })
                     .collect::<HashMap<String, String>>(),
             })))
         }

--- a/rust/numaflow-core/src/mapper/map.rs
+++ b/rust/numaflow-core/src/mapper/map.rs
@@ -709,7 +709,7 @@ mod tests {
 
         // wait for the server to start
         tokio::time::sleep(Duration::from_millis(100)).await;
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
 
         let client = MapClient::new(create_rpc_channel(sock_file).await?);
         let mapper = MapHandle::new(
@@ -802,7 +802,7 @@ mod tests {
         // wait for the server to start
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let client = MapClient::new(create_rpc_channel(sock_file).await?);
         let mapper = MapHandle::new(
             MapMode::Unary,
@@ -893,7 +893,7 @@ mod tests {
         // wait for the server to start
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let client = MapClient::new(create_rpc_channel(sock_file).await?);
         let mapper = MapHandle::new(
             MapMode::Unary,
@@ -995,7 +995,7 @@ mod tests {
 
         // wait for the server to start
         tokio::time::sleep(Duration::from_millis(100)).await;
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
 
         let client = MapClient::new(create_rpc_channel(sock_file).await?);
         let mapper = MapHandle::new(
@@ -1109,7 +1109,7 @@ mod tests {
         // wait for the server to start
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let client = MapClient::new(create_rpc_channel(sock_file).await?);
         let mapper = MapHandle::new(
             MapMode::Batch,
@@ -1222,7 +1222,7 @@ mod tests {
 
         // wait for the server to start
         tokio::time::sleep(Duration::from_millis(100)).await;
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
 
         let client = MapClient::new(create_rpc_channel(sock_file).await?);
         let mapper = MapHandle::new(
@@ -1321,7 +1321,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         let client = MapClient::new(create_rpc_channel(sock_file).await?);
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let mapper = MapHandle::new(
             MapMode::Stream,
             500,

--- a/rust/numaflow-core/src/message.rs
+++ b/rust/numaflow-core/src/message.rs
@@ -1,4 +1,4 @@
-use std::cmp::PartialEq;
+use std::cmp::{Ordering, PartialEq};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
@@ -242,6 +242,22 @@ impl fmt::Display for Offset {
     }
 }
 
+impl PartialOrd for Offset {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Offset {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Offset::Int(a), Offset::Int(b)) => a.cmp(b),
+            (Offset::String(a), Offset::String(b)) => a.cmp(b),
+            _ => Ordering::Equal,
+        }
+    }
+}
+
 impl Default for Offset {
     fn default() -> Self {
         Offset::Int(Default::default())
@@ -273,6 +289,18 @@ impl IntOffset {
     }
 }
 
+impl PartialOrd for IntOffset {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for IntOffset {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.offset.cmp(&other.offset)
+    }
+}
+
 impl fmt::Display for IntOffset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}-{}", self.offset, self.partition_idx)
@@ -293,6 +321,18 @@ impl StringOffset {
             offset: seq.into(),
             partition_idx,
         }
+    }
+}
+
+impl PartialOrd for StringOffset {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for StringOffset {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.offset.cmp(&other.offset)
     }
 }
 

--- a/rust/numaflow-core/src/message.rs
+++ b/rust/numaflow-core/src/message.rs
@@ -233,6 +233,15 @@ pub(crate) enum Offset {
     String(StringOffset),
 }
 
+impl Offset {
+    pub(crate) fn partition_idx(&self) -> u16 {
+        match self {
+            Offset::Int(offset) => offset.partition_idx,
+            Offset::String(offset) => offset.partition_idx,
+        }
+    }
+}
+
 impl fmt::Display for Offset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/rust/numaflow-core/src/metrics.rs
+++ b/rust/numaflow-core/src/metrics.rs
@@ -1796,7 +1796,7 @@ mod tests {
                 .await
                 .expect("Failed to create source reader");
 
-        let tracker = TrackerHandle::new(None, None);
+        let tracker = TrackerHandle::new(None);
         let source = Source::new(
             5,
             SourceType::UserDefinedSource(Box::new(src_read), Box::new(src_ack), lag_reader),

--- a/rust/numaflow-core/src/monovertex.rs
+++ b/rust/numaflow-core/src/monovertex.rs
@@ -23,7 +23,7 @@ pub(crate) async fn start_forwarder(
     cln_token: CancellationToken,
     config: &MonovertexConfig,
 ) -> error::Result<()> {
-    let tracker_handle = TrackerHandle::new(None, None);
+    let tracker_handle = TrackerHandle::new(None);
 
     let transformer = create_components::create_transformer(
         config.batch_size,

--- a/rust/numaflow-core/src/monovertex/forwarder.rs
+++ b/rust/numaflow-core/src/monovertex/forwarder.rs
@@ -194,7 +194,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_forwarder() {
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
 
         // create the source which produces x number of messages
         let cln_token = CancellationToken::new();
@@ -257,7 +257,7 @@ mod tests {
             .await
             .map_err(|e| panic!("failed to create source reader: {:?}", e))
             .unwrap();
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let source = Source::new(
             5,
             SourceType::UserDefinedSource(Box::new(src_read), Box::new(src_ack), lag_reader),
@@ -332,7 +332,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_flatmap_operation() {
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         // create the source which produces x number of messages
         let cln_token = CancellationToken::new();
 

--- a/rust/numaflow-core/src/pipeline.rs
+++ b/rust/numaflow-core/src/pipeline.rs
@@ -453,10 +453,7 @@ async fn start_aligned_reduce_forwarder(
     reduce_vtx_config: ReduceVtxConfig,
     aligned_config: AlignedReducerConfig,
 ) -> Result<()> {
-    // For reduce, we don't need to pass the watermark handle to the tracker, since the
-    // tracker only tracks the offsets until they are written to the WAL, watermark is
-    // not published using the tracker, instead writer directly publishes the watermark for reduce
-    // vertices since the lowest watermark is identified by the window manager.
+    // for reduce we do not pass serving callback handler to tracker.
     let tracker_handle = TrackerHandle::new(None);
 
     // Create aligned window manager based on window type
@@ -644,8 +641,7 @@ async fn start_unaligned_reduce_forwarder(
     reduce_vtx_config: ReduceVtxConfig,
     unaligned_config: UnalignedReducerConfig,
 ) -> Result<()> {
-    // we don't need to pass the watermark handle to the tracker because in reduce windower is
-    // responsible for identifying the lowest watermark in the pod.
+    // for reduce we do not pass serving callback handler to tracker.
     let tracker_handle = TrackerHandle::new(None);
 
     // Create unaligned window manager based on window type

--- a/rust/numaflow-core/src/pipeline.rs
+++ b/rust/numaflow-core/src/pipeline.rs
@@ -140,7 +140,7 @@ async fn start_source_forwarder(
         tracker_handle: tracker_handle.clone(),
         cancel_token: cln_token.clone(),
         watermark_handle: source_watermark_handle.clone().map(WatermarkHandle::Source),
-        vertex_type: config.vertex_type.to_string(),
+        vertex_type: config.vertex_type,
         isb_config: config.isb_config.clone(),
     });
 
@@ -246,7 +246,7 @@ async fn start_map_forwarder(
         tracker_handle: tracker_handle.clone(),
         cancel_token: cln_token.clone(),
         watermark_handle: watermark_handle.clone().map(WatermarkHandle::ISB),
-        vertex_type: config.vertex_type.to_string(),
+        vertex_type: config.vertex_type.clone(),
         isb_config: config.isb_config.clone(),
     });
 
@@ -502,7 +502,9 @@ async fn start_aligned_reduce_forwarder(
 
     // we don't need to pass the watermark handle to the tracker because in reduce windower is
     // responsible for identifying the lowest watermark in the pod.
-    let tracker_handle = TrackerHandle::new(None, None);
+    let tracker_handle =
+        TrackerHandle::new(watermark_handle.clone().map(WatermarkHandle::ISB), None);
+
     // Create buffer reader
     let buffer_reader = JetStreamReader::new(ISBReaderConfig {
         vertex_type: config.vertex_type.to_string(),
@@ -525,7 +527,7 @@ async fn start_aligned_reduce_forwarder(
         tracker_handle: tracker_handle.clone(),
         cancel_token: cln_token.clone(),
         watermark_handle: watermark_handle.clone().map(WatermarkHandle::ISB),
-        vertex_type: config.vertex_type.to_string(),
+        vertex_type: config.vertex_type.clone(),
         isb_config: config.isb_config.clone(),
     });
 
@@ -676,7 +678,9 @@ async fn start_unaligned_reduce_forwarder(
 
     // we don't need to pass the watermark handle to the tracker because in reduce windower is
     // responsible for identifying the lowest watermark in the pod.
-    let tracker_handle = TrackerHandle::new(None, None);
+    let tracker_handle =
+        TrackerHandle::new(watermark_handle.clone().map(WatermarkHandle::ISB), None);
+
     // Create buffer reader
     let buffer_reader = JetStreamReader::new(ISBReaderConfig {
         vertex_type: config.vertex_type.to_string(),
@@ -698,7 +702,7 @@ async fn start_unaligned_reduce_forwarder(
         tracker_handle: tracker_handle.clone(),
         cancel_token: cln_token.clone(),
         watermark_handle: watermark_handle.clone().map(WatermarkHandle::ISB),
-        vertex_type: config.vertex_type.to_string(),
+        vertex_type: config.vertex_type.clone(),
         isb_config: config.isb_config.clone(),
     });
 

--- a/rust/numaflow-core/src/pipeline.rs
+++ b/rust/numaflow-core/src/pipeline.rs
@@ -246,7 +246,7 @@ async fn start_map_forwarder(
         tracker_handle: tracker_handle.clone(),
         cancel_token: cln_token.clone(),
         watermark_handle: watermark_handle.clone().map(WatermarkHandle::ISB),
-        vertex_type: config.vertex_type.clone(),
+        vertex_type: config.vertex_type,
         isb_config: config.isb_config.clone(),
     });
 
@@ -529,7 +529,7 @@ async fn start_aligned_reduce_forwarder(
         tracker_handle: tracker_handle.clone(),
         cancel_token: cln_token.clone(),
         watermark_handle: watermark_handle.clone().map(WatermarkHandle::ISB),
-        vertex_type: config.vertex_type.clone(),
+        vertex_type: config.vertex_type,
         isb_config: config.isb_config.clone(),
     });
 
@@ -704,7 +704,7 @@ async fn start_unaligned_reduce_forwarder(
         tracker_handle: tracker_handle.clone(),
         cancel_token: cln_token.clone(),
         watermark_handle: watermark_handle.clone().map(WatermarkHandle::ISB),
-        vertex_type: config.vertex_type.clone(),
+        vertex_type: config.vertex_type,
         isb_config: config.isb_config.clone(),
     });
 

--- a/rust/numaflow-core/src/pipeline.rs
+++ b/rust/numaflow-core/src/pipeline.rs
@@ -890,7 +890,7 @@ async fn start_sink_forwarder(
             config.read_timeout,
             sink.sink_config.clone(),
             sink.fb_sink_config.clone(),
-            tracker_handle,
+            tracker_handle.clone(),
             serving_store.clone(),
             &cln_token,
         )

--- a/rust/numaflow-core/src/pipeline/forwarder/source_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/source_forwarder.rs
@@ -282,7 +282,7 @@ mod tests {
             tracker_handle: tracker_handle.clone(),
             cancel_token: cln_token.clone(),
             watermark_handle: None,
-            vertex_type: "Source".to_string(),
+            vertex_type: VertexType::Source,
             isb_config: None,
         });
 

--- a/rust/numaflow-core/src/pipeline/forwarder/source_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/source_forwarder.rs
@@ -162,7 +162,7 @@ mod tests {
     #[cfg(feature = "nats-tests")]
     #[tokio::test]
     async fn test_source_forwarder() {
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
 
         // create the source which produces x number of messages
         let cln_token = CancellationToken::new();

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/reader.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/reader.rs
@@ -652,7 +652,7 @@ mod tests {
             streams: vec![],
             wip_ack_interval: Duration::from_millis(5),
         };
-        let tracker = TrackerHandle::new(None, None);
+        let tracker = TrackerHandle::new(None);
         let js_reader = JetStreamReader::new(ISBReaderConfig {
             vertex_type: "Map".to_string(),
             stream: stream.clone(),
@@ -715,7 +715,7 @@ mod tests {
 
         reader_cancel_token.cancel();
         for offset in offsets {
-            tracker.delete(offset, None).await.unwrap();
+            tracker.delete(offset).await.unwrap();
         }
         js_reader_task.await.unwrap().unwrap();
         context.delete_stream(stream.name).await.unwrap();
@@ -728,7 +728,7 @@ mod tests {
         // Create JetStream context
         let client = async_nats::connect(js_url).await.unwrap();
         let context = jetstream::new(client);
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
 
         let js_stream = Stream::new("test-ack", "test", 0);
         // Delete stream if it exists
@@ -813,7 +813,7 @@ mod tests {
 
         // after reading messages remove from the tracker so that the messages are acked
         for offset in offsets {
-            tracker_handle.delete(offset, None).await.unwrap();
+            tracker_handle.delete(offset).await.unwrap();
         }
 
         // wait until the tracker becomes empty, don't wait more than 1 second
@@ -909,7 +909,7 @@ mod tests {
             streams: vec![],
             wip_ack_interval: Duration::from_millis(5),
         };
-        let tracker = TrackerHandle::new(None, None);
+        let tracker = TrackerHandle::new(None);
         let js_reader = JetStreamReader::new(ISBReaderConfig {
             vertex_type: "Map".to_string(),
             stream: stream.clone(),
@@ -981,7 +981,7 @@ mod tests {
         assert_eq!(received_message.offset.to_string(), offset.to_string());
 
         // Clean up
-        tracker.delete(offset, None).await.unwrap();
+        tracker.delete(offset).await.unwrap();
         reader_cancel_token.cancel();
         js_reader_task.await.unwrap().unwrap();
         context.delete_stream(stream.name).await.unwrap();

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/writer.rs
@@ -610,8 +610,8 @@ impl JetstreamWriter {
                 }
             }
 
-            // Now that the PAF is resolved, we can delete the entry from the tracker
-            // which will optionally publish the watermarks
+            // Now that the PAF is resolved, we can delete the entry from the tracker which will send
+            // an ACK to the reader.
             this.tracker_handle
                 .delete(message.offset.clone())
                 .await

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/writer.rs
@@ -237,7 +237,7 @@ impl JetstreamWriter {
                 if message.dropped() {
                     // delete the entry from tracker
                     self.tracker_handle
-                        .delete(message.offset, None)
+                        .delete(message.offset)
                         .await
                         .expect("Failed to delete offset from tracker");
                     pipeline_metrics()
@@ -438,7 +438,7 @@ impl JetstreamWriter {
                         BufferFullStrategy::DiscardLatest => {
                             // delete the entry from tracker
                             self.tracker_handle
-                                .delete(offset.clone(), None)
+                                .delete(offset.clone())
                                 .await
                                 .expect("Failed to delete offset from tracker");
                             // increment drop metric if buffer is full and
@@ -621,7 +621,7 @@ impl JetstreamWriter {
                     // Now that the PAF is resolved, we can delete the entry from the tracker
                     // which will optionally publish the watermarks
                     this.tracker_handle
-                        .delete(message.offset.clone(), Some(offsets))
+                        .delete(message.offset.clone())
                         .await
                         .expect("Failed to delete offset from tracker");
                 }
@@ -708,7 +708,7 @@ mod tests {
     #[cfg(feature = "nats-tests")]
     #[tokio::test]
     async fn test_async_write() {
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let cln_token = CancellationToken::new();
         let js_url = "localhost:4222";
         // Create JetStream context
@@ -850,7 +850,7 @@ mod tests {
             }],
             js_ctx: context.clone(),
             paf_concurrency: 100,
-            tracker_handle: TrackerHandle::new(None, None),
+            tracker_handle: TrackerHandle::new(None),
             cancel_token: cln_token.clone(),
             watermark_handle: None,
             vertex_type: VertexType::Source,
@@ -871,7 +871,7 @@ mod tests {
     #[cfg(feature = "nats-tests")]
     #[tokio::test]
     async fn test_write_with_cancellation() {
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let js_url = "localhost:4222";
         // Create JetStream context
         let client = async_nats::connect(js_url).await.unwrap();
@@ -1080,7 +1080,7 @@ mod tests {
     #[cfg(feature = "nats-tests")]
     #[tokio::test]
     async fn test_check_stream_status() {
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let js_url = "localhost:4222";
         // Create JetStream context
         let client = async_nats::connect(js_url).await.unwrap();
@@ -1183,7 +1183,7 @@ mod tests {
         // Create JetStream context
         let client = async_nats::connect(js_url).await.unwrap();
         let context = jetstream::new(client);
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
 
         let stream = Stream::new("test_publish_messages", "temp", 0);
         // Delete stream if it exists
@@ -1278,7 +1278,7 @@ mod tests {
         // Create JetStream context
         let client = async_nats::connect(js_url).await.unwrap();
         let context = jetstream::new(client);
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
 
         let stream = Stream::new("test_publish_cancellation", "temp", 0);
         // Delete stream if it exists
@@ -1403,7 +1403,7 @@ mod tests {
         let js_url = "localhost:4222";
         let client = async_nats::connect(js_url).await.unwrap();
         let context = jetstream::new(client);
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let cln_token = CancellationToken::new();
 
         let vertex1_streams = vec![

--- a/rust/numaflow-core/src/reduce/pbq.rs
+++ b/rust/numaflow-core/src/reduce/pbq.rs
@@ -150,7 +150,7 @@ impl PBQ {
             while let Some(offset) = offset_stream.next().await {
                 // no watermark publishing here, since we are just acknowledging the write to WAL
                 tracker_handle
-                    .delete(offset, None)
+                    .delete(offset)
                     .await
                     .expect("Failed to delete offset");
             }
@@ -235,7 +235,7 @@ mod tests {
             streams: vec![],
             wip_ack_interval: Duration::from_millis(5),
         };
-        let tracker = TrackerHandle::new(None, None);
+        let tracker = TrackerHandle::new(None);
         use crate::pipeline::isb::jetstream::reader::ISBReaderConfig;
         let js_reader = JetStreamReader::new(ISBReaderConfig {
             vertex_type: "test".to_string(),
@@ -349,7 +349,7 @@ mod tests {
             streams: vec![],
             wip_ack_interval: Duration::from_millis(5),
         };
-        let tracker = TrackerHandle::new(None, None);
+        let tracker = TrackerHandle::new(None);
         use crate::pipeline::isb::jetstream::reader::ISBReaderConfig;
         let js_reader = JetStreamReader::new(ISBReaderConfig {
             vertex_type: "test".to_string(),
@@ -584,7 +584,7 @@ mod tests {
             streams: vec![],
             wip_ack_interval: Duration::from_millis(5),
         };
-        let tracker = TrackerHandle::new(None, None);
+        let tracker = TrackerHandle::new(None);
         use crate::pipeline::isb::jetstream::reader::ISBReaderConfig;
         let js_reader = JetStreamReader::new(ISBReaderConfig {
             vertex_type: "test".to_string(),

--- a/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
@@ -1,5 +1,7 @@
+use crate::config::{get_vertex_name, get_vertex_replica};
 use crate::error::Error;
 use crate::message::Message;
+use crate::metrics::{pipeline_drop_metric_labels, pipeline_metrics};
 use crate::pipeline::isb::jetstream::writer::JetstreamWriter;
 use crate::reduce::reducer::aligned::user_defined::UserDefinedAlignedReduce;
 use crate::reduce::reducer::aligned::windower::{
@@ -297,9 +299,10 @@ impl AlignedReduceActor {
     async fn window_append(&mut self, mut window_msg: AlignedWindowMessage) {
         let window_id = &window_msg.pnf_slot;
 
-        // Get the existing stream or log error if not found create a new one.
+        // Get the existing stream or log error if not found create a new one. This is due to replay,
+        // during normal operation there will be an explicit open message before the append message.
         let Some(active_stream) = self.active_streams.get(window_id) else {
-            // windows may not be found during replay, because the windower doesn't send the open
+            // windows may not be found during replay, because the window-manager doesn't send the open
             // message for the active windows that got replayed, hence we create a new one.
             // this happens because of out-of-order messages, and we have to ensure that the (t+1)th
             // message is sent to the window that could be created by (t)th message iff (t+1)th message
@@ -578,7 +581,16 @@ impl AlignedReducer {
         // Drop late messages
         if msg.is_late && msg.event_time < self.current_watermark.sub(self.allowed_lateness) {
             debug!(event_time = ?msg.event_time.timestamp_millis(), watermark = ?self.current_watermark.timestamp_millis(), "Late message detected, dropping");
-            // TODO(ajain): add a metric for this
+            pipeline_metrics()
+                .forwarder
+                .drop_total
+                .get_or_create(&pipeline_drop_metric_labels(
+                    get_vertex_name(),
+                    get_vertex_replica().to_string().as_str(),
+                    "late-message",
+                ))
+                .inc();
+
             return;
         }
 
@@ -591,6 +603,15 @@ impl AlignedReducer {
                 offset = ?msg.offset,
                 "Old message popped up, Watermark is behind the event time"
             );
+            pipeline_metrics()
+                .forwarder
+                .drop_total
+                .get_or_create(&pipeline_drop_metric_labels(
+                    get_vertex_name(),
+                    get_vertex_replica().to_string().as_str(),
+                    "old-message-popped-up",
+                ))
+                .inc();
             return;
         }
 

--- a/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
@@ -765,7 +765,7 @@ mod tests {
             tracker_handle: tracker_handle.clone(),
             cancel_token: cln_token.clone(),
             watermark_handle: None,
-            vertex_type: "Reduce".to_string(),
+            vertex_type: VertexType::ReduceUDF,
             isb_config: None,
         });
 
@@ -1014,7 +1014,7 @@ mod tests {
             tracker_handle: tracker_handle.clone(),
             cancel_token: cln_token.clone(),
             watermark_handle: None,
-            vertex_type: "Reduce".to_string(),
+            vertex_type: VertexType::ReduceUDF,
             isb_config: None,
         });
 
@@ -1266,7 +1266,7 @@ mod tests {
             tracker_handle: tracker_handle.clone(),
             cancel_token: cln_token.clone(),
             watermark_handle: None,
-            vertex_type: "Reduce".to_string(),
+            vertex_type: VertexType::ReduceUDF,
             isb_config: None,
         });
 

--- a/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
@@ -747,7 +747,7 @@ mod tests {
 
         // Create JetstreamWriter
         let cln_token = CancellationToken::new();
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         use crate::pipeline::isb::jetstream::writer::ISBWriterConfig;
         let js_writer = JetstreamWriter::new(ISBWriterConfig {
             config: vec![ToVertexConfig {
@@ -996,7 +996,7 @@ mod tests {
 
         // Create JetstreamWriter
         let cln_token = CancellationToken::new();
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         use crate::pipeline::isb::jetstream::writer::ISBWriterConfig;
         let js_writer = JetstreamWriter::new(ISBWriterConfig {
             config: vec![ToVertexConfig {
@@ -1248,7 +1248,7 @@ mod tests {
 
         // Create JetstreamWriter
         let cln_token = CancellationToken::new();
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         use crate::pipeline::isb::jetstream::writer::ISBWriterConfig;
         let js_writer = JetstreamWriter::new(ISBWriterConfig {
             config: vec![ToVertexConfig {

--- a/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
@@ -570,6 +570,7 @@ impl AlignedReducer {
     ) {
         // Drop late messages
         if msg.is_late && msg.event_time < self.current_watermark.sub(self.allowed_lateness) {
+            debug!(event_time = ?msg.event_time.timestamp_millis(), watermark = ?self.current_watermark.timestamp_millis(), "Late message detected, dropping");
             // TODO(ajain): add a metric for this
             return;
         }

--- a/rust/numaflow-core/src/reduce/reducer/aligned/windower/sliding.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/windower/sliding.rs
@@ -76,6 +76,10 @@ pub(crate) struct SlidingWindowManager {
     slide: Duration,
     /// Active windows sorted by end time. The state is saved to a file on shutdown and loaded on
     /// startup.
+    /// NOTE: During replay we will assume that these windows are opened when we get the first message.
+    /// Since we do not differentiate between the first message and subsequent messages, we does an
+    /// "append" and in the "append" we "open" the stream if stream doesn't exist.
+    /// TODO: perhaps we can differentiate between replayed window vs new window during normal operation.
     active_windows: Arc<RwLock<BTreeSet<Window>>>,
     /// Closed windows sorted by end time. We need to keep track of closed windows so that we can
     /// find the oldest window computed and forwarded. The watermark is progressed based on the latest

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
@@ -982,7 +982,7 @@ mod tests {
 
         // Create JetstreamWriter
         let cln_token = CancellationToken::new();
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let js_writer = JetstreamWriter::new(ISBWriterConfig {
             config: vec![ToVertexConfig {
                 name: "test-vertex",
@@ -1207,7 +1207,7 @@ mod tests {
 
         // Create JetstreamWriter
         let cln_token = CancellationToken::new();
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let js_writer = JetstreamWriter::new(ISBWriterConfig {
             config: vec![ToVertexConfig {
                 name: "test-vertex",
@@ -1489,7 +1489,7 @@ mod tests {
 
         // Create JetstreamWriter
         let cln_token = CancellationToken::new();
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let js_writer = JetstreamWriter::new(ISBWriterConfig {
             config: vec![ToVertexConfig {
                 name: "test-vertex",
@@ -1691,7 +1691,7 @@ mod tests {
 
         // Create JetstreamWriter
         let cln_token = CancellationToken::new();
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let js_writer = JetstreamWriter::new(ISBWriterConfig {
             config: vec![ToVertexConfig {
                 name: "test-vertex",
@@ -1925,7 +1925,7 @@ mod tests {
 
         // Create JetstreamWriter
         let cln_token = CancellationToken::new();
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let js_writer = JetstreamWriter::new(ISBWriterConfig {
             config: vec![ToVertexConfig {
                 name: "test-vertex",

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
@@ -999,7 +999,7 @@ mod tests {
             tracker_handle: tracker_handle.clone(),
             cancel_token: cln_token.clone(),
             watermark_handle: None,
-            vertex_type: "Reduce".to_string(),
+            vertex_type: VertexType::ReduceUDF,
             isb_config: None,
         });
 
@@ -1224,7 +1224,7 @@ mod tests {
             tracker_handle: tracker_handle.clone(),
             cancel_token: cln_token.clone(),
             watermark_handle: None,
-            vertex_type: "Reduce".to_string(),
+            vertex_type: VertexType::ReduceUDF,
             isb_config: None,
         });
 
@@ -1506,7 +1506,7 @@ mod tests {
             tracker_handle: tracker_handle.clone(),
             cancel_token: cln_token.clone(),
             watermark_handle: None,
-            vertex_type: "Reduce".to_string(),
+            vertex_type: VertexType::ReduceUDF,
             isb_config: None,
         });
 
@@ -1708,7 +1708,7 @@ mod tests {
             tracker_handle: tracker_handle.clone(),
             cancel_token: cln_token.clone(),
             watermark_handle: None,
-            vertex_type: "Reduce".to_string(),
+            vertex_type: VertexType::ReduceUDF,
             isb_config: None,
         });
 
@@ -1942,7 +1942,7 @@ mod tests {
             tracker_handle: tracker_handle.clone(),
             cancel_token: cln_token.clone(),
             watermark_handle: None,
-            vertex_type: "Reduce".to_string(),
+            vertex_type: VertexType::ReduceUDF,
             isb_config: None,
         });
 

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/windower/session.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/windower/session.rs
@@ -363,7 +363,13 @@ impl SessionWindowManager {
             // Check if the end time of the last window is after the start time of the previous window
             // If it is that means they should be merged, add the previous window to the merged slice
             // and update the end time of the last window
-            while i > 0 && windows.get(i - 1).expect("should have previous window").end_time > last_window.start_time {
+            while i > 0
+                && windows
+                    .get(i - 1)
+                    .expect("should have previous window")
+                    .end_time
+                    > last_window.start_time
+            {
                 i -= 1;
                 merged_group.push(windows.get(i).expect("should have window").clone());
 

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/windower/session.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/windower/session.rs
@@ -307,7 +307,7 @@ impl SessionWindowManager {
 
     /// Merge multiple windows into a single window
     fn merge_windows(windows: &[Window]) -> (Window, UnalignedWindowMessage) {
-        let first = &windows[0];
+        let first = windows.first().expect("should have first window");
 
         let (start_time, end_time) = windows.iter().fold(
             (first.start_time, first.end_time),
@@ -355,24 +355,25 @@ impl SessionWindowManager {
             i -= 1;
 
             // Initialize a slice to hold the current window and any subsequent mergeable windows
-            let mut merged_group = vec![windows[i].clone()];
+            let mut merged_group = vec![windows.get(i).expect("should have window").clone()];
 
             // Set the last window to be the current window
-            let mut last_window = windows[i].clone();
+            let mut last_window = windows.get(i).expect("should have window").clone();
 
             // Check if the end time of the last window is after the start time of the previous window
             // If it is that means they should be merged, add the previous window to the merged slice
             // and update the end time of the last window
-            while i > 0 && windows[i - 1].end_time > last_window.start_time {
+            while i > 0 && windows.get(i - 1).expect("should have previous window").end_time > last_window.start_time {
                 i -= 1;
-                merged_group.push(windows[i].clone());
+                merged_group.push(windows.get(i).expect("should have window").clone());
 
                 // Merge the window into last_window to expand the range
-                if windows[i].start_time < last_window.start_time {
-                    last_window.start_time = windows[i].start_time;
+                let current_window = windows.get(i).expect("should have window");
+                if current_window.start_time < last_window.start_time {
+                    last_window.start_time = current_window.start_time;
                 }
-                if windows[i].end_time > last_window.end_time {
-                    last_window.end_time = windows[i].end_time;
+                if current_window.end_time > last_window.end_time {
+                    last_window.end_time = current_window.end_time;
                 }
             }
 

--- a/rust/numaflow-core/src/shared/create_components.rs
+++ b/rust/numaflow-core/src/shared/create_components.rs
@@ -723,6 +723,7 @@ pub async fn create_edge_watermark_handle(
     js_context: &Context,
     cln_token: &CancellationToken,
     window_manager: Option<WindowManager>,
+    tracker_handle: TrackerHandle,
 ) -> error::Result<Option<ISBWatermarkHandle>> {
     match &config.watermark_config {
         Some(WatermarkConfig::Edge(edge_config)) => {
@@ -736,6 +737,7 @@ pub async fn create_edge_watermark_handle(
                 &config.to_vertex_config,
                 cln_token.clone(),
                 window_manager,
+                tracker_handle,
             )
             .await?;
             Ok(Some(handle))

--- a/rust/numaflow-core/src/shared/forward.rs
+++ b/rust/numaflow-core/src/shared/forward.rs
@@ -29,6 +29,11 @@ pub(crate) fn should_forward(
 
 /// Determine the partition to write the message to by hashing the message id.
 pub(crate) fn determine_partition(shuffle_key: String, partitions_count: u16) -> u16 {
+    // if there is only one partition, we don't need to hash
+    if partitions_count == 1 {
+        return 0;
+    }
+
     let mut hasher = DefaultHasher::new();
     hasher.write(shuffle_key.as_bytes());
     let hash_value = hasher.finish();

--- a/rust/numaflow-core/src/sink.rs
+++ b/rust/numaflow-core/src/sink.rs
@@ -494,7 +494,7 @@ impl SinkWriter {
                             for offset in offsets {
                                 // Delete the message from the tracker
                                 self.tracker_handle
-                                    .delete(offset, None)
+                                    .delete(offset)
                                     .await
                                     .expect("tracker delete should never fail");
                             }
@@ -1137,7 +1137,7 @@ mod tests {
             10,
             Duration::from_secs(1),
             SinkClientType::Log,
-            TrackerHandle::new(None, None),
+            TrackerHandle::new(None),
         )
         .build()
         .await
@@ -1170,7 +1170,7 @@ mod tests {
     #[tokio::test]
     async fn test_streaming_write() {
         let cln_token = CancellationToken::new();
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let sink_writer = SinkWriterBuilder::new(
             10,
             Duration::from_millis(100),
@@ -1226,7 +1226,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_streaming_write_error() {
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         // start the server
         let (_shutdown_tx, shutdown_rx) = oneshot::channel();
         let tmp_dir = tempfile::TempDir::new().unwrap();
@@ -1313,7 +1313,7 @@ mod tests {
     #[tokio::test]
     async fn test_fallback_write() {
         let cln_token = CancellationToken::new();
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
 
         // start the server
         let (_shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -1413,7 +1413,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let serving_store = ServingStore::Nats(Box::new(
             NatsServingStore::new(
                 context.clone(),

--- a/rust/numaflow-core/src/sink/sqs.rs
+++ b/rust/numaflow-core/src/sink/sqs.rs
@@ -172,7 +172,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_sqs_sink_e2e() {
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let (source, src_handle, src_shutdown_tx) = get_simple_source(tracker_handle.clone()).await;
         // let source = get_sqs_source().await;
         let sink_writer = get_sqs_sink(tracker_handle.clone()).await;

--- a/rust/numaflow-core/src/source.rs
+++ b/rust/numaflow-core/src/source.rs
@@ -815,7 +815,7 @@ mod tests {
             .map_err(|e| panic!("failed to create source reader: {:?}", e))
             .unwrap();
 
-        let tracker = TrackerHandle::new(None, None);
+        let tracker = TrackerHandle::new(None);
         let source = Source::new(
             5,
             SourceType::UserDefinedSource(Box::new(src_read), Box::new(src_ack), lag_reader),

--- a/rust/numaflow-core/src/source/kafka.rs
+++ b/rust/numaflow-core/src/source/kafka.rs
@@ -111,17 +111,25 @@ impl source::SourceAcker for KafkaSource {
                 )));
             }
             let topic = (*parts.first().expect("should have topic part")).to_string();
-            let partition = parts.get(1).expect("should have partition part").parse::<i32>().map_err(|e| {
-                Error::Source(format!(
-                    "invalid partition id. kafka_offset={offset}, error={e:?}"
-                ))
-            })?;
+            let partition = parts
+                .get(1)
+                .expect("should have partition part")
+                .parse::<i32>()
+                .map_err(|e| {
+                    Error::Source(format!(
+                        "invalid partition id. kafka_offset={offset}, error={e:?}"
+                    ))
+                })?;
 
-            let partition_offset = parts.get(2).expect("should have offset part").parse::<i64>().map_err(|e| {
-                Error::Source(format!(
-                    "invalid offset id. kafka_offset={offset}, error={e:?}"
-                ))
-            })?;
+            let partition_offset = parts
+                .get(2)
+                .expect("should have offset part")
+                .parse::<i64>()
+                .map_err(|e| {
+                    Error::Source(format!(
+                        "invalid offset id. kafka_offset={offset}, error={e:?}"
+                    ))
+                })?;
             kafka_offsets.push(numaflow_kafka::source::KafkaOffset {
                 topic,
                 partition,

--- a/rust/numaflow-core/src/source/kafka.rs
+++ b/rust/numaflow-core/src/source/kafka.rs
@@ -110,14 +110,14 @@ impl source::SourceAcker for KafkaSource {
                     "Invalid Kafka offset format. Expected format: <topic>:<partition>:<offset>. offset={offset:?}"
                 )));
             }
-            let topic = parts[0].to_string();
-            let partition = parts[1].parse::<i32>().map_err(|e| {
+            let topic = (*parts.first().expect("should have topic part")).to_string();
+            let partition = parts.get(1).expect("should have partition part").parse::<i32>().map_err(|e| {
                 Error::Source(format!(
                     "invalid partition id. kafka_offset={offset}, error={e:?}"
                 ))
             })?;
 
-            let partition_offset = parts[2].parse::<i64>().map_err(|e| {
+            let partition_offset = parts.get(2).expect("should have offset part").parse::<i64>().map_err(|e| {
                 Error::Source(format!(
                     "invalid offset id. kafka_offset={offset}, error={e:?}"
                 ))

--- a/rust/numaflow-core/src/source/sqs.rs
+++ b/rust/numaflow-core/src/source/sqs.rs
@@ -191,7 +191,7 @@ pub mod tests {
 
         // create SQS source with test client
         use crate::tracker::TrackerHandle;
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let source = Source::new(
             1,
             SourceType::Sqs(sqs_source),

--- a/rust/numaflow-core/src/tracker.rs
+++ b/rust/numaflow-core/src/tracker.rs
@@ -353,7 +353,9 @@ impl Tracker {
         self.entries
             .values()
             .filter_map(|partition_entries| {
-                partition_entries.first_key_value().and_then(|(_, entry)| entry.watermark)
+                partition_entries
+                    .first_key_value()
+                    .and_then(|(_, entry)| entry.watermark)
             })
             .min()
     }

--- a/rust/numaflow-core/src/transformer.rs
+++ b/rust/numaflow-core/src/transformer.rs
@@ -371,7 +371,7 @@ mod tests {
 
         // wait for the server to start
         tokio::time::sleep(Duration::from_millis(100)).await;
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
 
         let client = SourceTransformClient::new(create_rpc_channel(sock_file).await?);
         let transformer = Transformer::new(
@@ -449,7 +449,7 @@ mod tests {
         // wait for the server to start
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let client = SourceTransformClient::new(create_rpc_channel(sock_file).await?);
         let transformer = Transformer::new(
             500,
@@ -537,7 +537,7 @@ mod tests {
         // wait for the server to start
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let tracker_handle = TrackerHandle::new(None, None);
+        let tracker_handle = TrackerHandle::new(None);
         let client = SourceTransformClient::new(create_rpc_channel(sock_file).await?);
         let transformer = Transformer::new(
             500,

--- a/rust/numaflow-core/src/watermark/idle/isb.rs
+++ b/rust/numaflow-core/src/watermark/idle/isb.rs
@@ -104,9 +104,15 @@ impl ISBIdleDetector {
             .get_mut(stream.vertex)
             .unwrap_or_else(|| panic!("Invalid vertex: {}", stream.vertex));
 
-        last_published_wm[stream.partition as usize].last_wm_published_time = Utc::now();
+        last_published_wm
+            .get_mut(stream.partition as usize)
+            .expect("should have partition")
+            .last_wm_published_time = Utc::now();
         // setting None for wmb-offset means it is active
-        last_published_wm[stream.partition as usize].wmb_msg_offset = None;
+        last_published_wm
+            .get_mut(stream.partition as usize)
+            .expect("should have partition")
+            .wmb_msg_offset = None;
     }
 
     /// fetches the offset to be used for publishing the idle watermark. Only a WMB (idle=true) can be used
@@ -119,7 +125,10 @@ impl ISBIdleDetector {
                 .read()
                 .expect("Failed to get read lock");
             let last_published_wm = read_guard.get(stream.vertex).expect("Invalid vertex");
-            last_published_wm[stream.partition as usize].clone()
+            last_published_wm
+                .get(stream.partition as usize)
+                .expect("should have partition")
+                .clone()
         };
 
         if let Some(offset) = idle_state.wmb_msg_offset {
@@ -155,8 +164,14 @@ impl ISBIdleDetector {
             .unwrap_or_else(|| panic!("Invalid vertex: {}", stream.vertex));
 
         // setting an offset for wmb-offset means it is idle, and we will do inplace incr of WM for that offset.
-        last_published_wm[stream.partition as usize].wmb_msg_offset = Some(offset);
-        last_published_wm[stream.partition as usize].last_wm_published_time = Utc::now();
+        last_published_wm
+            .get_mut(stream.partition as usize)
+            .expect("should have partition")
+            .wmb_msg_offset = Some(offset);
+        last_published_wm
+            .get_mut(stream.partition as usize)
+            .expect("should have partition")
+            .last_wm_published_time = Utc::now();
     }
 
     /// fetches the idle streams, we consider a stream as idle if the last published

--- a/rust/numaflow-core/src/watermark/isb/wm_fetcher.rs
+++ b/rust/numaflow-core/src/watermark/isb/wm_fetcher.rs
@@ -100,10 +100,11 @@ impl ISBWatermarkFetcher {
             // if the epoch is not i64::MAX, update the last processed watermark for this particular edge and the partition
             // while fetching watermark we need to consider the smallest last processed watermark among all the partitions
             if epoch != i64::MAX {
-                self.last_processed_wm
+                *self.last_processed_wm
                     .get_mut(edge)
                     .unwrap_or_else(|| panic!("invalid vertex {edge}"))
-                    [partition_idx as usize] = epoch;
+                    .get_mut(partition_idx as usize)
+                    .expect("should have partition index") = epoch;
             }
         }
 
@@ -191,10 +192,11 @@ impl ISBWatermarkFetcher {
             if epoch < i64::MAX {
                 min_wm = min_wm.min(epoch);
                 // update the last processed watermark for this particular edge and the specific partition
-                self.last_processed_wm
+                *self.last_processed_wm
                     .get_mut(edge)
                     .unwrap_or_else(|| panic!("invalid vertex {edge}"))
-                    [partition_idx as usize] = epoch;
+                    .get_mut(partition_idx as usize)
+                    .expect("should have partition index") = epoch;
             }
         }
 

--- a/rust/numaflow-core/src/watermark/isb/wm_fetcher.rs
+++ b/rust/numaflow-core/src/watermark/isb/wm_fetcher.rs
@@ -100,7 +100,8 @@ impl ISBWatermarkFetcher {
             // if the epoch is not i64::MAX, update the last processed watermark for this particular edge and the partition
             // while fetching watermark we need to consider the smallest last processed watermark among all the partitions
             if epoch != i64::MAX {
-                *self.last_processed_wm
+                *self
+                    .last_processed_wm
                     .get_mut(edge)
                     .unwrap_or_else(|| panic!("invalid vertex {edge}"))
                     .get_mut(partition_idx as usize)
@@ -192,7 +193,8 @@ impl ISBWatermarkFetcher {
             if epoch < i64::MAX {
                 min_wm = min_wm.min(epoch);
                 // update the last processed watermark for this particular edge and the specific partition
-                *self.last_processed_wm
+                *self
+                    .last_processed_wm
                     .get_mut(edge)
                     .unwrap_or_else(|| panic!("invalid vertex {edge}"))
                     .get_mut(partition_idx as usize)

--- a/rust/numaflow-core/src/watermark/isb/wm_publisher.rs
+++ b/rust/numaflow-core/src/watermark/isb/wm_publisher.rs
@@ -171,7 +171,9 @@ impl ISBWatermarkPublisher {
         // is monotonically increasing.
         // NOTE: in idling case since we reuse the control message offset, we can have the same offset
         // with larger watermark (we should publish it).
-        let last_state = &mut last_published_wm_state[stream.partition as usize];
+        let last_state = last_published_wm_state
+            .get_mut(stream.partition as usize)
+            .expect("should have partition");
         if offset < last_state.offset {
             last_state.watermark = last_state.watermark.max(watermark);
             return;
@@ -221,7 +223,9 @@ impl ISBWatermarkPublisher {
             .ok();
 
         // update the last published watermark state
-        last_published_wm_state[stream.partition as usize] = LastPublishedState {
+        *last_published_wm_state
+            .get_mut(stream.partition as usize)
+            .expect("should have partition") = LastPublishedState {
             offset,
             watermark,
             last_published_time: Instant::now(),

--- a/rust/numaflow-core/src/watermark/processor/manager.rs
+++ b/rust/numaflow-core/src/watermark/processor/manager.rs
@@ -264,7 +264,8 @@ impl ProcessorManager {
 
             match vertex_type {
                 VertexType::Source | VertexType::Sink | VertexType::MapUDF => {
-                    processor.timelines
+                    processor
+                        .timelines
                         .get_mut(wmb.partition as usize)
                         .expect("should have partition")
                         .put(wmb);
@@ -275,7 +276,8 @@ impl ProcessorManager {
                     if wmb.partition != vertex_replica {
                         continue;
                     }
-                    processor.timelines
+                    processor
+                        .timelines
                         .get_mut(0)
                         .expect("should have partition 0")
                         .put(wmb);
@@ -356,7 +358,8 @@ impl ProcessorManager {
 
                     match vertex_type {
                         VertexType::Source | VertexType::Sink | VertexType::MapUDF => {
-                            processor.timelines
+                            processor
+                                .timelines
                                 .get_mut(wmb.partition as usize)
                                 .expect("should have partition")
                                 .put(wmb);
@@ -367,7 +370,8 @@ impl ProcessorManager {
                             if wmb.partition != vertex_replica {
                                 continue;
                             }
-                            processor.timelines
+                            processor
+                                .timelines
                                 .get_mut(0)
                                 .expect("should have partition 0")
                                 .put(wmb);

--- a/rust/numaflow-core/src/watermark/processor/manager.rs
+++ b/rust/numaflow-core/src/watermark/processor/manager.rs
@@ -264,7 +264,10 @@ impl ProcessorManager {
 
             match vertex_type {
                 VertexType::Source | VertexType::Sink | VertexType::MapUDF => {
-                    processor.timelines[wmb.partition as usize].put(wmb);
+                    processor.timelines
+                        .get_mut(wmb.partition as usize)
+                        .expect("should have partition")
+                        .put(wmb);
                 }
                 VertexType::ReduceUDF => {
                     // reduce vertex only reads from one partition so we should only consider wmbs
@@ -272,7 +275,10 @@ impl ProcessorManager {
                     if wmb.partition != vertex_replica {
                         continue;
                     }
-                    processor.timelines[0].put(wmb);
+                    processor.timelines
+                        .get_mut(0)
+                        .expect("should have partition 0")
+                        .put(wmb);
                 }
             }
         }
@@ -350,7 +356,10 @@ impl ProcessorManager {
 
                     match vertex_type {
                         VertexType::Source | VertexType::Sink | VertexType::MapUDF => {
-                            processor.timelines[wmb.partition as usize].put(wmb);
+                            processor.timelines
+                                .get_mut(wmb.partition as usize)
+                                .expect("should have partition")
+                                .put(wmb);
                         }
                         // reduce vertex only reads from one partition so we should only consider wmbs
                         // which belong to this vertex replica
@@ -358,7 +367,10 @@ impl ProcessorManager {
                             if wmb.partition != vertex_replica {
                                 continue;
                             }
-                            processor.timelines[0].put(wmb);
+                            processor.timelines
+                                .get_mut(0)
+                                .expect("should have partition 0")
+                                .put(wmb);
                         }
                     }
                 }

--- a/rust/numaflow-core/src/watermark/source.rs
+++ b/rust/numaflow-core/src/watermark/source.rs
@@ -1291,7 +1291,7 @@ mod tests {
         })
         .await;
 
-        let wmb_found = result.unwrap_or(false); // false if timeout occurred
+        let wmb_found = result.unwrap_or(false);
         assert!(wmb_found, "Idle watermark not found");
     }
 

--- a/rust/numaflow-core/src/watermark/source.rs
+++ b/rust/numaflow-core/src/watermark/source.rs
@@ -844,7 +844,6 @@ mod tests {
             partition: 0,
         };
 
-        let mut wmb_found = false;
         for i in 1..11 {
             // publish source watermarks before publishing edge watermarks
             let messages = vec![

--- a/test/reduce-one-e2e/testdata/complex-sliding-window-pipeline.yaml
+++ b/test/reduce-one-e2e/testdata/complex-sliding-window-pipeline.yaml
@@ -9,8 +9,6 @@ spec:
     readBatchSize: 50
   vertices:
     - name: in
-      limits:
-        readBatchSize: 1
       scale:
         min: 1
       source:


### PR DESCRIPTION
* Avoids tracking of the offsets in the watermark code, uses tracker for that.
* Tracker also tracks the watermark along with the offsets, it also exposes method to fetch the lowest watermark for a given vertex.
* Watermark calls are made blocking since they are in memory operations and ideally should be very fast, with fire and forget chances of inconsistent state is high.
* Avoids performing hash operation to determine the partition to write to when we only have single partition.
* Sliding replay bug fix: sliding replay was not working because we were not updating the append operation to open operation.