### PR TITLE
fix: requeue reconciliation after seeing container restart

### DIFF
--- a/pkg/reconciler/monovertex/controller.go
+++ b/pkg/reconciler/monovertex/controller.go
@@ -165,11 +165,11 @@ func (mr *monoVertexReconciler) reconcile(ctx context.Context, monoVtx *dfv1.Mon
 		mr.recorder.Eventf(monoVtx, corev1.EventTypeNormal, "UpdateMonoVertexPhase", "Updated MonoVertex phase from %s to %s", string(originalPhase), string(desiredPhase))
 	}
 	// Check children resource status
-	if err := mr.checkChildrenResourceStatus(ctx, monoVtx); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to check mono vertex children resource status, %w", err)
+	if ctrlResult, err := mr.checkChildrenResourceStatus(ctx, monoVtx); err != nil {
+		return ctrlResult, fmt.Errorf("failed to check mono vertex children resource status, %w", err)
+	} else {
+		return ctrl.Result{}, nil
 	}
-
-	return ctrl.Result{}, nil
 }
 
 // orchestrateFixedResources orchestrates fixed resources such as daemon service related objects for a mono vertex.
@@ -582,7 +582,7 @@ func (mr *monoVertexReconciler) buildPodSpec(monoVtx *dfv1.MonoVertex) (*corev1.
 }
 
 // checkChildrenResourceStatus checks the status of the children resources of the mono vertex
-func (mr *monoVertexReconciler) checkChildrenResourceStatus(ctx context.Context, monoVtx *dfv1.MonoVertex) error {
+func (mr *monoVertexReconciler) checkChildrenResourceStatus(ctx context.Context, monoVtx *dfv1.MonoVertex) (ctrl.Result, error) {
 	defer func() {
 		for _, c := range monoVtx.Status.Conditions {
 			if c.Status != metav1.ConditionTrue {
@@ -600,10 +600,11 @@ func (mr *monoVertexReconciler) checkChildrenResourceStatus(ctx context.Context,
 		if apierrors.IsNotFound(err) {
 			monoVtx.Status.MarkDaemonUnHealthy(
 				"GetDaemonServiceFailed", "Deployment not found, might be still under creation")
-			return nil
+			// Do not need to explicitly requeue, as the controller watches daemon objects anyways.
+			return ctrl.Result{}, nil
 		}
 		monoVtx.Status.MarkDaemonUnHealthy("GetDaemonServiceFailed", err.Error())
-		return err
+		return ctrl.Result{}, err
 	}
 	if status, reason, msg := reconciler.CheckDeploymentStatus(&daemonDeployment); status {
 		monoVtx.Status.MarkDaemonHealthy()
@@ -616,21 +617,24 @@ func (mr *monoVertexReconciler) checkChildrenResourceStatus(ctx context.Context,
 	var podList corev1.PodList
 	if err := mr.client.List(ctx, &podList, &client.ListOptions{Namespace: monoVtx.GetNamespace(), LabelSelector: selector}); err != nil {
 		monoVtx.Status.MarkPodNotHealthy("ListMonoVerticesPodsFailed", err.Error())
-		return fmt.Errorf("failed to get pods of a mono vertex: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to get pods of a mono vertex: %w", err)
 	}
 	readyPods := reconciler.NumOfReadyPods(podList)
 	if readyPods > int(monoVtx.Status.Replicas) { // It might happen in some corner cases, such as during rollout
 		readyPods = int(monoVtx.Status.Replicas)
 	}
 	monoVtx.Status.ReadyReplicas = uint32(readyPods)
-	if healthy, reason, msg := reconciler.CheckPodsStatus(&podList); healthy {
+	if healthy, reason, msg, transientUnhealthy := reconciler.CheckPodsStatus(&podList); healthy {
 		monoVtx.Status.MarkPodHealthy(reason, msg)
 	} else {
-		// Do not need to explicitly requeue, since the it keeps watching the status change of the pods
 		monoVtx.Status.MarkPodNotHealthy(reason, msg)
+		if transientUnhealthy {
+			// If it's unhealthy caused by restart in the last N mins, need to explicitly requeue, otherwise there's no need
+			// as the controller keeps watching the status change of the pods.
+			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+		}
 	}
-
-	return nil
+	return ctrl.Result{}, nil
 }
 
 // Clean up metrics, should be called when corresponding mvtx is deleted

--- a/pkg/reconciler/util_test.go
+++ b/pkg/reconciler/util_test.go
@@ -37,7 +37,7 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 				}},
 			}},
 		}
-		done, reason, message := CheckPodsStatus(&pods)
+		done, reason, message, _ := CheckPodsStatus(&pods)
 		assert.Equal(t, "All pods are healthy", message)
 		assert.Equal(t, "Running", reason)
 		assert.True(t, done)
@@ -53,17 +53,18 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 				},
 			},
 		}
-		done, reason, message := CheckPodsStatus(&pods)
+		done, reason, message, transient := CheckPodsStatus(&pods)
 		assert.Equal(t, "Pod test-pod is unhealthy", message)
 		assert.Equal(t, "PodCrashLoopBackOff", reason)
 		assert.False(t, done)
+		assert.False(t, transient)
 	})
 
 	t.Run("Test Vertex status as false with no pods", func(t *testing.T) {
 		pods := corev1.PodList{
 			Items: []corev1.Pod{},
 		}
-		done, reason, message := CheckPodsStatus(&pods)
+		done, reason, message, _ := CheckPodsStatus(&pods)
 		assert.Equal(t, "No Pods found", message)
 		assert.Equal(t, "NoPodsFound", reason)
 		assert.True(t, done)
@@ -86,7 +87,7 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 				}},
 			}},
 		}
-		done, reason, message := CheckPodsStatus(&pods)
+		done, reason, message, _ := CheckPodsStatus(&pods)
 		assert.Equal(t, "All pods are healthy", message)
 		assert.Equal(t, "Running", reason)
 		assert.True(t, done)
@@ -110,10 +111,11 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 				}},
 			}},
 		}
-		done, reason, message := CheckPodsStatus(&pods)
+		done, reason, message, transient := CheckPodsStatus(&pods)
 		assert.Equal(t, "Pod test-pod is unhealthy", message)
 		assert.Equal(t, "PodRecentRestart", reason)
 		assert.False(t, done)
+		assert.True(t, transient)
 	})
 }
 


### PR DESCRIPTION
Fixes: #2853

When container detects if there's any container restart due to OOM in the last 2 mins, it marks the vertex/mvtx as unhealthy. However, after that unless there's any controller watches objects change (e.g. pod creation/deletion), it will not re-check the status.

This PR explicitly requeue the request after detecting container restart.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
