### PR TITLE
Use ReadWriteOncePod as default PVC access mode (fixes #2854)

### DIFF
--- a/api/json-schema/schema.json
+++ b/api/json-schema/schema.json
@@ -21379,7 +21379,7 @@
       "description": "PersistenceStrategy defines the strategy of persistence",
       "properties": {
         "accessMode": {
-          "description": "Available access modes such as ReadWriteOnce, ReadWriteMany https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes",
+          "description": "Available access modes such as ReadWriteOncePod, ReadWriteOnce, ReadWriteMany https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes",
           "type": "string"
         },
         "storageClassName": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -21375,7 +21375,7 @@
       "type": "object",
       "properties": {
         "accessMode": {
-          "description": "Available access modes such as ReadWriteOnce, ReadWriteMany https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes",
+          "description": "Available access modes such as ReadWriteOncePod, ReadWriteOnce, ReadWriteMany https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes",
           "type": "string"
         },
         "storageClassName": {

--- a/docs/APIs.md
+++ b/docs/APIs.md
@@ -7315,7 +7315,8 @@ Kubernetes core/v1.PersistentVolumeAccessMode </a> </em>
 <em>(Optional)</em>
 <p>
 
-Available access modes such as ReadWriteOnce, ReadWriteMany
+Available access modes such as ReadWriteOncePod, ReadWriteOnce,
+ReadWriteMany
 <a href="https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes">https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes</a>
 </p>
 

--- a/docs/core-concepts/inter-step-buffer-service.md
+++ b/docs/core-concepts/inter-step-buffer-service.md
@@ -72,7 +72,7 @@ spec:
     version: latest # Do NOT use "latest" but a specific version in your real deployment
     persistence:
       storageClassName: standard # Optional, will use K8s cluster default storage class if not specified
-      accessMode: ReadWriteOnce # Optional, defaults to ReadWriteOnce
+      accessMode: ReadWriteOncePod # Optional, defaults to ReadWriteOncePod
       volumeSize: 10Gi # Optional, defaults to 20Gi
 ```
 

--- a/docs/user-guide/user-defined-functions/reduce/reduce.md
+++ b/docs/user-guide/user-defined-functions/reduce/reduce.md
@@ -117,7 +117,7 @@ vertices:
 
 `persistentVolumeClaim` supports the following fields, `volumeSize`, `storageClassName`, and`accessMode`.
 As name suggests,`volumeSize` specifies the size of the volume. `accessMode` can be of many types, but for
-reduce use case we need only `ReadWriteOnce`. `storageClassName` can also be provided, more info on storage class
+reduce use case we need only `ReadWriteOncePod`. `storageClassName` can also be provided, more info on storage class
 can be found [here](https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1). The default
 value of `storageClassName` is `default` which is default StorageClass may be deployed to a Kubernetes
 cluster by addon manager during installation.
@@ -132,7 +132,7 @@ vertices:
         storage:
           persistentVolumeClaim:
             volumeSize: 10Gi
-            accessMode: ReadWriteOnce
+            accessMode: ReadWriteOncePod
 ```
 
 ### EmptyDir

--- a/examples/11-join-on-reduce.yaml
+++ b/examples/11-join-on-reduce.yaml
@@ -29,7 +29,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 10Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       sink:
         # A simple log printing sink

--- a/examples/12-simple-session-pipeline.yaml
+++ b/examples/12-simple-session-pipeline.yaml
@@ -34,7 +34,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 2Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       scale:
         min: 1

--- a/examples/13-streaming-reduce-pipeline.yaml
+++ b/examples/13-streaming-reduce-pipeline.yaml
@@ -34,7 +34,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 1Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       scale:
         min: 1

--- a/examples/6-reduce-fixed-window-with-pvc.yaml
+++ b/examples/6-reduce-fixed-window-with-pvc.yaml
@@ -29,7 +29,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 1Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
       partitions: 2
     - name: sink
       scale:

--- a/examples/7-reduce-sliding-window.yaml
+++ b/examples/7-reduce-sliding-window.yaml
@@ -40,7 +40,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 10Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
       containerTemplate:
         env:
           - name: NUMAFLOW_DEBUG

--- a/examples/8-reduce-complex-pipeline.yaml
+++ b/examples/8-reduce-complex-pipeline.yaml
@@ -32,7 +32,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 2Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: non-keyed-fixed-sum
       udf:
         container:
@@ -46,7 +46,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 2Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: non-keyed-sliding-sum
       udf:
         container:
@@ -61,7 +61,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 2Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       scale:
         min: 1

--- a/pkg/apis/numaflow/v1alpha1/generated.proto
+++ b/pkg/apis/numaflow/v1alpha1/generated.proto
@@ -1138,7 +1138,7 @@ message PersistenceStrategy {
   // +optional
   optional string storageClassName = 1;
 
-  // Available access modes such as ReadWriteOnce, ReadWriteMany
+  // Available access modes such as ReadWriteOncePod, ReadWriteOnce, ReadWriteMany
   // https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
   // +optional
   optional string accessMode = 2;

--- a/pkg/apis/numaflow/v1alpha1/persistence_strategy.go
+++ b/pkg/apis/numaflow/v1alpha1/persistence_strategy.go
@@ -23,7 +23,7 @@ import (
 )
 
 var DefaultVolumeSize = apiresource.MustParse("20Gi")
-var DefaultAccessMode = corev1.ReadWriteOnce
+var DefaultAccessMode = corev1.ReadWriteOncePod
 
 // PersistenceStrategy defines the strategy of persistence
 type PersistenceStrategy struct {
@@ -31,7 +31,7 @@ type PersistenceStrategy struct {
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
 	// +optional
 	StorageClassName *string `json:"storageClassName,omitempty" protobuf:"bytes,1,opt,name=storageClassName"`
-	// Available access modes such as ReadWriteOnce, ReadWriteMany
+	// Available access modes such as ReadWriteOncePod, ReadWriteOnce, ReadWriteMany
 	// https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
 	// +optional
 	AccessMode *corev1.PersistentVolumeAccessMode `json:"accessMode,omitempty" protobuf:"bytes,2,opt,name=accessMode,casttype=k8s.io/api/core/v1.PersistentVolumeAccessMode"`
@@ -46,7 +46,7 @@ func (ps PersistenceStrategy) GetPVCSpec(name string) corev1.PersistentVolumeCla
 	if ps.VolumeSize != nil {
 		volSize = *ps.VolumeSize
 	}
-	// Default to ReadWriteOnce
+	// Default to ReadWriteOncePod
 	accessMode := DefaultAccessMode
 	if ps.AccessMode != nil {
 		accessMode = *ps.AccessMode

--- a/pkg/apis/numaflow/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/numaflow/v1alpha1/zz_generated.openapi.go
@@ -3676,7 +3676,7 @@ func schema_pkg_apis_numaflow_v1alpha1_PersistenceStrategy(ref common.ReferenceC
 					},
 					"accessMode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Available access modes such as ReadWriteOnce, ReadWriteMany https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes",
+							Description: "Available access modes such as ReadWriteOncePod, ReadWriteOnce, ReadWriteMany https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/reconciler/vertex/controller_test.go
+++ b/pkg/reconciler/vertex/controller_test.go
@@ -599,7 +599,7 @@ func Test_reconcile(t *testing.T) {
 				},
 				Storage: &dfv1.PBQStorage{
 					PersistentVolumeClaim: &dfv1.PersistenceStrategy{
-						AccessMode: ptr.To[corev1.PersistentVolumeAccessMode](corev1.ReadWriteOnce),
+						AccessMode: ptr.To[corev1.PersistentVolumeAccessMode](corev1.ReadWriteOncePod),
 					},
 				},
 			},

--- a/rust/numaflow-core/src/config/components.rs
+++ b/rust/numaflow-core/src/config/components.rs
@@ -3557,7 +3557,7 @@ mod reducer_tests {
 
         let pbq_storage = PbqStorage {
             persistent_volume_claim: Some(Box::new(PersistenceStrategy {
-                access_mode: Some("ReadWriteOnce".to_string()),
+                access_mode: Some("ReadWriteOncePod".to_string()),
                 storage_class_name: Some("standard".to_string()),
                 volume_size: None,
             })),

--- a/rust/numaflow-models/src/models/persistence_strategy.rs
+++ b/rust/numaflow-models/src/models/persistence_strategy.rs
@@ -20,7 +20,7 @@ limitations under the License.
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PersistenceStrategy {
-    /// Available access modes such as ReadWriteOnce, ReadWriteMany https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
+    /// Available access modes such as ReadWriteOncePod, ReadWriteOnce, ReadWriteMany https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
     #[serde(rename = "accessMode", skip_serializing_if = "Option::is_none")]
     pub access_mode: Option<String>,
     /// Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1

--- a/test/diamond-e2e/testdata/join-on-reduce.yaml
+++ b/test/diamond-e2e/testdata/join-on-reduce.yaml
@@ -43,7 +43,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 2Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       scale:
         min: 1

--- a/test/idle-source-e2e/testdata/idle-source-reduce-pipeline.yaml
+++ b/test/idle-source-e2e/testdata/idle-source-reduce-pipeline.yaml
@@ -40,7 +40,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 2Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       scale:
         min: 1

--- a/test/idle-source-e2e/testdata/kafka-pipeline.yaml
+++ b/test/idle-source-e2e/testdata/kafka-pipeline.yaml
@@ -37,7 +37,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 1Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       scale:
         min: 1

--- a/test/reduce-one-e2e/testdata/complex-sliding-window-pipeline.yaml
+++ b/test/reduce-one-e2e/testdata/complex-sliding-window-pipeline.yaml
@@ -36,7 +36,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 1Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: non-keyed-fixed-sum
       udf:
         container:
@@ -51,7 +51,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 1Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: non-keyed-sliding-sum
       udf:
         container:
@@ -67,7 +67,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 1Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       scale:
         min: 1

--- a/test/reduce-one-e2e/testdata/simple-keyed-reduce-pipeline.yaml
+++ b/test/reduce-one-e2e/testdata/simple-keyed-reduce-pipeline.yaml
@@ -35,7 +35,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 1Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       scale:
         min: 1

--- a/test/reduce-one-e2e/testdata/simple-non-keyed-reduce-pipeline.yaml
+++ b/test/reduce-one-e2e/testdata/simple-non-keyed-reduce-pipeline.yaml
@@ -37,7 +37,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 1Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       scale:
         min: 1

--- a/test/reduce-one-e2e/testdata/simple-reduce-pipeline-wal.yaml
+++ b/test/reduce-one-e2e/testdata/simple-reduce-pipeline-wal.yaml
@@ -36,7 +36,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 1Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       scale:
         min: 1

--- a/test/reduce-two-e2e/testdata/session-reduce/simple-session-keyed-counter-pipeline-go.yaml
+++ b/test/reduce-two-e2e/testdata/session-reduce/simple-session-keyed-counter-pipeline-go.yaml
@@ -35,7 +35,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 2Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       scale:
         min: 1

--- a/test/reduce-two-e2e/testdata/session-reduce/simple-session-keyed-counter-pipeline-java.yaml
+++ b/test/reduce-two-e2e/testdata/session-reduce/simple-session-keyed-counter-pipeline-java.yaml
@@ -33,7 +33,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 1Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
     - name: sink
       scale:
         min: 1

--- a/test/sideinputs-e2e/testdata/reduce-sideinput-pipeline.yaml
+++ b/test/sideinputs-e2e/testdata/reduce-sideinput-pipeline.yaml
@@ -37,7 +37,7 @@ spec:
           storage:
             persistentVolumeClaim:
               volumeSize: 2Gi
-              accessMode: ReadWriteOnce
+              accessMode: ReadWriteOncePod
       sideInputs:
         - myticker
     - name: sink


### PR DESCRIPTION
fixes #2854

Changes the DefaultAccessMode from ReadWriteOnce to ReadWriteOncePod in persistence_strategy for jetstream buffer and redis buffer service.