### PR TITLE
fix: flaky `timeAlgo` UI test

### DIFF
--- a/ui/src/utils/index.test.ts
+++ b/ui/src/utils/index.test.ts
@@ -126,13 +126,17 @@ describe("index", () => {
     });
   });
   it("timeAgo", () => {
-    expect(timeAgo(new Date(Date.now() - 10000).toISOString())).toEqual(
-      "10 seconds ago"
-    );
-    // Use a larger time difference to avoid flaky test due to execution time
-    expect(timeAgo(new Date(Date.now() + 5000).toISOString())).toEqual(
-      "5 seconds from now"
-    );
+    // Use fake timers to eliminate flakiness and make tests deterministic
+    jest.useFakeTimers().setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    
+    // Test future time
+    expect(timeAgo("2025-01-01T00:00:10.000Z")).toEqual("10 seconds from now");
+    
+    // Test past time
+    expect(timeAgo("2024-12-31T23:59:50.000Z")).toEqual("10 seconds ago");
+    
+    // Restore real timers
+    jest.useRealTimers();
   });
 
   it("getISB", () => {


### PR DESCRIPTION
### Issue

test may take some milliseconds to execute and since timeAlgo uses Math.floor(), we get 0 seconds instead of 1 seconds for some future time

### Fix

Use fake timers to make test deterministic