### PR TITLE
fix: detect terminating pods as soon as possible

### DIFF
--- a/pkg/reconciler/monovertex/controller_test.go
+++ b/pkg/reconciler/monovertex/controller_test.go
@@ -413,4 +413,59 @@ func Test_reconcile(t *testing.T) {
 		assert.Equal(t, uint32(20), testObj.Status.Replicas)
 		assert.Equal(t, uint32(5), testObj.Status.UpdatedReplicas)
 	})
+
+	t.Run("test isTerminatingPod", func(t *testing.T) {
+		cl := fake.NewClientBuilder().Build()
+		r := fakeReconciler(t, cl)
+
+		now := metav1.Now()
+		// Pod with DeletionTimestamp set
+		pod1 := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pod1",
+				Namespace:         testNamespace,
+				DeletionTimestamp: &now,
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+			},
+		}
+		assert.True(t, r.isTerminatingPod(pod1), "Pod with DeletionTimestamp should be terminating")
+
+		// Pod in Failed phase
+		pod2 := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod2",
+				Namespace: testNamespace,
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+			},
+		}
+		assert.True(t, r.isTerminatingPod(pod2), "Pod in Failed phase should be terminating")
+
+		// Pod in Succeeded phase
+		pod3 := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod3",
+				Namespace: testNamespace,
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodSucceeded,
+			},
+		}
+		assert.True(t, r.isTerminatingPod(pod3), "Pod in Succeeded phase should be terminating")
+
+		// Pod in Running phase, no DeletionTimestamp
+		pod4 := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod4",
+				Namespace: testNamespace,
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+			},
+		}
+		assert.False(t, r.isTerminatingPod(pod4), "Pod in Running phase with no DeletionTimestamp should not be terminating")
+	})
 }

--- a/pkg/reconciler/vertex/controller.go
+++ b/pkg/reconciler/vertex/controller.go
@@ -602,7 +602,7 @@ func (r *vertexReconciler) findExistingPods(ctx context.Context, vertex *dfv1.Ve
 	}
 	result := make(map[string]corev1.Pod)
 	for _, v := range pods.Items {
-		if !v.DeletionTimestamp.IsZero() {
+		if r.isTerminatingPod(&v) {
 			// Ignore pods being deleted
 			continue
 		}
@@ -613,6 +613,12 @@ func (r *vertexReconciler) findExistingPods(ctx context.Context, vertex *dfv1.Ve
 		}
 	}
 	return result, nil
+}
+
+func (r *vertexReconciler) isTerminatingPod(pod *corev1.Pod) bool {
+	// A pod is terminating if its deletion timestamp is set (i.e., non-nil)
+	// It is also terminating if its status phase is in "Failed" or "Succeeded"
+	return !pod.DeletionTimestamp.IsZero() || pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded
 }
 
 func (r *vertexReconciler) findExistingServices(ctx context.Context, vertex *dfv1.Vertex) (map[string]corev1.Service, error) {


### PR DESCRIPTION
### What this PR does / why we need it
When a pod is being shut down by kubernetes (evicted from node, OOMkilled, etc...) the pod will expend some time in intermediate states before garbage collectors pick up the terminated pod and remove it (populating the DeletionTimestamp field).
If we use the status.phase field we can detect pods being terminated before that so we can produce new replicas as needed a bit earlier.

### Related issues
Fixes https://github.com/numaproj/numaflow/issues/2918

### Testing

https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase

### Special notes for reviewers
Anything notable for review (risk, rollout, follow-ups).

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
