### PR TITLE
fix: timeout increased for a flaky ui test and check rust formatting in lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,7 @@ $(GOPATH)/bin/golangci-lint:
 lint: $(GOPATH)/bin/golangci-lint
 	go mod tidy
 	$(GOPATH)/bin/golangci-lint run --fix --verbose --concurrency 4 --timeout 5m --enable goimports
+	cd rust && cargo fmt --check || (echo "Run 'cd rust && cargo fmt' to fix formatting issues" && exit 1)
 
 .PHONY: start
 start: image

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/VertexUpdate/index.test.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/VertexUpdate/index.test.tsx
@@ -191,10 +191,13 @@ describe("VertexUpdate", () => {
         )
       ).toBeInTheDocument();
     });
-    // Wait for onUpdateComplete call
-    await waitFor(() => {
-      expect(mockRefresh).toHaveBeenCalledTimes(1);
-    });
+    // Wait for onUpdateComplete call (after 1000ms setTimeout)
+    await waitFor(
+      () => {
+        expect(mockRefresh).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 2000 }
+    );
   });
 
   it("submit failure", async () => {


### PR DESCRIPTION
### What this PR does / why we need it

- after 1s, refresh() was called and timeout to check this was also 1s, increased it to 2s

```
          setTimeout(() => {
            setStatus(undefined);
            setValidationMessage(undefined);
            refresh();
          }, 1000);
```

```
    await waitFor(
      () => {
        expect(mockRefresh).toHaveBeenCalledTimes(1);
      },
      { timeout: 2000 }
    );
```

- added cargo fmt --check in lint target
### Related issues
Fixes flaky ui test in CI

### Testing
local

### Special notes for reviewers
n/a

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
