### PR TITLE
test: Fix time based refill tests

### DIFF
--- a/rust/numaflow-throttling/src/lib.rs
+++ b/rust/numaflow-throttling/src/lib.rs
@@ -1475,7 +1475,7 @@ mod tests {
         // Phase 3: Wait for some time to allow token refill
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        // Phase 3: Each pod tries to acquire all available tokens
+        // Phase 3: Each pod tries to acquire some available tokens
         let mut total_got_tokens_phase3 = 0;
         let mut total_expected_tokens_phase3 = 0;
         for rate_limiter in rate_limiters.iter() {
@@ -1698,7 +1698,7 @@ mod tests {
         // Phase 3: Wait for some time to allow token refill
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        // Phase 3: Each pod tries to acquire all available tokens
+        // Phase 3: Each pod tries to acquire some available tokens
         let mut total_got_tokens_phase3 = 0;
         let mut total_expected_tokens_phase3 = 0;
         for rate_limiter in rate_limiters.iter() {


### PR DESCRIPTION
### What this PR does / why we need it
Aims to replace calling `acquire_n` with `attempt_acquire_n` to remove dependence on time for the following tests:
* `test_distributed_rate_limiter_time_based_refill`
* `test_distributed_rate_limiter_time_based_refill_redis`

Add following tests to run simple slow tests for calling `acquire_n`:
* `test_distributed_rate_limiter_simple_acquire_n_in_memory_store`
* `test_distributed_rate_limiter_simple_acquire_n_redis_store`

Furthermore added redis cleanup calls to the previously generalized unit tests.

### Testing
All the added unit tests were verified to be passing

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
