### PR TITLE
fix: rater should not consider nil metric data points

### DIFF
--- a/pkg/daemon/server/service/rater/helper.go
+++ b/pkg/daemon/server/service/rater/helper.go
@@ -33,8 +33,11 @@ const (
 
 // UpdatePendingCount updates the pending count for a pod at a given time
 func UpdatePendingCount(q *sharedqueue.OverflowQueue[*TimestampedCounts], time int64, podPendingCounts *PodPendingCount) {
-	items := q.Items()
+	if podPendingCounts == nil {
+		return
+	}
 
+	items := q.Items()
 	// find the element matching the input timestamp and update it
 	for _, i := range items {
 		if i.timestamp == time {
@@ -51,8 +54,11 @@ func UpdatePendingCount(q *sharedqueue.OverflowQueue[*TimestampedCounts], time i
 
 // UpdateCount updates the count of processed messages for a pod at a given time
 func UpdateCount(q *sharedqueue.OverflowQueue[*TimestampedCounts], time int64, podReadCounts *PodReadCount) {
-	items := q.Items()
+	if podReadCounts == nil {
+		return
+	}
 
+	items := q.Items()
 	// find the element matching the input timestamp and update it
 	for _, i := range items {
 		if i.timestamp == time {

--- a/pkg/daemon/server/service/rater/helper_test.go
+++ b/pkg/daemon/server/service/rater/helper_test.go
@@ -103,19 +103,6 @@ func TestUpdateCount(t *testing.T) {
 		assert.Equal(t, 10.0, q.Items()[0].podPartitionCount["pod1"]["partition1"])
 		assert.Equal(t, 20.0, q.Items()[1].podPartitionCount["pod1"]["partition1"])
 	})
-
-	t.Run("givenTimeNotExistsCountNotAvailable_whenUpdate_thenAddEmptyItem", func(t *testing.T) {
-		q := sharedqueue.New[*TimestampedCounts](1800)
-		tc := NewTimestampedCounts(TestTime)
-		tc.Update(&PodReadCount{"pod1", map[string]float64{"partition1": 10.0}})
-		q.Append(tc)
-
-		UpdateCount(q, TestTime+1, nil)
-
-		assert.Equal(t, 2, q.Length())
-		assert.Equal(t, 10.0, q.Items()[0].podPartitionCount["pod1"]["partition1"])
-		assert.Equal(t, 0, len(q.Items()[1].podPartitionCount))
-	})
 }
 
 func TestCalculateRate(t *testing.T) {

--- a/pkg/mvtxdaemon/server/service/rater/helper.go
+++ b/pkg/mvtxdaemon/server/service/rater/helper.go
@@ -34,8 +34,11 @@ const (
 
 // UpdateCount updates the count for a given timestamp in the queue.
 func UpdateCount(q *sharedqueue.OverflowQueue[*TimestampedCounts], time int64, podReadCounts *PodMetricsCount) {
-	items := q.Items()
+	if podReadCounts == nil {
+		return
+	}
 
+	items := q.Items()
 	// find the element matching the input timestamp and update it
 	for _, i := range items {
 		if i.timestamp == time {

--- a/pkg/mvtxdaemon/server/service/rater/helper_test.go
+++ b/pkg/mvtxdaemon/server/service/rater/helper_test.go
@@ -93,19 +93,6 @@ func TestUpdateCount(t *testing.T) {
 		assert.Equal(t, 10.0, q.Items()[0].podReadCounts["pod1"])
 		assert.Equal(t, 20.0, q.Items()[1].podReadCounts["pod1"])
 	})
-
-	t.Run("givenTimeNotExistsCountNotAvailable_whenUpdate_thenAddEmptyItem", func(t *testing.T) {
-		q := sharedqueue.New[*TimestampedCounts](1800)
-		tc := NewTimestampedCounts(TestTime)
-		tc.Update(&PodMetricsCount{"pod1", 10.0})
-		q.Append(tc)
-
-		UpdateCount(q, TestTime+1, nil)
-
-		assert.Equal(t, 2, q.Length())
-		assert.Equal(t, 10.0, q.Items()[0].podReadCounts["pod1"])
-		assert.Equal(t, 0, len(q.Items()[1].podReadCounts))
-	})
 }
 
 func TestCalculatePending(t *testing.T) {


### PR DESCRIPTION
Since, we didn't have a nil check to avoid storing the nil metric data points in the tracked counts, we were seeing sudden spikes in processing rate when we redeploy the pipeline or MonoVertex.

```
CalculateRate: lookbackSeconds: 120, partitionName: default-even-odd-sum-compute-counter-0,
 counts: [
 {timestamp: 1758206641, podPartitionCount: map[]} 
 {timestamp: 1758206642, podPartitionCount: map[]} 
 {timestamp: 1758206643, podPartitionCount: map[]} 
 {timestamp: 1758206644, podPartitionCount: map[]} 
 {timestamp: 1758206645, podPartitionCount: map[even-odd-sum-compute-counter-0:map[default-even-odd-sum-compute-counter-0:4263] even-odd-sum-compute-counter-1:map[default-even-odd-sum-compute-counter-1:1827]]} 
 {timestamp: 1758206646, podPartitionCount: map[even-odd-sum-compute-counter-0:map[default-even-odd-sum-compute-counter-0:4263] even-odd-sum-compute-counter-1:map[default-even-odd-sum-compute-counter-1:1833]]} 
 {timestamp: 1758206647, podPartitionCount: map[even-odd-sum-compute-counter-0:map[default-even-odd-sum-compute-counter-0:4277] even-odd-sum-compute-counter-1:map[default-even-odd-sum-compute-counter-1:1839]]} 
 {timestamp: 1758206648, podPartitionCount: map[even-odd-sum-compute-counter-0:map[default-even-odd-sum-compute-counter-0:4291] even-odd-sum-compute-counter-1:map[default-even-odd-sum-compute-counter-1:1845]]} 
 {timestamp: 1758206649, podPartitionCount: map[even-odd-sum-compute-counter-0:map[default-even-odd-sum-compute-counter-0:4305] even-odd-sum-compute-counter-1:map[default-even-odd-sum-compute-counter-1:1851]]} 
 {timestamp: 1758206650, podPartitionCount: map[even-odd-sum-compute-counter-0:map[default-even-odd-sum-compute-counter-0:4319] even-odd-sum-compute-counter-1:map[default-even-odd-sum-compute-counter-1:1857]]} 
 {timestamp: 1758206651, podPartitionCount: map[even-odd-sum-compute-counter-0:map[default-even-odd-sum-compute-counter-0:4333] even-odd-sum-compute-counter-1:map[default-even-odd-sum-compute-counter-1:1863]]} 
 {timestamp: 1758206652, podPartitionCount: map[even-odd-sum-compute-counter-0:map[default-even-odd-sum-compute-counter-0:4347] even-odd-sum-compute-counter-1:map[default-even-odd-sum-compute-counter-1:1869]]}
 {timestamp: 1758206653, podPartitionCount: map[even-odd-sum-compute-counter-0:map[default-even-odd-sum-compute-counter-0:4361] even-odd-sum-compute-counter-1:map[default-even-odd-sum-compute-counter-1:1875]]}
 {timestamp: 1758206654, podPartitionCount: map[even-odd-sum-compute-counter-0:map[default-even-odd-sum-compute-counter-0:4375] even-odd-sum-compute-counter-1:map[default-even-odd-sum-compute-counter-1:1881]]}
 {timestamp: 1758206655, podPartitionCount: map[even-odd-sum-compute-counter-0:map[default-even-odd-sum-compute-counter-0:4389] even-odd-sum-compute-counter-1:map[default-even-odd-sum-compute-counter-1:1881]]}
]
CalculateRate: startIndex: 0
CalculateRate: endIndex: 13
CalculateRate: timeDiff: 13
CalculateRate: delta: 0.000000
CalculateRate: delta: 0.000000
CalculateRate: delta: 0.000000
CalculateRate: delta: 4263.000000
CalculateRate: delta: 4263.000000
CalculateRate: delta: 4277.000000
CalculateRate: delta: 4291.000000
CalculateRate: delta: 4305.000000
CalculateRate: delta: 4319.000000
CalculateRate: delta: 4333.000000
CalculateRate: delta: 4347.000000
CalculateRate: delta: 4361.000000
CalculateRate: delta: 4375.000000
CalculateRate: rate: 336.538462 (the processing rate should have been 20 in this case)
```