### PR TITLE
feat: Implement token deposition logic for unused tokens

### DIFF
--- a/rust/numaflow-core/src/pipeline/isb/jetstream/reader.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/reader.rs
@@ -371,6 +371,11 @@ impl<C: NumaflowTypeConfig> JetStreamReader<C> {
             None => batch_size,
         };
 
+        let cur_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+
         let start = Instant::now();
         let jetstream_messages = match self
             .consumer
@@ -413,6 +418,7 @@ impl<C: NumaflowTypeConfig> JetStreamReader<C> {
                         effective_batch_size
                             .checked_sub(jetstream_messages.len())
                             .unwrap_or(0),
+                        cur_epoch,
                     )
                     .await;
             }

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/reader.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/reader.rs
@@ -371,6 +371,7 @@ impl<C: NumaflowTypeConfig> JetStreamReader<C> {
             None => batch_size,
         };
 
+        // Note the epoch at which we got the estimated batch size from the rate limiter
         let cur_epoch = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("Time went backwards")
@@ -411,6 +412,9 @@ impl<C: NumaflowTypeConfig> JetStreamReader<C> {
             }
         };
 
+        // deposit the unused tokens back to the rate limiter
+        // utilize the cur_epoch we calculated when we initially acquired the tokens
+        // to ensure that the tokens are deposited for the correct epoch.
         match &self.rate_limiter {
             Some(rate_limiter) => {
                 rate_limiter

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/reader.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/reader.rs
@@ -406,6 +406,19 @@ impl<C: NumaflowTypeConfig> JetStreamReader<C> {
             }
         };
 
+        match &self.rate_limiter {
+            Some(rate_limiter) => {
+                rate_limiter
+                    .deposit_unused(
+                        effective_batch_size
+                            .checked_sub(jetstream_messages.len())
+                            .unwrap_or(0),
+                    )
+                    .await;
+            }
+            None => {}
+        }
+
         pipeline_metrics()
             .jetstream_isb
             .read_time_total

--- a/rust/numaflow-throttling/src/lib.rs
+++ b/rust/numaflow-throttling/src/lib.rs
@@ -1858,6 +1858,36 @@ mod tests {
             .test_name("test_distributed_rate_limiter_deposit_logic_3".to_string())
             .mode(Mode::Relaxed)
             .deposited_tokens(vec![5, 5, 5, 5, 5]),
+            // Integer slope with multiple pods
+            // keep depositing same amount of tokens in each epoch
+            // The tokens fetched in next epoch should be independent of deposited tokens
+            // in relaxed mode
+            test_utils::TestCase::new(
+                20,
+                10,
+                Duration::from_secs(10),
+                2,
+                vec![(None, 1), (None, 1), (None, 1), (None, 1), (None, 1)],
+                vec![5, 5, 6, 6, 7],
+            )
+            .test_name("test_distributed_rate_limiter_deposit_logic_4".to_string())
+            .mode(Mode::Relaxed)
+            .deposited_tokens(vec![5, 5, 5, 5, 5]),
+            // Integer slope with multiple pods
+            // keep depositing same amount of tokens in each epoch
+            // The tokens fetched in next epoch should be independent of deposited tokens
+            // in scheduled mode
+            test_utils::TestCase::new(
+                20,
+                10,
+                Duration::from_secs(10),
+                2,
+                vec![(None, 1), (None, 1), (None, 1), (None, 1), (None, 1)],
+                vec![5, 5, 6, 6, 7],
+            )
+            .test_name("test_distributed_rate_limiter_deposit_logic_5".to_string())
+            .mode(Mode::Scheduled)
+            .deposited_tokens(vec![5, 5, 5, 5, 5]),
         ];
         test_utils::run_distributed_rate_limiter_multiple_pods_test_cases(test_cases).await;
     }
@@ -2537,6 +2567,92 @@ mod tests {
             ),
         ];
 
+        test_utils::run_distributed_rate_limiter_multiple_pods_test_cases(test_cases).await;
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "redis-tests")]
+    async fn test_distributed_rate_limiter_deposit_logic_redis() {
+        use test_utils::StoreType;
+
+        let test_cases = vec![
+            // Integer slope with multiple pods
+            // Keep acquiring min tokens with regular gaps in epochs between calls
+            // Acquire None tokens here and there to check the max tokens shelled out.
+            test_utils::TestCase::new(
+                20,
+                10,
+                Duration::from_secs(10),
+                2,
+                vec![(Some(2), 0), (None, 0), (None, 1), (None, 0), (Some(3), 1)],
+                vec![2, 5, 2, 5, 3],
+            )
+            .test_name("test_distributed_rate_limiter_deposit_logic_redis_1".to_string())
+            .mode(Mode::Relaxed)
+            .store_type(StoreType::Redis)
+            .deposited_tokens(vec![2, 2, 0, 3, 0]),
+            // Integer slope with multiple pods
+            // Keep depositing all the tokens back
+            // We'll get burst tokens in each pull within the same epoch
+            test_utils::TestCase::new(
+                20,
+                10,
+                Duration::from_secs(10),
+                2,
+                vec![(None, 0), (None, 0), (None, 0), (None, 0), (None, 1)],
+                vec![5, 5, 5, 5, 5],
+            )
+            .test_name("test_distributed_rate_limiter_deposit_logic_redis_2".to_string())
+            .mode(Mode::Relaxed)
+            .store_type(StoreType::Redis)
+            .deposited_tokens(vec![5, 5, 5, 5, 5]),
+            // Integer slope with multiple pods
+            // keep depositing same amount of tokens in each epoch
+            test_utils::TestCase::new(
+                20,
+                10,
+                Duration::from_secs(10),
+                2,
+                vec![(None, 1), (None, 0), (None, 1), (None, 0), (None, 1)],
+                vec![5, 5, 5, 6, 5],
+            )
+            .test_name("test_distributed_rate_limiter_deposit_logic_redis_3".to_string())
+            .mode(Mode::Relaxed)
+            .store_type(StoreType::Redis)
+            .deposited_tokens(vec![5, 5, 5, 5, 5]),
+            // Integer slope with multiple pods
+            // keep depositing same amount of tokens in each epoch
+            // The tokens fetched in next epoch should be independent of deposited tokens
+            // in relaxed mode
+            test_utils::TestCase::new(
+                20,
+                10,
+                Duration::from_secs(10),
+                2,
+                vec![(None, 1), (None, 1), (None, 1), (None, 1), (None, 1)],
+                vec![5, 5, 6, 6, 7],
+            )
+            .test_name("test_distributed_rate_limiter_deposit_logic_redis_4".to_string())
+            .mode(Mode::Relaxed)
+            .store_type(StoreType::Redis)
+            .deposited_tokens(vec![5, 5, 5, 5, 5]),
+            // Integer slope with multiple pods
+            // keep depositing same amount of tokens in each epoch
+            // The tokens fetched in next epoch should be independent of deposited tokens
+            // in scheduled mode
+            test_utils::TestCase::new(
+                20,
+                10,
+                Duration::from_secs(10),
+                2,
+                vec![(None, 1), (None, 1), (None, 1), (None, 1), (None, 1)],
+                vec![5, 5, 6, 6, 7],
+            )
+            .test_name("test_distributed_rate_limiter_deposit_logic_redis_5".to_string())
+            .mode(Mode::Scheduled)
+            .store_type(StoreType::Redis)
+            .deposited_tokens(vec![5, 5, 5, 5, 5]),
+        ];
         test_utils::run_distributed_rate_limiter_multiple_pods_test_cases(test_cases).await;
     }
 }

--- a/rust/numaflow-throttling/src/lib.rs
+++ b/rust/numaflow-throttling/src/lib.rs
@@ -2834,7 +2834,7 @@ mod tests {
             .test_name("test_distributed_rate_limiter_only_scheduled_mode_redis15".to_string())
             .mode(Mode::Scheduled)
             .store_type(Redis),
-            ];
+        ];
         test_utils::run_distributed_rate_limiter_multiple_pods_test_cases(test_cases).await;
     }
 
@@ -2919,8 +2919,7 @@ mod tests {
             .mode(Mode::Scheduled)
             .store_type(StoreType::Redis)
             .deposited_tokens(vec![5, 5, 5, 5, 5]),
-            ];
+        ];
         test_utils::run_distributed_rate_limiter_multiple_pods_test_cases(test_cases).await;
     }
 }
-

--- a/rust/numaflow-throttling/src/lib.rs
+++ b/rust/numaflow-throttling/src/lib.rs
@@ -584,7 +584,7 @@ impl<S: Store> RateLimit<WithState<S>> {
                 } else {
                     TokenAvailability::Exhausted
                 }
-            },
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #2913 

### What this PR does / why we need it
Change get_tokens for *WithState Ratelimiters* to utilize deposited tokens.

This PR implements using unused tokens that were deposited within the same epoch.
Implementation for modes that utilize unused tokens to compute_refill is present in #2962 

### Testing
All of the previously added unit tests are passing. New unit tests were added to test the get_tokens logic when depositing back unused tokens. 

### Special notes for reviewers
Anything notable for review (risk, rollout, follow-ups).

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
