### PR TITLE
fix:  udf write metrics in streaming mode

### DIFF
--- a/rust/numaflow-core/src/mapper/map/user_defined.rs
+++ b/rust/numaflow-core/src/mapper/map/user_defined.rs
@@ -414,12 +414,6 @@ impl UserDefinedStreamMap {
                 .remove(&resp.id)
                 .expect("map entry should always be present");
 
-            pipeline_metrics()
-                .forwarder
-                .udf_write_total
-                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_MAP_UDF))
-                .inc();
-
             // once we get eot, we can drop the sender to let the callee
             // know that we are done sending responses
             if let Some(map::TransmissionStatus { eot: true }) = resp.status {
@@ -442,6 +436,11 @@ impl UserDefinedStreamMap {
                     .await
                     .expect("failed to send response");
                 message_info.current_index += 1;
+                pipeline_metrics()
+                    .forwarder
+                    .udf_write_total
+                    .get_or_create(pipeline_metric_labels(VERTEX_TYPE_MAP_UDF))
+                    .inc();
             }
 
             // Write the sender back to the map, because we need to send


### PR DESCRIPTION
### What this PR does / why we need it

https://github.com/numaproj/numaflow/issues/2876#issuecomment-3328715065

### Related issues
Fixes #

### Testing

Running both Rust and Go pipeline with map udf in streaming mode and comparing the prometheus metrics.

### Special notes for reviewers
Anything notable for review (risk, rollout, follow-ups).

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
