### PR TITLE
fix: [::]:50051 is not parsable by ASP.NET.CORE 9 

### DIFF
--- a/rust/numaflow-core/src/shared/grpc.rs
+++ b/rust/numaflow-core/src/shared/grpc.rs
@@ -144,7 +144,7 @@ pub(crate) async fn create_rpc_channel(socket_path: PathBuf) -> error::Result<Ch
 
 /// Connects to the UDS socket and returns a channel
 pub(crate) async fn connect_with_uds(uds_path: PathBuf) -> error::Result<Channel> {
-    let channel = Endpoint::try_from("http://[::]:50051")
+    let channel = Endpoint::try_from("http://[::1]:50051")
         .map_err(|e| Error::Connection(format!("Failed to create endpoint: {e:?}")))?
         .connect_with_connector(service_fn(move |_: Uri| {
             let uds_socket = uds_path.clone();

--- a/rust/numaflow-sideinput/src/manager/client.rs
+++ b/rust/numaflow-sideinput/src/manager/client.rs
@@ -84,7 +84,7 @@ async fn create_rpc_channel(socket_path: PathBuf) -> Result<Channel> {
 }
 
 async fn connect_with_uds(uds_path: PathBuf) -> Result<Channel> {
-    let channel = Endpoint::try_from("http://[::]:50051")
+    let channel = Endpoint::try_from("http://[::1]:50051")
         .map_err(|e| Error::Connection(format!("Failed to create endpoint: {e:?}")))?
         .connect_with_connector(service_fn(move |_: Uri| {
             let uds_socket = uds_path.clone();

--- a/rust/serving/src/app/store/datastore/user_defined.rs
+++ b/rust/serving/src/app/store/datastore/user_defined.rs
@@ -90,7 +90,7 @@ pub(crate) async fn create_rpc_channel(socket_path: PathBuf) -> StoreResult<Chan
 
 /// Connects to the UDS socket and returns a channel
 pub(crate) async fn connect_with_uds(uds_path: PathBuf) -> StoreResult<Channel> {
-    let channel = Endpoint::try_from("http://[::]:50051")
+    let channel = Endpoint::try_from("http://[::1]:50051")
         .map_err(|e| StoreError::Connection(format!("Failed to create endpoint: {e:?}")))?
         .connect_with_connector(service_fn(move |_: Uri| {
             let uds_socket = uds_path.clone();


### PR DESCRIPTION
Closes #3019 

Since we are ATM connecting only to loopback, we can move to `http://[::1]:50051`

| Address | Meaning                              | IPv4 Equivalent | Typical Use                                    |
|---------|--------------------------------------|-----------------|------------------------------------------------|
| `[::1]`	  | Localhost (this machine only)        | 127.0.0.1       | Client: Connecting to a local server.          |
| `[::]`    | Any Address (all network interfaces) | 0.0.0.0	        | Server: Listening for any incoming connection. |