### PR TITLE
fix: active partitions for source watermark publisher

### DIFF
--- a/rust/numaflow-core/src/metrics.rs
+++ b/rust/numaflow-core/src/metrics.rs
@@ -1532,7 +1532,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .await;
 
         let sink_writer = SinkWriterBuilder::new(
             10,

--- a/rust/numaflow-core/src/monovertex/forwarder.rs
+++ b/rust/numaflow-core/src/monovertex/forwarder.rs
@@ -296,7 +296,8 @@ mod tests {
             Some(transformer),
             None,
             None,
-        );
+        )
+        .await;
 
         let sink_writer =
             SinkWriterBuilder::new(10, Duration::from_millis(100), SinkClientType::Log)
@@ -431,7 +432,8 @@ mod tests {
             Some(transformer),
             None,
             None,
-        );
+        )
+        .await;
 
         let sink_writer =
             SinkWriterBuilder::new(10, Duration::from_millis(100), SinkClientType::Log)
@@ -574,7 +576,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .await;
 
         // create a mapper
         let (mp_shutdown_tx, mp_shutdown_rx) = oneshot::channel();
@@ -695,7 +698,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .await;
 
         // create a mapper
         let (bmp_shutdown_tx, bmp_shutdown_rx) = oneshot::channel();
@@ -816,7 +820,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .await;
 
         // create a mapper
         let (fms_shutdown_tx, fms_shutdown_rx) = oneshot::channel();

--- a/rust/numaflow-core/src/pipeline/forwarder/source_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/source_forwarder.rs
@@ -412,7 +412,8 @@ mod tests {
             Some(transformer),
             None,
             None,
-        );
+        )
+        .await;
 
         // create a js writer
         let js_url = "localhost:4222";

--- a/rust/numaflow-core/src/shared/create_components.rs
+++ b/rust/numaflow-core/src/shared/create_components.rs
@@ -368,7 +368,8 @@ pub async fn create_source<C: NumaflowTypeConfig>(
                 transformer,
                 watermark_handle,
                 rate_limiter,
-            ))
+            )
+            .await)
         }
         SourceType::Pulsar(pulsar_config) => {
             let pulsar = new_pulsar_source(
@@ -387,7 +388,8 @@ pub async fn create_source<C: NumaflowTypeConfig>(
                 transformer,
                 watermark_handle,
                 rate_limiter,
-            ))
+            )
+            .await)
         }
         SourceType::Sqs(sqs_source_config) => {
             let sqs = new_sqs_source(
@@ -406,7 +408,8 @@ pub async fn create_source<C: NumaflowTypeConfig>(
                 transformer,
                 watermark_handle,
                 rate_limiter,
-            ))
+            )
+            .await)
         }
         SourceType::Jetstream(jetstream_config) => {
             let jetstream = new_jetstream_source(
@@ -424,7 +427,8 @@ pub async fn create_source<C: NumaflowTypeConfig>(
                 transformer,
                 watermark_handle,
                 rate_limiter,
-            ))
+            )
+            .await)
         }
         SourceType::Nats(nats_config) => {
             let nats = new_nats_source(
@@ -442,7 +446,8 @@ pub async fn create_source<C: NumaflowTypeConfig>(
                 transformer,
                 watermark_handle,
                 rate_limiter,
-            ))
+            )
+            .await)
         }
         SourceType::Kafka(kafka_config) => {
             let config = *kafka_config.clone();
@@ -456,7 +461,8 @@ pub async fn create_source<C: NumaflowTypeConfig>(
                 transformer,
                 watermark_handle,
                 rate_limiter,
-            ))
+            )
+            .await)
         }
         SourceType::Http(http_source_config) => {
             let http_source =
@@ -470,7 +476,8 @@ pub async fn create_source<C: NumaflowTypeConfig>(
                 transformer,
                 watermark_handle,
                 rate_limiter,
-            ))
+            )
+            .await)
         }
 
         SourceType::UserDefined(user_defined_config) => {
@@ -494,7 +501,8 @@ pub async fn create_source<C: NumaflowTypeConfig>(
                 transformer,
                 watermark_handle,
                 rate_limiter,
-            ))
+            )
+            .await)
         }
     }
 }

--- a/rust/numaflow-core/src/sink/sqs.rs
+++ b/rust/numaflow-core/src/sink/sqs.rs
@@ -262,7 +262,8 @@ pub mod tests {
                 None,
                 None,
                 None,
-            ),
+            )
+            .await,
             source_handle,
             src_shutdown_tx,
         )

--- a/rust/numaflow-core/src/source/sqs.rs
+++ b/rust/numaflow-core/src/source/sqs.rs
@@ -218,7 +218,8 @@ pub mod tests {
             None,
             None,
             None,
-        );
+        )
+        .await;
 
         // create sink writer
         use crate::sink::{SinkClientType, SinkWriterBuilder};

--- a/rust/numaflow-core/src/watermark/idle/source.rs
+++ b/rust/numaflow-core/src/watermark/idle/source.rs
@@ -115,7 +115,6 @@ mod tests {
     use super::*;
     use crate::config::pipeline::watermark::IdleConfig;
     use std::time::Duration;
-    use tokio::time;
 
     #[test]
     fn test_is_source_idling() {


### PR DESCRIPTION
### Issue
When we never receive data from a source, the processing entities (partitions) are not initialized. As a result, heartbeats are not published for these processing entities in the Source vertex. Consequently, the vertex downstream of the Source vertex does not consider the timelines of these processing entities for watermark progression, leading to incorrect watermark propagation.

### Fix
Initialize the source watermark publisher component by retrieving partitions from the source during boot-up to ensure that all processing entities, to which we are supposed to publish watermarks, are initialized and heartbeats are published.

### Testing
Tested using an accumulator pipeline by not sending any data to an input-source and make sure the window never gets closed.

```
apiVersion: numaflow.numaproj.io/v1alpha1
kind: Pipeline
metadata:
  name: stream-sorter
spec:
  watermark:
    idleSource:
      threshold: 5s
      stepInterval: 2s
      incrementBy: 1s
  limits:
    readBatchSize: 1
  vertices:
    - name: input-one
      scale:
        min: 1
      source:
        http: {}
    - name: input-two
      scale:
        min: 1
      source:
        http: {}
    - name: accum
      udf:
        container:
          image: quay.io/numaio/numaflow-rs/stream-sorter:stable
        groupBy:
          window:
            accumulator:
              timeout: 5s
          keyed: true
          storage:
            persistentVolumeClaim:
              volumeSize: 1Gi
    - name: sink
      scale:
        min: 1
      sink:
        log: {}
  edges:
    - from: input-one
      to: accum
    - from: input-two
      to: accum
    - from: accum
      to: sink
```
