### PR TITLE
fix: enable reading from Kafka topics compressed with zstd (Fixes #3063)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN chmod +x /bin/entrypoint
 FROM lukemathwalker/cargo-chef:latest-rust-1.90 AS chef
 ARG TARGETPLATFORM
 WORKDIR /numaflow
-RUN apt-get update && apt-get install -y protobuf-compiler cmake
+RUN apt-get update && apt-get install -y protobuf-compiler cmake clang
 
 FROM chef AS planner
 COPY ./rust/ .

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -237,7 +237,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "cc",
  "cmake",
  "dunce",
@@ -764,6 +764,24 @@ dependencies = [
  "shlex",
  "syn",
  "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -3473,6 +3491,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "sasl2-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -5613,6 +5632,7 @@ version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
+ "bindgen 0.71.1",
  "cc",
  "pkg-config",
 ]

--- a/rust/extns/numaflow-kafka/Cargo.toml
+++ b/rust/extns/numaflow-kafka/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-rdkafka = { version = "0.38.0", default-features = false, features = ["cmake-build", "tokio", "ssl-vendored", "gssapi-vendored", "sasl", "curl", "curl-static"] }
+rdkafka = { version = "0.38.0", default-features = false, features = ["cmake-build", "tokio", "ssl-vendored", "gssapi-vendored", "sasl", "curl", "curl-static", "zstd"] }
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 tokio-util.workspace = true


### PR DESCRIPTION
### What this PR does / why we need it

This PR enables using the Kafka source to read from topics compressed with Zstandard (zstd).

### Related issues
Partially Fixes #3063 

### Testing
This PR has been tested by deploying the Numaflow system, the JetStream inter-step buffer service, and a Kafka cluster with a topic containing a zstd compressed message. With this setup, a Numaflow pipeline can successfully read from the compressed Kafka topic. The PR has also been tested by confirming that the binaries can be built without errors.

####  Reading Kafka Messages with zstd Compression
This section is similar to the example provided in #3063 and is included here for completeness. Create the namespace `numaflow-system` and deploy the Numaflow system:
```bash
kubectl create namespace numaflow-system
make start
```

Create the namespace `numaflow` and deploy the Jetstream inter-step buffer service:
```bash
kubectl create namespace numaflow
kubectl apply -n numaflow -f https://raw.githubusercontent.com/numaproj/numaflow/main/examples/0-isbsvc-jetstream.yaml
```

Deploy the Kafka cluster:
```bash
kubectl apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  name: kafka-deployment
  namespace: numaflow
spec:
  replicas: 1
  selector:
    matchLabels:
      app: kafka
  template:
    metadata:
      labels:
        app: kafka
    spec:
      containers:
      - name: kafka
        image: apache/kafka:latest
        ports:
        - containerPort: 9092
          name: plaintext
        - containerPort: 9093
          name: controller
        env:
        - name: KAFKA_NODE_ID
          value: "1"
        - name: KAFKA_PROCESS_ROLES
          value: "broker,controller"
        - name: KAFKA_LISTENERS
          value: "PLAINTEXT://:9092,CONTROLLER://:9093"
        - name: KAFKA_ADVERTISED_LISTENERS
          value: "PLAINTEXT://kafka-service:9092"
        - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
          value: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
        - name: KAFKA_CONTROLLER_QUORUM_VOTERS
          value: "1@localhost:9093"
        - name: KAFKA_CONTROLLER_LISTENER_NAMES
          value: "CONTROLLER"
        - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
          value: "1"
        - name: KAFKA_COMPRESSION_TYPE
          value: "zstd"
        livenessProbe:
          tcpSocket:
            port: 9092
        readinessProbe:
          tcpSocket:
            port: 9092
---
apiVersion: v1
kind: Service
metadata:
  name: kafka-service
  namespace: numaflow
spec:
  type: ClusterIP
  ports:
  - port: 9092
    targetPort: 9092
    protocol: TCP
    name: plaintext
  - port: 9093
    targetPort: 9093
    protocol: TCP
    name: controller
  selector:
    app: kafka
EOF
```

Create the Kafka topic `zstd-compressed-topic`:
```bash
kubectl apply -f - <<EOF
apiVersion: batch/v1
kind: Job
metadata:
  name: kafka-create-topic
  namespace: numaflow
spec:
  template:
    spec:
      restartPolicy: OnFailure
      containers:
      - name: create-topic
        image: apache/kafka:latest
        command: ['sh', '-c']
        args:
        - |
          /opt/kafka/bin/kafka-topics.sh \
            --bootstrap-server kafka-service:9092 \
            --create --topic zstd-compressed-topic \
            --partitions 1 --replication-factor 1
EOF
```

Write the message `Hello Kafka` using zstd compression:
```bash
kubectl apply -f - <<EOF
apiVersion: batch/v1
kind: Job
metadata:
  name: kafka-write-message
  namespace: numaflow
spec:
  template:
    spec:
      restartPolicy: OnFailure
      containers:
      - name: write-message
        image: apache/kafka:latest
        command: ['sh', '-c']
        args:
        - |
          echo "Hello Kafka" | /opt/kafka/bin/kafka-console-producer.sh \
            --bootstrap-server kafka-service:9092 \
            --topic zstd-compressed-topic \
            --producer-property compression.type=zstd
EOF
```

Deploy the Numaflow pipeline that reads the zstd compressed message and writes it to the log sink:
```bash
kubectl apply -f - <<EOF
apiVersion: numaflow.numaproj.io/v1alpha1
kind: Pipeline
metadata:
  name: example-pipeline
  namespace: numaflow
spec:
  edges:
  - from: source
    to: sink
  vertices:
  - containerTemplate:
    name: source
    scale:
      max: 1
      min: 1
    source:
      kafka:
        brokers:
        - kafka-service:9092
        config: |
          auto.offset.reset: earliest
        consumerGroup: consumer-group
        topic: zstd-compressed-topic
  - containerTemplate:
    name: sink
    scale:
      max: 1
      min: 1
    sink:
      log: {}
EOF
```
Inspect the Kafka source and log sink and observe that the zstd compressed message has been successfully read from the Kafka topic and written to the log sink.

#### Build Binaries

Run the following command and confirm that the binaries are successfully built without any errors:

```bash
make build-rust-docker-ghactions
```

### Special notes for reviewers
Note that this PR differs slightly from the proposed solution in #3063. The solution in #3063 involves the `zstd-pkg-config` feature in Cargo.toml and adds `clang` and `libclang-dev` as dependencies in the Dockerfile. This results in the zstd library being dynamically linked. However, [a comment by BulkBeing](https://github.com/numaproj/numaflow/issues/3063#issuecomment-3488586725)  shows that these changes causes a compilation error when building the binaries.

In contrast, this PR uses the `zstd` feature, which statically links the library. This approach does not to the best of my knowledge result in any compilation errors. I leave the choice between static and dynamic linking to the discretion of the Numaflow team.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
