### PR TITLE
fix: add back drop metrics after sink refactor

### DIFF
--- a/rust/numaflow-core/src/pipeline/isb/writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/writer.rs
@@ -123,7 +123,12 @@ impl ISBWriter {
     async fn write_to_isb(&self, message: Message, cln_token: CancellationToken) -> Result<()> {
         // Handle dropped messages
         if message.dropped() {
-            self.publish_stream_drop_metric("n/a", "to_drop", message.value.len());
+            // Increment metric for user-initiated drops via DROP tag
+            pipeline_metrics()
+                .forwarder
+                .udf_drop_total
+                .get_or_create(pipeline_metric_labels(self.vertex_type.as_str()))
+                .inc();
             return Ok(());
         }
 


### PR DESCRIPTION
### What this PR does / why we need it

- Add back metric for dropped messages because of retry strategy
- Distinguish drop metric in case of user initiated DROP tag

### Related issues
Fixes #

### Testing
How was this tested (unit/integration/manual)? Include commands, links, or screenshots if applicable.

### Special notes for reviewers
Anything notable for review (risk, rollout, follow-ups).

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
