### PR TITLE
lint: fail if cargo check has warnings

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+rustflags = ["-Dwarnings"]
+


### PR DESCRIPTION
fail on build if we have warnings