### PR TITLE
doc: Update FAQs with a scenario for `Server Info File not ready`

### DIFF
--- a/docs/user-guide/FAQ.md
+++ b/docs/user-guide/FAQ.md
@@ -29,6 +29,8 @@ This message indicates that the server has not started yet. Common reasons inclu
 
 -   The server was not started correctly in the `udcontainer`.
 -   The server is still initializing (for example, the application code is downloading cache files or performing setup tasks).
+-   Numa container is waiting for the server on a different endpoint than the one server is listening on. Example: 
+    -   If the udf implements reduce streaming, while the vertex spec is not configured with `streaming: true`
 
 ### 5. What is `partitions` in Numaflow?
 


### PR DESCRIPTION
### What this PR does / why we need it

Adds a scenario in FAQs where `Server Info File not ready` can occur. 

### Related issues
[#306](https://github.com/numaproj/numaflow-python/issues/306)

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
