### PR TITLE
chore: Preallocate Bytes/BytesMut when possible

### DIFF
--- a/rust/numaflow-core/src/message.rs
+++ b/rust/numaflow-core/src/message.rs
@@ -370,7 +370,7 @@ impl TryFrom<Message> for BytesMut {
             }),
         };
 
-        let mut buf = BytesMut::new();
+        let mut buf = BytesMut::with_capacity(proto_message.encoded_len());
         proto_message
             .encode(&mut buf)
             .map_err(|e| Error::Proto(e.to_string()))?;

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
@@ -8,7 +8,7 @@ use async_nats::jetstream::context::{PublishAckFuture, PublishErrorKind};
 use async_nats::jetstream::message::PublishMessage;
 use async_nats::jetstream::publish::PublishAck;
 use async_nats::jetstream::stream::RetentionPolicy::Limits;
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use tokio::time::{Instant, sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
@@ -233,16 +233,12 @@ impl JetStreamWriter {
             None => message.value,
         };
 
-        let payload: BytesMut = message
+        let payload: Bytes = message
             .try_into()
             .expect("message serialization should not fail");
 
         loop {
-            match self
-                .js_ctx
-                .publish(self.stream.name, payload.clone().freeze())
-                .await
-            {
+            match self.js_ctx.publish(self.stream.name, payload.clone()).await {
                 Ok(paf) => match paf.await {
                     Ok(ack) => {
                         debug!(

--- a/rust/numaflow-core/src/reduce/wal.rs
+++ b/rust/numaflow-core/src/reduce/wal.rs
@@ -9,7 +9,7 @@ use crate::reduce::wal::segment::WalType;
 use crate::reduce::wal::segment::append::AppendOnlyWal;
 use crate::reduce::wal::segment::compactor::{Compactor, WindowKind};
 use crate::shared::grpc::{prost_timestamp_from_utc, utc_from_timestamp};
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use std::sync::Arc;
 
 /// A WAL Segment.
@@ -56,11 +56,7 @@ impl TryFrom<WalMessage> for Bytes {
             metadata: None,
         };
 
-        let mut buf = BytesMut::new();
-        prost::Message::encode(&proto_message, &mut buf)
-            .map_err(|e| Error::Other(e.to_string()))?;
-
-        Ok(buf.freeze())
+        Ok(Bytes::from(prost::Message::encode_to_vec(&proto_message)))
     }
 }
 

--- a/rust/numaflow-core/src/watermark/wmb.rs
+++ b/rust/numaflow-core/src/watermark/wmb.rs
@@ -50,13 +50,14 @@ impl TryFrom<WMB> for BytesMut {
     type Error = Error;
 
     fn try_from(wmb: WMB) -> Result<Self, Self::Error> {
-        let mut bytes = BytesMut::new();
         let proto_wmb = numaflow_pb::objects::watermark::Wmb {
             idle: wmb.idle,
             offset: wmb.offset,
             watermark: wmb.watermark,
             partition: wmb.partition as i32,
         };
+
+        let mut bytes = BytesMut::with_capacity(proto_wmb.encoded_len());
 
         proto_wmb
             .encode(&mut bytes)


### PR DESCRIPTION
### What this PR does / why we need it
Pre-allocate Bytes, avoid `O(n)` cloning of `BytesMut` in some code paths.
<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
