### PR TITLE
feat(ui): show onSuccess and fallback sink container icons in Pipeline graph

### DIFF
--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomNode/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomNode/index.tsx
@@ -293,6 +293,12 @@ const CustomNode: FC<NodeProps> = ({
     ? "mono-vertex-img-wrapper-small"
     : "mono-vertex-img-wrapper";
   const imgClass = hasBothSinks ? "mono-vertex-img-small" : "mono-vertex-img";
+  const pipelineSinkWrapperClass = hasBothSinks
+    ? "pipeline-sink-container-wrapper-small"
+    : "pipeline-sink-container-wrapper";
+  const pipelineSinkImgClass = hasBothSinks
+    ? "pipeline-sink-container-img-small"
+    : "pipeline-sink-container-img";
   const nodeRateWrapperClass = hasBothSinks ? "node-rate-small" : "node-rate";
   const nodeRateStyle =
     data?.type === "monoVertex" && hasBothSinks
@@ -350,10 +356,19 @@ const CustomNode: FC<NodeProps> = ({
     );
   }, []);
 
+  const isSinkWithContainers =
+    data?.type === "sink" &&
+    data?.nodeInfo?.sink &&
+    (data?.nodeInfo?.sink?.onSuccess || data?.nodeInfo?.sink?.fallback);
+
   return (
     <Box data-testid={data?.name}>
       <Box
-        className={"react-flow__node-input"}
+        className={
+          isSinkWithContainers
+            ? "react-flow__node-input react-flow__node-input--sink-with-containers"
+            : "react-flow__node-input"
+        }
         onClick={handleClick}
         style={nodeStyle}
       >
@@ -549,6 +564,144 @@ const CustomNode: FC<NodeProps> = ({
               )}
             </Box>
           </>
+        )}
+        {data?.type === "sink" &&
+          data?.nodeInfo?.sink &&
+          (data?.nodeInfo?.sink?.onSuccess || data?.nodeInfo?.sink?.fallback) && (
+          <Box
+            className={"pipeline-sink-container-row"}
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              flex: 1,
+              gap: "0.8rem",
+            }}
+          >
+            <Tooltip
+              title={<Box className={"node-tooltip"}>Sink Container</Box>}
+              arrow
+              placement={
+                data?.nodeInfo?.sink?.fallback ||
+                data?.nodeInfo?.sink?.onSuccess
+                  ? "bottom"
+                  : "right"
+              }
+            >
+              <Box className={pipelineSinkWrapperClass}>
+                <img
+                  className={pipelineSinkImgClass}
+                  src={sink}
+                  alt={"sink-container"}
+                />
+              </Box>
+            </Tooltip>
+            <Box
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.6rem",
+              }}
+            >
+              {data?.nodeInfo?.sink?.onSuccess &&
+                !data?.nodeInfo?.sink?.fallback && (
+                  <Box style={{ display: "flex", alignItems: "center" }}>
+                    {arrowSvg}
+                    <Tooltip
+                      title={
+                        <Box className={"node-tooltip"}>
+                          OnSuccess Sink Container
+                        </Box>
+                      }
+                      arrow
+                      placement={"right"}
+                    >
+                      <Box className={pipelineSinkWrapperClass}>
+                        <img
+                          className={pipelineSinkImgClass}
+                          src={onSuccess}
+                          alt={"on-success-sink-container"}
+                        />
+                      </Box>
+                    </Tooltip>
+                  </Box>
+                )}
+              {data?.nodeInfo?.sink?.fallback &&
+                !data?.nodeInfo?.sink?.onSuccess && (
+                  <Box style={{ display: "flex", alignItems: "center" }}>
+                    {arrowSvg}
+                    <Tooltip
+                      title={
+                        <Box className={"node-tooltip"}>
+                          Fallback Sink Container
+                        </Box>
+                      }
+                      arrow
+                      placement={"right"}
+                    >
+                      <Box className={pipelineSinkWrapperClass}>
+                        <img
+                          className={pipelineSinkImgClass}
+                          src={fallback}
+                          alt={"fallback-sink-container"}
+                        />
+                      </Box>
+                    </Tooltip>
+                  </Box>
+                )}
+              {data?.nodeInfo?.sink?.onSuccess &&
+                data?.nodeInfo?.sink?.fallback && (
+                <Box
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "0.5rem",
+                  }}
+                >
+                  <Box style={{ display: "flex", alignItems: "center" }}>
+                    {arrowUpSvg}
+                    <Tooltip
+                      title={
+                        <Box className={"node-tooltip"}>
+                          OnSuccess Sink Container
+                        </Box>
+                      }
+                      arrow
+                      placement={"right"}
+                    >
+                      <Box className={pipelineSinkWrapperClass}>
+                        <img
+                          className={pipelineSinkImgClass}
+                          src={onSuccess}
+                          alt={"on-success-sink-container"}
+                        />
+                      </Box>
+                    </Tooltip>
+                  </Box>
+                  <Box style={{ display: "flex", alignItems: "center" }}>
+                    {arrowDownSvg}
+                    <Tooltip
+                      title={
+                        <Box className={"node-tooltip"}>
+                          Fallback Sink Container
+                        </Box>
+                      }
+                      arrow
+                      placement={"right"}
+                    >
+                      <Box className={pipelineSinkWrapperClass}>
+                        <img
+                          className={pipelineSinkImgClass}
+                          src={fallback}
+                          alt={"fallback-sink-container"}
+                        />
+                      </Box>
+                    </Tooltip>
+                  </Box>
+                </Box>
+              )}
+            </Box>
+          </Box>
         )}
         <Tooltip
           title={

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomNode/style.css
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomNode/style.css
@@ -90,6 +90,15 @@
   cursor: pointer;
 }
 
+.react-flow__node-input--sink-with-containers {
+  min-height: 11.2rem;
+  height: auto;
+}
+
+.pipeline-sink-container-row {
+  padding: 0.2rem 0;
+}
+
 .node-info {
   display: flex;
   width: 100%;
@@ -154,6 +163,44 @@
 .mono-vertex-img-small {
   height: 0.9rem;
   width: 0.9rem;
+}
+
+/* Pipeline sink container icons - slightly larger for visibility */
+.pipeline-sink-container-wrapper,
+.pipeline-sink-container-wrapper-small {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid #d1dee9;
+  background: #fff;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.pipeline-sink-container-wrapper:hover,
+.pipeline-sink-container-wrapper-small:hover {
+  border-color: #009eac;
+  box-shadow: 0 0 0 1px rgba(0, 158, 172, 0.2);
+}
+
+.pipeline-sink-container-wrapper {
+  height: 3.4rem;
+  width: 3.4rem;
+}
+
+.pipeline-sink-container-img {
+  height: 1.9rem;
+  width: 1.9rem;
+}
+
+.pipeline-sink-container-wrapper-small {
+  height: 3rem;
+  width: 3rem;
+}
+
+.pipeline-sink-container-img-small {
+  height: 1.6rem;
+  width: 1.6rem;
 }
 
 .node-icon {

--- a/ui/src/utils/fetchWrappers/systemInfoFetch.ts
+++ b/ui/src/utils/fetchWrappers/systemInfoFetch.ts
@@ -42,7 +42,7 @@ export const useSystemInfoFetch = (props: SystemInfoProps) => {
       setSystemInfo(data?.data);
       return;
     }
-  }, [data, fetchLoading]);
+  }, [data, fetchLoading, error]);
 
   return { systemInfo, error: errMsg, loading };
 };

--- a/ui/src/utils/fetcherHooks/pipelineViewFetch.ts
+++ b/ui/src/utils/fetcherHooks/pipelineViewFetch.ts
@@ -113,7 +113,7 @@ export const usePipelineViewFetch = (
     };
 
     fetchPipeline();
-  }, [requestKey, addError]);
+  }, [requestKey, addError, namespaceId, pipelineId]);
 
   // Call to get buffers
   useEffect(() => {


### PR DESCRIPTION
Fixes #3118

Sink vertices in the Pipeline graph now show separate container icons when sink.onSuccess or sink.fallback are set in the spec:
- Sink – main sink container
- OnSuccess – shown when sink.onSuccess is configured
- Fallback – shown when sink.fallback is configured

Behavior matches how MonoVertex nodes show multiple containers. Changes are limited to:
- CustomNode/index.tsx – render Sink / OnSuccess / Fallback icons for sink vertices
- CustomNode/style.css – styles for the new container icons

Screenshot (sink vertex with main sink, onSuccess, and Fallback Sink Container icons):
<img width="812" height="501" alt="Numaflow pr image" src="https://github.com/user-attachments/assets/fe6a81ef-4307-4646-b894-f602078bf341" />


Question for reviewers: For the new Sink / OnSuccess / Fallback container icons, should clicking each icon open different sidebar content (e.g. logs/config for that container), or should all continue to open the same vertex details? Current behavior is unchanged (same vertex details for all).