### PR TITLE
fix: use vertex name as partition label for source pending metric

### DIFF
--- a/rust/numaflow-core/src/metrics.rs
+++ b/rust/numaflow-core/src/metrics.rs
@@ -1468,7 +1468,7 @@ async fn expose_pending_metrics<C: crate::typ::NumaflowTypeConfig>(
                         let mut metric_labels = pipeline_metric_labels(VERTEX_TYPE_SOURCE).clone();
                         metric_labels.push((
                             PIPELINE_PARTITION_NAME_LABEL.to_string(),
-                            "Source".to_string(),
+                            get_vertex_name().to_string(),
                         ));
                         pipeline_metrics()
                             .pending_raw


### PR DESCRIPTION
### What this PR does / why we need it
Makes Source autoscaling work.

### Related issues
~Couldnt find an issue, but autoscaling for sources seems to have never worked, this fixes it by following the pattern of sinks.~

Closes #3208

### Testing
How was this tested (unit/integration/manual)? Include commands, links, or screenshots if applicable.
I couldnt find a good way to add tests for this, im open to suggestions.


### Special notes for reviewers
Anything notable for review (risk, rollout, follow-ups).

