### PR TITLE
perf: Use Intra-task concurrency in source transformer

### DIFF
--- a/rust/numaflow-core/src/transformer.rs
+++ b/rust/numaflow-core/src/transformer.rs
@@ -1,9 +1,9 @@
 use bytes::Bytes;
+use futures::stream::{self, StreamExt};
 use numaflow_monitor::runtime;
 use numaflow_pb::clients::sourcetransformer::source_transform_client::SourceTransformClient;
-use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{Semaphore, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use tonic::transport::Channel;
 use tonic::{Code, Status};
@@ -159,7 +159,6 @@ impl Transformer {
         let batch_start_time = tokio::time::Instant::now();
         let transform_handle = self.sender.clone();
         let tracker = self.tracker.clone();
-        let semaphore = Arc::new(Semaphore::new(self.concurrency));
         let mut labels = pipeline_metric_labels(VERTEX_TYPE_SOURCE).clone();
         labels.push((
             PIPELINE_PARTITION_NAME_LABEL.to_string(),
@@ -195,48 +194,43 @@ impl Transformer {
                 .inc_by(messages.len() as u64);
         }
 
-        let tasks: Vec<_> = messages
-            .into_iter()
-            .map(|read_msg| {
-                let permit_fut = Arc::clone(&semaphore).acquire_owned();
-                let transform_handle = transform_handle.clone();
-                let tracker = tracker.clone();
-                let hard_shutdown_token = hard_shutdown_token.clone();
+        let message_count = messages.len();
 
-                tokio::spawn(async move {
-                    let permit = permit_fut.await.map_err(|e| {
-                        Error::Transformer(format!("failed to acquire semaphore: {e}"))
-                    })?;
-                    let _permit = permit;
+        let transform_futs = messages.into_iter().map(|read_msg| {
+            let transform_handle = transform_handle.clone();
+            let tracker = tracker.clone();
+            let hard_shutdown_token = hard_shutdown_token.clone();
 
-                    let transformed_messages = Transformer::transform(
-                        transform_handle,
-                        read_msg.clone(),
-                        hard_shutdown_token.clone(),
+            async move {
+                let offset = read_msg.offset.clone();
+                let transformed_messages =
+                    Transformer::transform(transform_handle, read_msg, hard_shutdown_token).await?;
+
+                // update the tracker with the number of responses for each message
+                tracker
+                    .serving_update(
+                        &offset,
+                        transformed_messages
+                            .iter()
+                            .map(|m| m.tags.clone())
+                            .collect(),
                     )
                     .await?;
 
-                    // update the tracker with the number of responses for each message
-                    tracker
-                        .serving_update(
-                            &read_msg.offset,
-                            transformed_messages
-                                .iter()
-                                .map(|m| m.tags.clone())
-                                .collect(),
-                        )
-                        .await?;
+                Ok::<Vec<Message>, Error>(transformed_messages)
+            }
+        });
 
-                    Ok::<Vec<Message>, Error>(transformed_messages)
-                })
-            })
-            .collect();
+        // Use buffered to limit concurrency without spawning tasks.
+        // This polls up to `concurrency` futures at a time, reducing scheduling overhead.
+        let mut stream = stream::iter(transform_futs).buffered(self.concurrency);
 
-        let mut transformed_messages = Vec::new();
-        for task in tasks {
-            match task.await {
-                Ok(Ok(mut msgs)) => transformed_messages.append(&mut msgs),
-                Ok(Err(e)) => {
+        let mut transformed_messages = Vec::with_capacity(message_count * 2);
+
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(mut msgs) => transformed_messages.append(&mut msgs),
+                Err(e) => {
                     // increment transform error metric for pipeline
                     // error here indicates that there was some problem in transformation
                     if !is_mono_vertex() {
@@ -246,11 +240,12 @@ impl Transformer {
                             .get_or_create(&labels)
                             .inc();
                     }
+                    // Early exit - remaining futures are dropped when stream goes out of scope
                     return Err(e);
                 }
-                Err(e) => return Err(Error::Transformer(format!("task join failed: {e}"))),
             }
         }
+
         // batch transformation was successful
         // send transformer metrics
         let dropped_messages_count = transformed_messages
@@ -329,6 +324,7 @@ mod tests {
     use numaflow::shared::ServerExtras;
     use numaflow::sourcetransform;
     use numaflow_pb::clients::sourcetransformer::source_transform_client::SourceTransformClient;
+    use std::sync::Arc;
     use std::time::Duration;
     use tempfile::TempDir;
     use tokio::sync::oneshot;


### PR DESCRIPTION
### What this PR does / why we need it
Changes from `tokio::spawn`s to single task concurrency. This avoids the need for semaphore which was appearing in the hot path when CPU profiling was done on a Monovertex at high throughput. This change improves the throughput by around 15% when transformer is involved.

<img width="1485" height="722" alt="Screenshot 2026-02-08 at 4 47 20 PM" src="https://github.com/user-attachments/assets/342aa96a-1958-4efd-8e77-b02dee655f33" />




<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
