### PR TITLE
chore: avoid watermark regression logs in source

### DIFF
--- a/rust/numaflow-core/src/watermark/isb.rs
+++ b/rust/numaflow-core/src/watermark/isb.rs
@@ -286,6 +286,7 @@ impl ISBWatermarkHandle {
             processor_name,
             js_context.clone(),
             &config.to_vertex_config,
+            false,
         )
         .await?;
 

--- a/rust/numaflow-core/src/watermark/isb/wm_publisher.rs
+++ b/rust/numaflow-core/src/watermark/isb/wm_publisher.rs
@@ -61,6 +61,8 @@ pub(crate) struct ISBWatermarkPublisher {
     last_published_wm: HashMap<&'static str, HashMap<u16, LastPublishedState>>,
     /// map of vertex to its ot bucket.
     ot_buckets: HashMap<&'static str, async_nats::jetstream::kv::Store>,
+    /// whether this publisher is for a source vertex (data can be out of order).
+    is_source: bool,
 }
 
 impl Drop for ISBWatermarkPublisher {
@@ -71,10 +73,13 @@ impl Drop for ISBWatermarkPublisher {
 
 impl ISBWatermarkPublisher {
     /// Creates a new ISBWatermarkPublisher.
+    /// If `is_source` is true, watermark regression warnings will be suppressed since
+    /// source data can be out of order.
     pub(crate) async fn new(
         processor_name: String,
         js_context: async_nats::jetstream::Context,
         bucket_configs: &[BucketConfig],
+        is_source: bool,
     ) -> Result<Self> {
         let mut ot_buckets = HashMap::new();
         let mut hb_buckets = Vec::with_capacity(bucket_configs.len());
@@ -117,6 +122,7 @@ impl ISBWatermarkPublisher {
             hb_handle,
             last_published_wm,
             ot_buckets,
+            is_source,
         })
     }
 
@@ -192,8 +198,12 @@ impl ISBWatermarkPublisher {
             return;
         }
 
+        // Skip publishing if watermark regression is detected.
+        // For source publishers, we silently skip without logging since data can be out of order.
         if watermark < last_state.watermark {
-            warn!(?watermark, ?last_state.watermark, "Watermark regression detected, skipping publish");
+            if !self.is_source {
+                warn!(?watermark, ?last_state.watermark, "Watermark regression detected, skipping publish");
+            }
             return;
         }
 
@@ -280,6 +290,7 @@ mod tests {
             "processor1".to_string(),
             js_context.clone(),
             &bucket_configs,
+            false,
         )
         .await
         .expect("Failed to create publisher");
@@ -425,6 +436,7 @@ mod tests {
             "processor1".to_string(),
             js_context.clone(),
             &bucket_configs,
+            false,
         )
         .await
         .expect("Failed to create publisher");
@@ -533,6 +545,7 @@ mod tests {
             "processor1".to_string(),
             js_context.clone(),
             &bucket_configs,
+            false,
         )
         .await
         .expect("Failed to create publisher");

--- a/rust/numaflow-core/src/watermark/source/source_wm_publisher.rs
+++ b/rust/numaflow-core/src/watermark/source/source_wm_publisher.rs
@@ -57,6 +57,7 @@ impl SourceWatermarkPublisher {
                 processor_name.clone(),
                 self.js_context.clone(),
                 std::slice::from_ref(&self.source_config),
+                true,
             )
             .await
             .expect("Failed to create publisher");
@@ -115,6 +116,7 @@ impl SourceWatermarkPublisher {
                 processor_name.clone(),
                 self.js_context.clone(),
                 &self.to_vertex_configs,
+                true,
             )
             .await
             .expect("Failed to create publisher");
@@ -137,6 +139,7 @@ impl SourceWatermarkPublisher {
                     processor_name.clone(),
                     self.js_context.clone(),
                     &self.to_vertex_configs,
+                    true,
                 )
                 .await
                 .expect("Failed to create publisher");


### PR DESCRIPTION
Data can come out of order in source, so event_time may not be monotonically increasing.