### PR TITLE
chore(ci): increase timeout for unit tests to 20 minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Start JetStream
         run: docker run -d -p 4222:4222 nats:latest -js


### PR DESCRIPTION
`cargo clippy-ci` takes about 4 mins.