### PR TITLE
chore: chunk sqs writes to batch size 10

### DIFF
--- a/rust/numaflow-core/src/watermark/processor/timeline.rs
+++ b/rust/numaflow-core/src/watermark/processor/timeline.rs
@@ -70,7 +70,7 @@ impl OffsetTimeline {
                 error!("The new input offset should never be smaller than the existing offset");
             }
             (Ordering::Less, _) => {
-                error!(
+                debug!(
                     "Watermark should not regress, current: {:?}, new: {:?}",
                     element_node, node
                 );


### PR DESCRIPTION
* SQS batch size can't be more than 10, so if the batch size is higher we need to chunk them to size of 10 and perform multiple writes.