### PR TITLE
fix: remove trailing comma in UniqueStringList.ToString

### DIFF
--- a/pkg/shared/util/uniq_str_list.go
+++ b/pkg/shared/util/uniq_str_list.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"container/list"
+	"strings"
 	"sync"
 )
 
@@ -94,9 +95,12 @@ func (l *UniqueStringList) Remove(value string) {
 func (l *UniqueStringList) ToString() string {
 	l.lock.RLock()
 	defer l.lock.RUnlock()
-	var s string
+	var sb strings.Builder
 	for e := l.l.Front(); e != nil; e = e.Next() {
-		s += e.Value.(string) + ","
+		if sb.Len() > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(e.Value.(string))
 	}
-	return s
+	return sb.String()
 }

--- a/pkg/shared/util/uniq_str_list_test.go
+++ b/pkg/shared/util/uniq_str_list_test.go
@@ -67,3 +67,15 @@ func TestUniqStrList(t *testing.T) {
 	assert.Equal(t, true, l.Contains("a"))
 	assert.Equal(t, true, l.Contains("c"))
 }
+
+func TestUniqueStringList_ToString(t *testing.T) {
+	l := NewUniqueStringList()
+	assert.Equal(t, "", l.ToString())
+
+	l.PushBack("a")
+	assert.Equal(t, "a", l.ToString())
+
+	l.PushBack("b")
+	l.PushBack("c")
+	assert.Equal(t, "a,b,c", l.ToString())
+}


### PR DESCRIPTION
## Summary

- `ToString()` was appending a comma after every element, producing a trailing comma (e.g. `"a,b,c,"` instead of `"a,b,c"`)
- Switched to `strings.Builder` to fix the output and avoid repeated string allocations
- Added missing test coverage for `ToString()`

## Test plan

- [x] `TestUniqueStringList_ToString` covers empty list, single element, and multi-element cases
- [x] All existing tests in `pkg/shared/util` continue to pass