### PR TITLE
perf: precompile DNS1035 regex as package-level variable

### DIFF
--- a/pkg/shared/util/string.go
+++ b/pkg/shared/util/string.go
@@ -78,9 +78,10 @@ func CompareSlice(operator v1alpha1.LogicOperator, a []string, b []string) bool 
 	return false
 }
 
+var dns1035Regex = regexp.MustCompile(`[^a-z0-9-]+`)
+
 func DNS1035(str string) string {
-	re := regexp.MustCompile(`[^a-z0-9-]+`)
-	return re.ReplaceAllString(strings.ToLower(str), "-")
+	return dns1035Regex.ReplaceAllString(strings.ToLower(str), "-")
 }
 
 // Hashcode returns a unique hashcode of a string.


### PR DESCRIPTION
## Summary

- `DNS1035` was calling `regexp.MustCompile` on every invocation, recompiling the same regex each time
- Moved it to a package-level variable so it is compiled once at startup

## Test plan

- [x] All existing `TestDNS1035` test cases pass with no changes needed