### PR TITLE
chore: set max message size to 64mb for udsource

### DIFF
--- a/rust/numaflow-core/src/shared/create_components.rs
+++ b/rust/numaflow-core/src/shared/create_components.rs
@@ -533,7 +533,11 @@ async fn create_source_client(
 
     let channel =
         create_rpc_channel(PathBuf::from(user_defined_config.socket_path.clone())).await?;
-    let mut client = SourceClient::new(channel);
+
+    let mut client = SourceClient::new(channel)
+        .max_encoding_message_size(user_defined_config.grpc_max_message_size)
+        .max_decoding_message_size(user_defined_config.grpc_max_message_size);
+
     wait_until_source_ready(&cln_token, &mut client).await?;
     Ok((client, server_info))
 }


### PR DESCRIPTION
```
{"timestamp":"2026-03-13T20:55:21.597452Z","level":"ERROR","message":"Error while reading messages: Grpc(Status { code: OutOfRange, message: \"Error, decoded message length too large: found 16153794 bytes, the limit is: 4194304 bytes\", source: None })","target":"numaflow_core::source"}
```