### PR TITLE
refactor(style): remove unnecessary else blocks after return in util functions

### DIFF
--- a/pkg/shared/util/env.go
+++ b/pkg/shared/util/env.go
@@ -25,9 +25,8 @@ import (
 func LookupEnvStringOr(key, defaultValue string) string {
 	if v, existing := os.LookupEnv(key); existing && v != "" {
 		return v
-	} else {
-		return defaultValue
 	}
+	return defaultValue
 }
 
 func LookupEnvIntOr(key string, defaultValue int) int {
@@ -37,9 +36,8 @@ func LookupEnvIntOr(key string, defaultValue int) int {
 			panic(fmt.Errorf("invalid value for env variable %q, value %q", key, valStr))
 		}
 		return val
-	} else {
-		return defaultValue
 	}
+	return defaultValue
 }
 
 func LookupEnvBoolOr(key string, defaultValue bool) bool {
@@ -49,7 +47,6 @@ func LookupEnvBoolOr(key string, defaultValue bool) bool {
 			panic(fmt.Errorf("invalid value for env variable %q, value %q", key, valStr))
 		}
 		return val
-	} else {
-		return defaultValue
 	}
+	return defaultValue
 }

--- a/pkg/shared/util/json.go
+++ b/pkg/shared/util/json.go
@@ -19,11 +19,11 @@ package util
 import "encoding/json"
 
 func MustJSON(in interface{}) string {
-	if data, err := json.Marshal(in); err != nil {
+	data, err := json.Marshal(in)
+	if err != nil {
 		panic(err)
-	} else {
-		return string(data)
 	}
+	return string(data)
 }
 
 // MustUnJSON unmarshalls JSON or panics.


### PR DESCRIPTION
## Summary

Idiomatic Go avoids `else` blocks when the `if` branch already returns. Cleaned up the following functions in `pkg/shared/util`:

- `env.go`: `LookupEnvStringOr`, `LookupEnvIntOr`, `LookupEnvBoolOr`
- `json.go`: `MustJSON`

No behavior change — purely a style/readability improvement.

## Test plan

- [x] All existing tests in `pkg/shared/util` pass with no changes