### PR TITLE
chore: add currentRate and maxRate to monovertex rate limit scaling log

### DIFF
--- a/rust/extns/numaflow-nats/src/jetstream.rs
+++ b/rust/extns/numaflow-nats/src/jetstream.rs
@@ -698,7 +698,6 @@ mod tests {
         // Read messages
         let messages = source.read_messages().await.unwrap();
         assert_eq!(messages.len(), 30);
-        tokio::time::sleep(Duration::from_millis(30)).await;
         let pending = source.pending_messages().await.unwrap();
         assert_eq!(
             pending,


### PR DESCRIPTION
### What this PR does / why we need it
Adds currentRate and maxRate to monovertex rate limit log for debugging