### PR TITLE
fix: replace single sleep before fetching pending count with a timeout

### DIFF
--- a/rust/extns/numaflow-nats/src/jetstream.rs
+++ b/rust/extns/numaflow-nats/src/jetstream.rs
@@ -705,7 +705,7 @@ mod tests {
         .await;
 
         assert!(
-            result.is_err(),
+            result.is_ok(),
             "{description}: expected Some({expected}) but got {:?} after {timeout:?}",
             source.pending_messages().await.unwrap()
         );


### PR DESCRIPTION
### What this PR does / why we need it
From this: https://github.com/numaproj/numaflow/pull/3349

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
