### PR TITLE
fix: start lastScaledAt as creationTime by default

### DIFF
--- a/pkg/reconciler/monovertex/controller.go
+++ b/pkg/reconciler/monovertex/controller.go
@@ -307,6 +307,9 @@ func (mr *monoVertexReconciler) orchestratePods(ctx context.Context, monoVtx *df
 		monoVtx.Status.Replicas = uint32(desiredReplicas)
 		monoVtx.Status.LastScaledAt = metav1.Time{Time: time.Now()}
 	}
+	if monoVtx.Status.LastScaledAt.IsZero() {
+		monoVtx.Status.LastScaledAt = monoVtx.CreationTimestamp
+	}
 	if monoVtx.Status.Selector == "" {
 		selector, _ := labels.Parse(dfv1.KeyComponent + "=" + dfv1.ComponentMonoVertex + "," + dfv1.KeyMonoVertexName + "=" + monoVtx.Name)
 		monoVtx.Status.Selector = selector.String()

--- a/pkg/reconciler/monovertex/controller_test.go
+++ b/pkg/reconciler/monovertex/controller_test.go
@@ -304,6 +304,34 @@ func Test_orchestratePods(t *testing.T) {
 			assert.True(t, strings.HasPrefix(n, testObj.Name+"-mv-0") || strings.HasPrefix(n, testObj.Name+"-mv-1"))
 		}
 	})
+
+	t.Run("test lastScaledAt initialised to CreationTimestamp when zero", func(t *testing.T) {
+		cl := fake.NewClientBuilder().Build()
+		r := fakeReconciler(t, cl)
+		testObj := testMonoVtx.DeepCopy()
+		creationTime := time.Now()
+		testObj.CreationTimestamp = metav1.Time{Time: creationTime}
+		err := r.orchestratePods(context.TODO(), testObj)
+		assert.NoError(t, err)
+		assert.Equal(t, creationTime.Unix(), testObj.Status.LastScaledAt.Unix())
+	})
+
+	t.Run("test lastScaledAt not overwritten when already set", func(t *testing.T) {
+		cl := fake.NewClientBuilder().Build()
+		r := fakeReconciler(t, cl)
+		testObj := testMonoVtx.DeepCopy()
+		testObj.CreationTimestamp = metav1.Time{Time: time.Now()}
+		// First call: creates pods and sets LastScaledAt (currentReplicas != desiredReplicas)
+		err := r.orchestratePods(context.TODO(), testObj)
+		assert.NoError(t, err)
+		// Overwrite with a known value now that replicas are aligned
+		existingScaledAt := time.Now().Add(-1 * time.Hour)
+		testObj.Status.LastScaledAt = metav1.Time{Time: existingScaledAt}
+		// Second call: currentReplicas == desiredReplicas, our guard must not overwrite
+		err = r.orchestratePods(context.TODO(), testObj)
+		assert.NoError(t, err)
+		assert.Equal(t, existingScaledAt.Unix(), testObj.Status.LastScaledAt.Unix())
+	})
 }
 
 func Test_orchestrateFixedResources(t *testing.T) {

--- a/pkg/reconciler/vertex/controller.go
+++ b/pkg/reconciler/vertex/controller.go
@@ -320,6 +320,9 @@ func (r *vertexReconciler) orchestratePods(ctx context.Context, vertex *dfv1.Ver
 		vertex.Status.Replicas = uint32(desiredReplicas)
 		vertex.Status.LastScaledAt = metav1.Time{Time: time.Now()}
 	}
+	if vertex.Status.LastScaledAt.IsZero() {
+		vertex.Status.LastScaledAt = vertex.CreationTimestamp
+	}
 	if vertex.Status.Selector == "" {
 		selector, _ := labels.Parse(dfv1.KeyPipelineName + "=" + vertex.Spec.PipelineName + "," + dfv1.KeyVertexName + "=" + vertex.Spec.Name)
 		vertex.Status.Selector = selector.String()

--- a/pkg/reconciler/vertex/controller_test.go
+++ b/pkg/reconciler/vertex/controller_test.go
@@ -789,6 +789,54 @@ func Test_reconcile(t *testing.T) {
 		assert.Equal(t, uint32(20), testObj.Status.Replicas)
 		assert.Equal(t, uint32(5), testObj.Status.UpdatedReplicas)
 	})
+
+	t.Run("test lastScaledAt initialised to CreationTimestamp when zero", func(t *testing.T) {
+		cl := fake.NewClientBuilder().Build()
+		ctx := context.TODO()
+		testIsbSvc := testJetStreamIsbSvc.DeepCopy()
+		testIsbSvc.Status.MarkConfigured()
+		testIsbSvc.Status.MarkDeployed()
+		err := cl.Create(ctx, testIsbSvc)
+		assert.Nil(t, err)
+		testPl := testPipeline.DeepCopy()
+		err = cl.Create(ctx, testPl)
+		assert.Nil(t, err)
+		r := fakeReconciler(t, cl)
+		testObj := testVertex.DeepCopy()
+		creationTime := time.Now()
+		testObj.CreationTimestamp = metav1.Time{Time: creationTime}
+		testObj.Spec.Sink = &dfv1.Sink{}
+		_, err = r.reconcile(ctx, testObj)
+		assert.NoError(t, err)
+		assert.Equal(t, creationTime.Unix(), testObj.Status.LastScaledAt.Unix())
+	})
+
+	t.Run("test lastScaledAt not overwritten when already set", func(t *testing.T) {
+		cl := fake.NewClientBuilder().Build()
+		ctx := context.TODO()
+		testIsbSvc := testJetStreamIsbSvc.DeepCopy()
+		testIsbSvc.Status.MarkConfigured()
+		testIsbSvc.Status.MarkDeployed()
+		err := cl.Create(ctx, testIsbSvc)
+		assert.Nil(t, err)
+		testPl := testPipeline.DeepCopy()
+		err = cl.Create(ctx, testPl)
+		assert.Nil(t, err)
+		r := fakeReconciler(t, cl)
+		testObj := testVertex.DeepCopy()
+		testObj.CreationTimestamp = metav1.Time{Time: time.Now()}
+		testObj.Spec.Sink = &dfv1.Sink{}
+		// First reconcile: creates pod and sets LastScaledAt (currentReplicas != desiredReplicas)
+		_, err = r.reconcile(ctx, testObj)
+		assert.NoError(t, err)
+		// Overwrite with a known value now that replicas are aligned
+		existingScaledAt := time.Now().Add(-1 * time.Hour)
+		testObj.Status.LastScaledAt = metav1.Time{Time: existingScaledAt}
+		// Second reconcile: currentReplicas == desiredReplicas, our guard must not overwrite
+		_, err = r.reconcile(ctx, testObj)
+		assert.NoError(t, err)
+		assert.Equal(t, existingScaledAt.Unix(), testObj.Status.LastScaledAt.Unix())
+	})
 }
 
 func Test_reconcileEvents(t *testing.T) {


### PR DESCRIPTION
### What this PR does / why we need it

When a vertex or monovertex is first reconciled and replicas have not changed
(i.e. `currentReplicas == desiredReplicas`), the `LastScaledAt` field in the
status is never set and stays at its Go zero value (`metav1.Time{}`).

Since #2570 migrated status updates to Server-Side Apply (SSA), the full status
struct is serialised and sent as a JSON patch. A zero `metav1.Time` serialises
as JSON `null`. The full CRD schema defines `lastScaledAt` as
`type: string, format: date-time` without `nullable: true`, so the Kubernetes
API server rejects the patch with:

```
Vertex.numaflow.numaproj.io "<name>" is invalid: status.lastScaledAt:
  Invalid value: "null": lastScaledAt in body must be of type string: "null"
```

This creates a deadlock on every reconcile loop:

1. Vertex created → `LastScaledAt` is zero → SSA writes `null` → API rejects
2. Vertex never reaches `Running` phase
3. Autoscaler skips it: _"Vertex not in Running phase, skip scaling"_
4. `LastScaledAt` never gets set → back to step 1

The trigger condition is any vertex where `currentReplicas == desiredReplicas`
on the first reconcile — for example a source vertex with `scale.disabled: true`,
or any vertex during a pipeline pause where `min: 0, max: 0` means
`currentReplicas` and `desiredReplicas` are both 0.

**Fix:** after the existing replica-change branch, initialise `LastScaledAt` to
the vertex's own `CreationTimestamp` if it is still zero. This ensures SSA never
writes `null` for this field regardless of scale configuration, while also being
semantically accurate (the vertex was "last scaled" when it was created).

### Related issues

Fixes #3357

### Testing

Reproduced locally against a Minikube cluster running Numaflow v1.7.3:

1. Deployed a pipeline with a source vertex configured with `scale.disabled: true`
   (i.e. `currentReplicas == desiredReplicas` from the start)
2. Confirmed the controller logged the `lastScaledAt: null` reconciler error in a
   tight loop and the vertex never reached `Running` phase
3. Applied the fix and redeployed — the error disappeared, the vertex reached
   `Running`, and `kubectl get vertex <name> -o jsonpath='{.status.lastScaledAt}'`
   returned the vertex's creation timestamp

### Special notes for reviewers

- The root cause was introduced by #2570 (SSA migration). The minimal CRD
  install was not affected because its `status` uses
  `x-kubernetes-preserve-unknown-fields: true` and skips typed validation.
- Only `controller.go` for vertex and monovertex are changed — no CRD schema
  changes, no API changes.
- The same pattern (initialise to `CreationTimestamp` when zero) could apply to
  any other `metav1.Time` status fields added in future if they share the same
  SSA serialisation path.
