### PR TITLE
chore: remove phantom data markers

### DIFF
--- a/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
@@ -13,7 +13,6 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use numaflow_pb::objects::wal::GcEvent;
 use std::collections::HashMap;
-use std::marker::PhantomData;
 use std::ops::Sub;
 use std::sync::Arc;
 use std::time::Duration;
@@ -45,7 +44,6 @@ struct ReduceTask<C: NumaflowTypeConfig> {
     error_tx: mpsc::Sender<Error>,
     window: Window,
     window_manager: AlignedWindowManager,
-    _marker: PhantomData<C>,
 }
 
 impl<C: NumaflowTypeConfig> ReduceTask<C> {
@@ -65,7 +63,6 @@ impl<C: NumaflowTypeConfig> ReduceTask<C> {
             error_tx,
             window,
             window_manager,
-            _marker: PhantomData,
         }
     }
 
@@ -185,7 +182,6 @@ struct AlignedReduceActor<C: NumaflowTypeConfig> {
     window_manager: AlignedWindowManager,
     /// Cancellation token to signal tasks to stop
     cln_token: CancellationToken,
-    _marker: PhantomData<C>,
 }
 
 impl<C: NumaflowTypeConfig> AlignedReduceActor<C> {
@@ -228,7 +224,6 @@ impl<C: NumaflowTypeConfig> AlignedReduceActor<C> {
             gc_wal_tx,
             window_manager,
             cln_token,
-            _marker: PhantomData,
         }
     }
 
@@ -378,7 +373,6 @@ pub(crate) struct AlignedReducer<C: NumaflowTypeConfig> {
     keyed: bool,
     /// Graceful shutdown timeout duration.
     graceful_timeout: Duration,
-    _marker: PhantomData<C>,
 }
 
 impl<C: NumaflowTypeConfig> AlignedReducer<C> {
@@ -403,7 +397,6 @@ impl<C: NumaflowTypeConfig> AlignedReducer<C> {
             graceful_timeout,
             shutting_down_on_err: false,
             final_result: Ok(()),
-            _marker: PhantomData,
         }
     }
 

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
@@ -19,7 +19,6 @@ use numaflow_pb::clients::sessionreduce::SessionReduceRequest;
 use numaflow_pb::objects::wal::GcEvent;
 use prost::Message as ProstMessage;
 use std::collections::HashMap;
-use std::marker::PhantomData;
 use std::ops::Sub;
 use std::sync::Arc;
 use std::time::Duration;
@@ -63,7 +62,6 @@ struct ReduceTask<C: NumaflowTypeConfig> {
     /// For session: stores the window that got closed for that keys.
     /// For accumulator: stores a window with max end time (same start and end time)
     tracked_windows: HashMap<Vec<String>, Window>,
-    _marker: PhantomData<C>,
 }
 
 impl<C: NumaflowTypeConfig> ReduceTask<C> {
@@ -84,7 +82,6 @@ impl<C: NumaflowTypeConfig> ReduceTask<C> {
             window_manager,
             batch_timeout,
             tracked_windows: HashMap::new(),
-            _marker: PhantomData,
         }
     }
 
@@ -393,7 +390,6 @@ struct UnalignedReduceActor<C: NumaflowTypeConfig> {
     window_manager: UnalignedWindowManager,
     /// Cancellation token to signal tasks to stop
     cln_token: CancellationToken,
-    _marker: PhantomData<C>,
 }
 
 impl<C: NumaflowTypeConfig> UnalignedReduceActor<C> {
@@ -433,7 +429,6 @@ impl<C: NumaflowTypeConfig> UnalignedReduceActor<C> {
             gc_wal_tx,
             window_manager,
             cln_token,
-            _marker: PhantomData,
         }
     }
 
@@ -525,7 +520,6 @@ pub(crate) struct UnalignedReducer<C: NumaflowTypeConfig> {
     keyed: bool,
     /// Graceful shutdown timeout duration.
     graceful_timeout: Duration,
-    _marker: PhantomData<C>,
 }
 
 impl<C: NumaflowTypeConfig> UnalignedReducer<C> {
@@ -550,7 +544,6 @@ impl<C: NumaflowTypeConfig> UnalignedReducer<C> {
             current_watermark: DateTime::from_timestamp_millis(-1).expect("Invalid timestamp"),
             keyed,
             graceful_timeout,
-            _marker: PhantomData,
         }
     }
 


### PR DESCRIPTION
### What this PR does / why we need it

From the [nomicon explanation](https://doc.rust-lang.org/nomicon/phantom-data.html) it seems like the `PhantomData` is required to be declared in a struct's field, to help with static analysis, when the data it holds isn't declared in any other field. 

Since, the `ISBWriterOrchestrator<C>` already holds the generic type `C` that the PhantomData holds, i figure it should be safe to remove the phantom data marker. 

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
