### PR TITLE
feat: add reduce metrics for rust data plane

### DIFF
--- a/docs/operations/metrics/metrics.md
+++ b/docs/operations/metrics/metrics.md
@@ -55,6 +55,21 @@ These metrics are specific to map/UDF vertices.
 | `forwarder_udf_error_total`    | Counter     |                   | Total number of UDF errors                                        |
 | `forwarder_udf_processing_time` | Histogram  |                   | Processing times of User-Defined Functions (UDFs), in microseconds |
 
+### Reduce Metrics
+
+These metrics are specific to reduce (windowed aggregation) vertices.
+
+| Metric name                          | Metric type | Additional Labels | Description                                                          |
+|--------------------------------------|-------------|-------------------|----------------------------------------------------------------------|
+| `reduce_active_windows`              | Gauge       |                   | Number of currently open reduce windows                              |
+| `reduce_closed_windows`              | Gauge       |                   | Number of closed windows awaiting GC                                 |
+| `reduce_watermark_lag`               | Gauge       |                   | Difference between wall clock and watermark, in milliseconds         |
+| `reduce_window_processing_time`      | Histogram   |                   | Window open-to-close latency, in microseconds                        |
+| `reduce_pnf_process_time`            | Histogram   |                   | UDF reduce function execution time per window, in microseconds       |
+| `reduce_pbq_write`                   | Counter     |                   | Total messages written to PBQ                                        |
+
+> **Note:** All reduce metrics carry the standard pipeline common labels (`pipeline`, `vertex`, `replica`) with `vertex_type` always set to `ReduceUDF`.
+
 ### Fallback Sink Metrics
 
 These metrics are specific to sink vertices with a fallback sink configured.

--- a/docs/operations/metrics/metrics.md
+++ b/docs/operations/metrics/metrics.md
@@ -66,7 +66,7 @@ These metrics are specific to reduce (windowed aggregation) vertices.
 | `reduce_watermark_lag`               | Gauge       |                   | Difference between wall clock and watermark, in milliseconds         |
 | `reduce_window_processing_time`      | Histogram   |                   | Window open-to-close latency, in microseconds                        |
 | `reduce_pnf_process_time`            | Histogram   |                   | UDF reduce function execution time per window, in microseconds       |
-| `reduce_pbq_write`                   | Counter     |                   | Total messages written to PBQ                                        |
+| `reduce_pbq_write`                   | Counter     |                   | Total data messages written to PBQ |
 
 > **Note:** All reduce metrics carry the standard pipeline common labels (`pipeline`, `vertex`, `replica`) with `vertex_type` always set to `ReduceUDF`.
 

--- a/rust/numaflow-core/src/metrics/mod.rs
+++ b/rust/numaflow-core/src/metrics/mod.rs
@@ -155,7 +155,7 @@ const REDUCE_ACTIVE_WINDOWS: &str = "active_windows";
 const REDUCE_CLOSED_WINDOWS: &str = "closed_windows";
 const REDUCE_WINDOW_PROCESSING_TIME: &str = "window_processing_time";
 const REDUCE_PNF_PROCESS_TIME: &str = "pnf_process_time";
-const REDUCE_CURRENT_WATERMARK: &str = "current_watermark";
+const REDUCE_WATERMARK_LAG: &str = "watermark_lag";
 const REDUCE_PBQ_WRITE_TOTAL: &str = "pbq_write";
 
 // jetstream isb processing times
@@ -357,7 +357,7 @@ pub(crate) struct ReduceMetrics {
     // gauges
     pub(crate) active_windows: Family<Vec<(String, String)>, Gauge>,
     pub(crate) closed_windows: Family<Vec<(String, String)>, Gauge>,
-    pub(crate) current_watermark: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
+    pub(crate) watermark_lag: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
     // histograms
     pub(crate) window_processing_time: Family<Vec<(String, String)>, Histogram>,
     pub(crate) pnf_process_time: Family<Vec<(String, String)>, Histogram>,
@@ -370,7 +370,7 @@ impl ReduceMetrics {
         Self {
             active_windows: Family::<Vec<(String, String)>, Gauge>::default(),
             closed_windows: Family::<Vec<(String, String)>, Gauge>::default(),
-            current_watermark: Family::<Vec<(String, String)>, Gauge<f64, AtomicU64>>::default(),
+            watermark_lag: Family::<Vec<(String, String)>, Gauge<f64, AtomicU64>>::default(),
             window_processing_time:
                 Family::<Vec<(String, String)>, Histogram>::new_with_constructor(
                     // 1ms to 60 minutes in microseconds
@@ -1106,9 +1106,9 @@ impl PipelineMetrics {
             metrics.reduce.closed_windows.clone(),
         );
         reduce_registry.register(
-            REDUCE_CURRENT_WATERMARK,
-            "Current watermark value as epoch milliseconds",
-            metrics.reduce.current_watermark.clone(),
+            REDUCE_WATERMARK_LAG,
+            "Difference between current wall clock and watermark in milliseconds",
+            metrics.reduce.watermark_lag.clone(),
         );
         reduce_registry.register(
             REDUCE_WINDOW_PROCESSING_TIME,

--- a/rust/numaflow-core/src/metrics/mod.rs
+++ b/rust/numaflow-core/src/metrics/mod.rs
@@ -62,6 +62,7 @@ const MVTX_REGISTRY_GLOBAL_PREFIX: &str = "monovtx";
 // Prefixes for the sub-registries
 const SINK_REGISTRY_PREFIX: &str = "sink";
 const FALLBACK_SINK_REGISTRY_PREFIX: &str = "fallback_sink";
+const REDUCE_REGISTRY_PREFIX: &str = "reduce";
 const ON_SUCCESS_SINK_REGISTRY_PREFIX: &str = "onsuccess_sink";
 const TRANSFORMER_REGISTRY_PREFIX: &str = "transformer";
 const UDF_REGISTRY_PREFIX: &str = "udf";
@@ -148,6 +149,14 @@ const ACK_TIME: &str = "ack_time";
 const SINK_TIME: &str = "time";
 const FALLBACK_SINK_TIME: &str = "time";
 const ON_SUCCESS_SINK_TIME: &str = "time";
+
+// reduce specific metrics
+const REDUCE_ACTIVE_WINDOWS: &str = "active_windows";
+const REDUCE_CLOSED_WINDOWS: &str = "closed_windows";
+const REDUCE_WINDOW_PROCESSING_TIME: &str = "window_processing_time";
+const REDUCE_PNF_PROCESS_TIME: &str = "pnf_process_time";
+const REDUCE_CURRENT_WATERMARK: &str = "current_watermark";
+const REDUCE_PBQ_WRITE_TOTAL: &str = "pbq_write";
 
 // jetstream isb processing times
 const JETSTREAM_ISB_READ_TIME_TOTAL: &str = "read_time_total";
@@ -306,6 +315,8 @@ pub(crate) struct PipelineMetrics {
     pub(crate) sink_forwarder: SinkForwarderMetrics,
     pub(crate) jetstream_isb: JetStreamISBMetrics,
     pub(crate) pending_raw: Family<Vec<(String, String)>, Gauge>,
+    // reduce specific metrics
+    pub(crate) reduce: ReduceMetrics,
 }
 
 /// Family of metrics for the sink
@@ -339,6 +350,39 @@ pub(crate) struct UDFMetrics {
     /// Mapper latency
     pub(crate) time: Family<Vec<(String, String)>, Histogram>,
     pub(crate) errors_total: Family<Vec<(String, String)>, Counter>,
+}
+
+/// Family of metrics for the Reduce vertex
+pub(crate) struct ReduceMetrics {
+    // gauges
+    pub(crate) active_windows: Family<Vec<(String, String)>, Gauge>,
+    pub(crate) closed_windows: Family<Vec<(String, String)>, Gauge>,
+    pub(crate) current_watermark: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
+    // histograms
+    pub(crate) window_processing_time: Family<Vec<(String, String)>, Histogram>,
+    pub(crate) pnf_process_time: Family<Vec<(String, String)>, Histogram>,
+    // counters
+    pub(crate) pbq_write_total: Family<Vec<(String, String)>, Counter>,
+}
+
+impl ReduceMetrics {
+    pub(crate) fn new() -> Self {
+        Self {
+            active_windows: Family::<Vec<(String, String)>, Gauge>::default(),
+            closed_windows: Family::<Vec<(String, String)>, Gauge>::default(),
+            current_watermark: Family::<Vec<(String, String)>, Gauge<f64, AtomicU64>>::default(),
+            window_processing_time:
+                Family::<Vec<(String, String)>, Histogram>::new_with_constructor(
+                    // 1ms to 60 minutes in microseconds
+                    || Histogram::new(exponential_buckets_range(1000.0, 3_600_000_000.0, 10)),
+                ),
+            pnf_process_time: Family::<Vec<(String, String)>, Histogram>::new_with_constructor(
+                // 1ms to 20 minutes in microseconds
+                || Histogram::new(exponential_buckets_range(1000.0, 1_200_000_000.0, 10)),
+            ),
+            pbq_write_total: Family::<Vec<(String, String)>, Counter>::default(),
+        }
+    }
 }
 
 /// Generic forwarder metrics
@@ -762,6 +806,7 @@ impl PipelineMetrics {
             sink_forwarder: SinkForwarderMetrics::new(),
             jetstream_isb: JetStreamISBMetrics::new(),
             pending_raw: Family::<Vec<(String, String)>, Gauge>::default(),
+            reduce: ReduceMetrics::new(),
         };
         let mut registry = global_registry().registry.lock();
         Self::register_forwarder_metrics(&metrics, &mut registry);
@@ -769,6 +814,7 @@ impl PipelineMetrics {
         Self::register_sink_forwarder_metrics(&metrics, &mut registry);
         Self::register_jetstream_isb_metrics(&metrics, &mut registry);
         Self::register_vertex_metrics(&metrics, &mut registry);
+        Self::register_reduce_metrics(&metrics, &mut registry);
         metrics
     }
 
@@ -1044,6 +1090,40 @@ impl PipelineMetrics {
             VERTEX_PENDING_RAW,
             "Total number of pending messages",
             metrics.pending_raw.clone(),
+        );
+    }
+
+    fn register_reduce_metrics(metrics: &Self, registry: &mut Registry) {
+        let reduce_registry = registry.sub_registry_with_prefix(REDUCE_REGISTRY_PREFIX);
+        reduce_registry.register(
+            REDUCE_ACTIVE_WINDOWS,
+            "Number of currently open reduce windows",
+            metrics.reduce.active_windows.clone(),
+        );
+        reduce_registry.register(
+            REDUCE_CLOSED_WINDOWS,
+            "Number of closed reduce windows awaiting GC",
+            metrics.reduce.closed_windows.clone(),
+        );
+        reduce_registry.register(
+            REDUCE_CURRENT_WATERMARK,
+            "Current watermark value as epoch milliseconds",
+            metrics.reduce.current_watermark.clone(),
+        );
+        reduce_registry.register(
+            REDUCE_WINDOW_PROCESSING_TIME,
+            "Time from window open to window close in microseconds (1ms to 60 minutes)",
+            metrics.reduce.window_processing_time.clone(),
+        );
+        reduce_registry.register(
+            REDUCE_PNF_PROCESS_TIME,
+            "Time for UDF reduce function to complete per window in microseconds (1ms to 20 minutes)",
+            metrics.reduce.pnf_process_time.clone(),
+        );
+        reduce_registry.register(
+            REDUCE_PBQ_WRITE_TOTAL,
+            "Total number of messages written to PBQ",
+            metrics.reduce.pbq_write_total.clone(),
         );
     }
 }

--- a/rust/numaflow-core/src/reduce/pbq.rs
+++ b/rust/numaflow-core/src/reduce/pbq.rs
@@ -1,5 +1,7 @@
+use crate::config::pipeline::VERTEX_TYPE_REDUCE_UDF;
 use crate::error::Result;
 use crate::message::Message;
+use crate::metrics::{pipeline_metric_labels, pipeline_metrics};
 use crate::pipeline::isb::reader::ISBReaderOrchestrator;
 use crate::reduce::wal::WalMessage;
 use crate::reduce::wal::segment::append::{AppendOnlyWal, SegmentWriteMessage};
@@ -113,6 +115,11 @@ impl<C: NumaflowTypeConfig> PBQ<C> {
                 .send(msg.into())
                 .await
                 .expect("Receiver dropped");
+            pipeline_metrics()
+                .reduce
+                .pbq_write_total
+                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                .inc();
             replayed_count += 1;
         }
 
@@ -146,6 +153,11 @@ impl<C: NumaflowTypeConfig> PBQ<C> {
                 .expect("Receiver dropped");
 
             tx.send(msg).await.expect("Receiver dropped");
+            pipeline_metrics()
+                .reduce
+                .pbq_write_total
+                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                .inc();
         }
 
         isb_handle.await.expect("task failed")?;
@@ -173,6 +185,11 @@ impl<C: NumaflowTypeConfig> PBQ<C> {
         while let Some(msg) = isb_stream.next().await {
             // Forward the message to the output channel
             tx.send(msg).await.expect("Receiver dropped");
+            pipeline_metrics()
+                .reduce
+                .pbq_write_total
+                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                .inc();
         }
 
         // Wait for the ISB reader task to complete

--- a/rust/numaflow-core/src/reduce/pbq.rs
+++ b/rust/numaflow-core/src/reduce/pbq.rs
@@ -1,7 +1,7 @@
 use crate::config::pipeline::VERTEX_TYPE_REDUCE_UDF;
 use crate::error::Result;
 use crate::mark_success;
-use crate::message::Message;
+use crate::message::{Message, MessageType};
 use crate::metrics::{pipeline_metric_labels, pipeline_metrics};
 use crate::pipeline::isb::reader::ISBReaderOrchestrator;
 use crate::reduce::wal::WalMessage;
@@ -116,14 +116,18 @@ impl<C: NumaflowTypeConfig> PBQ<C> {
             let msg: WalMessage = msg.try_into().map_err(|e| {
                 crate::error::Error::Reduce(format!("Failed to parse WAL message: {e}"))
             })?;
-            messages_tx.send(msg.into()).await.map_err(|_| {
+            let message: Message = msg.into();
+            let is_data = message.typ == MessageType::Data;
+            messages_tx.send(message).await.map_err(|_| {
                 crate::error::Error::Reduce("PBQ WAL replay: receiver dropped".to_string())
             })?;
-            pipeline_metrics()
-                .reduce
-                .pbq_write_total
-                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
-                .inc();
+            if is_data {
+                pipeline_metrics()
+                    .reduce
+                    .pbq_write_total
+                    .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                    .inc();
+            }
             replayed_count += 1;
         }
 
@@ -160,16 +164,19 @@ impl<C: NumaflowTypeConfig> PBQ<C> {
                 })?;
 
             // Send cloned message downstream
+            let is_data = message.typ == MessageType::Data;
             tx.send(message).await.map_err(|_| {
                 crate::error::Error::Reduce(
                     "PBQ ISB reader: downstream receiver dropped".to_string(),
                 )
             })?;
-            pipeline_metrics()
-                .reduce
-                .pbq_write_total
-                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
-                .inc();
+            if is_data {
+                pipeline_metrics()
+                    .reduce
+                    .pbq_write_total
+                    .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                    .inc();
+            }
         }
 
         isb_handle
@@ -206,16 +213,19 @@ impl<C: NumaflowTypeConfig> PBQ<C> {
         while let Some(read_msg) = isb_stream.next().await {
             // Extract the message and forward to output channel
             let message = read_msg.message().clone();
+            let is_data = message.typ == MessageType::Data;
             tx.send(message).await.map_err(|_| {
                 crate::error::Error::Reduce(
                     "PBQ ISB reader: downstream receiver dropped".to_string(),
                 )
             })?;
-            pipeline_metrics()
-                .reduce
-                .pbq_write_total
-                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
-                .inc();
+            if is_data {
+                pipeline_metrics()
+                    .reduce
+                    .pbq_write_total
+                    .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                    .inc();
+            }
             // Mark the read message as success after processing
             mark_success!(read_msg);
         }

--- a/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
@@ -100,13 +100,12 @@ impl<C: NumaflowTypeConfig> ReduceTask<C> {
                 .client
                 .reduce_fn(message_stream, result_tx, cln_token)
                 .await;
-            if result.is_ok() {
-                pipeline_metrics()
-                    .reduce
-                    .pnf_process_time
-                    .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
-                    .observe(udf_start.elapsed().as_micros() as f64);
-            }
+            // recorded unconditionally; error/cancellation paths return below before window_processing_time
+            pipeline_metrics()
+                .reduce
+                .pnf_process_time
+                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                .observe(udf_start.elapsed().as_micros() as f64);
 
             if let Err(e) = result {
                 // Check if this is a cancellation error
@@ -519,7 +518,7 @@ impl<C: NumaflowTypeConfig> AlignedReducer<C> {
                                         // Only close windows if the idle watermark is greater than current watermark
                                         if idle_watermark > self.current_watermark {
                                             self.current_watermark = idle_watermark;
-                                            let lag = Utc::now().timestamp_millis() - self.current_watermark.timestamp_millis();
+                                            let lag = (Utc::now().timestamp_millis() - self.current_watermark.timestamp_millis()).max(0);
                                             pipeline_metrics()
                                                 .reduce
                                                 .watermark_lag
@@ -631,7 +630,8 @@ impl<C: NumaflowTypeConfig> AlignedReducer<C> {
 
         // Update watermark lag gauge (skip -1 sentinel)
         if self.current_watermark.timestamp_millis() != -1 {
-            let lag = Utc::now().timestamp_millis() - self.current_watermark.timestamp_millis();
+            let lag =
+                (Utc::now().timestamp_millis() - self.current_watermark.timestamp_millis()).max(0);
             pipeline_metrics()
                 .reduce
                 .watermark_lag

--- a/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
@@ -1,7 +1,8 @@
+use crate::config::pipeline::VERTEX_TYPE_REDUCE_UDF;
 use crate::config::{get_vertex_name, get_vertex_replica};
 use crate::error::Error;
 use crate::message::{Message, MessageType};
-use crate::metrics::{pipeline_drop_metric_labels, pipeline_metrics};
+use crate::metrics::{pipeline_drop_metric_labels, pipeline_metric_labels, pipeline_metrics};
 use crate::pipeline::isb::writer::ISBWriterOrchestrator;
 use crate::reduce::reducer::aligned::user_defined::UserDefinedAlignedReduce;
 use crate::reduce::reducer::aligned::windower::{
@@ -15,7 +16,7 @@ use numaflow_pb::objects::wal::GcEvent;
 use std::collections::HashMap;
 use std::ops::Sub;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
@@ -44,6 +45,7 @@ struct ReduceTask<C: NumaflowTypeConfig> {
     error_tx: mpsc::Sender<Error>,
     window: Window,
     window_manager: AlignedWindowManager,
+    window_open_time: Instant,
 }
 
 impl<C: NumaflowTypeConfig> ReduceTask<C> {
@@ -63,6 +65,7 @@ impl<C: NumaflowTypeConfig> ReduceTask<C> {
             error_tx,
             window,
             window_manager,
+            window_open_time: Instant::now(),
         }
     }
 
@@ -92,10 +95,18 @@ impl<C: NumaflowTypeConfig> ReduceTask<C> {
             // Call the reduce function. This is a blocking call and will return only once the window
             // is closed, cancellation is detected, or on error. The output is sent to the result_tx
             // channel which is consumed by the writer task and published to JetStream.
+            let udf_start = Instant::now();
             let result = self
                 .client
                 .reduce_fn(message_stream, result_tx, cln_token)
                 .await;
+            if result.is_ok() {
+                pipeline_metrics()
+                    .reduce
+                    .pnf_process_time
+                    .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                    .observe(udf_start.elapsed().as_micros() as f64);
+            }
 
             if let Err(e) = result {
                 // Check if this is a cancellation error
@@ -126,9 +137,23 @@ impl<C: NumaflowTypeConfig> ReduceTask<C> {
                 .oldest_window()
                 .expect("no oldest window found");
 
+            // Record window processing time (open to results-written)
+            pipeline_metrics()
+                .reduce
+                .window_processing_time
+                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                .observe(self.window_open_time.elapsed().as_micros() as f64);
+
             // we can safely delete the window from the window manager since the results are
             // successfully written to jetstream and watermark is published.
             self.window_manager.gc_window(self.window.clone());
+
+            // Update closed windows gauge after GC removes the window
+            pipeline_metrics()
+                .reduce
+                .closed_windows
+                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                .set(self.window_manager.closed_window_count() as i64);
 
             // now that the processing is done, we can add this window to the GC WAL.
             let Some(gc_wal_tx) = &self.gc_wal_tx else {
@@ -281,6 +306,13 @@ impl<C: NumaflowTypeConfig> AlignedReduceActor<C> {
             },
         );
 
+        // Update active windows gauge
+        pipeline_metrics()
+            .reduce
+            .active_windows
+            .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+            .set(self.window_manager.active_window_count() as i64);
+
         // Send the open command with the first message
         if let Err(e) = message_tx.send(window_msg).await
             && !self.cln_token.is_cancelled()
@@ -339,6 +371,18 @@ impl<C: NumaflowTypeConfig> AlignedReduceActor<C> {
             error!("No active stream found for window {:?}", window_id);
             return;
         };
+
+        // Update active and closed windows gauges
+        pipeline_metrics()
+            .reduce
+            .active_windows
+            .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+            .set(self.window_manager.active_window_count() as i64);
+        pipeline_metrics()
+            .reduce
+            .closed_windows
+            .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+            .set(self.window_manager.closed_window_count() as i64);
 
         // we don't need to write the close message to the client, stream closing
         // is considered as close for aligned windows.
@@ -475,6 +519,11 @@ impl<C: NumaflowTypeConfig> AlignedReducer<C> {
                                         // Only close windows if the idle watermark is greater than current watermark
                                         if idle_watermark > self.current_watermark {
                                             self.current_watermark = idle_watermark;
+                                            pipeline_metrics()
+                                                .reduce
+                                                .current_watermark
+                                                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                                                .set(self.current_watermark.timestamp_millis() as f64);
                                             self.close_windows_with_watermark(idle_watermark, &actor_tx).await;
                                         }
                                     }
@@ -578,6 +627,15 @@ impl<C: NumaflowTypeConfig> AlignedReducer<C> {
             msg.watermark
                 .unwrap_or(DateTime::from_timestamp_millis(-1).expect("Invalid timestamp")),
         );
+
+        // Update watermark gauge (skip -1 sentinel)
+        if self.current_watermark.timestamp_millis() != -1 {
+            pipeline_metrics()
+                .reduce
+                .current_watermark
+                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                .set(self.current_watermark.timestamp_millis() as f64);
+        }
 
         // Handle late messages
         if msg.is_late {

--- a/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/reducer.rs
@@ -519,11 +519,12 @@ impl<C: NumaflowTypeConfig> AlignedReducer<C> {
                                         // Only close windows if the idle watermark is greater than current watermark
                                         if idle_watermark > self.current_watermark {
                                             self.current_watermark = idle_watermark;
+                                            let lag = Utc::now().timestamp_millis() - self.current_watermark.timestamp_millis();
                                             pipeline_metrics()
                                                 .reduce
-                                                .current_watermark
+                                                .watermark_lag
                                                 .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
-                                                .set(self.current_watermark.timestamp_millis() as f64);
+                                                .set(lag as f64);
                                             self.close_windows_with_watermark(idle_watermark, &actor_tx).await;
                                         }
                                     }
@@ -628,13 +629,14 @@ impl<C: NumaflowTypeConfig> AlignedReducer<C> {
                 .unwrap_or(DateTime::from_timestamp_millis(-1).expect("Invalid timestamp")),
         );
 
-        // Update watermark gauge (skip -1 sentinel)
+        // Update watermark lag gauge (skip -1 sentinel)
         if self.current_watermark.timestamp_millis() != -1 {
+            let lag = Utc::now().timestamp_millis() - self.current_watermark.timestamp_millis();
             pipeline_metrics()
                 .reduce
-                .current_watermark
+                .watermark_lag
                 .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
-                .set(self.current_watermark.timestamp_millis() as f64);
+                .set(lag as f64);
         }
 
         // Handle late messages

--- a/rust/numaflow-core/src/reduce/reducer/aligned/windower.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/windower.rs
@@ -62,6 +62,22 @@ impl AlignedWindowManager {
             AlignedWindowManager::Sliding(manager) => manager.oldest_window(),
         }
     }
+
+    /// Returns the number of currently active windows.
+    pub(crate) fn active_window_count(&self) -> usize {
+        match self {
+            AlignedWindowManager::Fixed(manager) => manager.active_window_count(),
+            AlignedWindowManager::Sliding(manager) => manager.active_window_count(),
+        }
+    }
+
+    /// Returns the number of closed windows awaiting GC.
+    pub(crate) fn closed_window_count(&self) -> usize {
+        match self {
+            AlignedWindowManager::Fixed(manager) => manager.closed_window_count(),
+            AlignedWindowManager::Sliding(manager) => manager.closed_window_count(),
+        }
+    }
 }
 
 /// A Window is represented by its start and end time. All the data which event time falls within

--- a/rust/numaflow-core/src/reduce/reducer/aligned/windower/fixed.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/windower/fixed.rs
@@ -164,6 +164,22 @@ impl FixedWindowManager {
             .next()
             .cloned()
     }
+
+    /// Returns the number of currently active windows.
+    pub(crate) fn active_window_count(&self) -> usize {
+        self.active_windows
+            .read()
+            .expect("Poisoned lock for active_windows")
+            .len()
+    }
+
+    /// Returns the number of closed windows awaiting GC.
+    pub(crate) fn closed_window_count(&self) -> usize {
+        self.closed_windows
+            .read()
+            .expect("Poisoned lock for closed_windows")
+            .len()
+    }
 }
 
 #[cfg(test)]

--- a/rust/numaflow-core/src/reduce/reducer/aligned/windower/sliding.rs
+++ b/rust/numaflow-core/src/reduce/reducer/aligned/windower/sliding.rs
@@ -236,6 +236,22 @@ impl SlidingWindowManager {
             .cloned()
     }
 
+    /// Returns the number of currently active windows.
+    pub(crate) fn active_window_count(&self) -> usize {
+        self.active_windows
+            .read()
+            .expect("Poisoned lock for active_windows")
+            .len()
+    }
+
+    /// Returns the number of closed windows awaiting GC.
+    pub(crate) fn closed_window_count(&self) -> usize {
+        self.closed_windows
+            .read()
+            .expect("Poisoned lock for closed_windows")
+            .len()
+    }
+
     /// Helper method to format sorted window information for logging.
     fn format_windows_for_log(windows: &[ProtoWindow]) -> String {
         let formatted_windows: String = windows

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
@@ -10,9 +10,10 @@ use crate::reduce::reducer::unaligned::windower::{
 use crate::reduce::wal::segment::append::{AppendOnlyWal, SegmentWriteMessage};
 use crate::typ::NumaflowTypeConfig;
 
+use crate::config::pipeline::VERTEX_TYPE_REDUCE_UDF;
 use crate::config::{get_vertex_name, get_vertex_replica};
 use crate::jh_abort_guard;
-use crate::metrics::{pipeline_drop_metric_labels, pipeline_metrics};
+use crate::metrics::{pipeline_drop_metric_labels, pipeline_metric_labels, pipeline_metrics};
 use chrono::{DateTime, Utc};
 use numaflow_pb::clients::accumulator::AccumulatorRequest;
 use numaflow_pb::clients::sessionreduce::SessionReduceRequest;
@@ -621,7 +622,22 @@ impl<C: NumaflowTypeConfig> UnalignedReducer<C> {
                                         // Only close windows if the idle watermark is greater than current watermark
                                         if idle_watermark > self.current_watermark {
                                             self.current_watermark = idle_watermark;
+                                            pipeline_metrics()
+                                                .reduce
+                                                .current_watermark
+                                                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                                                .set(self.current_watermark.timestamp_millis() as f64);
                                             self.close_windows_by_wm(idle_watermark, &actor_tx).await;
+                                            pipeline_metrics()
+                                                .reduce
+                                                .active_windows
+                                                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                                                .set(self.window_manager.active_window_count() as i64);
+                                            pipeline_metrics()
+                                                .reduce
+                                                .closed_windows
+                                                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                                                .set(self.window_manager.closed_window_count() as i64);
                                         }
                                     }
                                     continue; // Skip further processing for WMB messages
@@ -634,6 +650,16 @@ impl<C: NumaflowTypeConfig> UnalignedReducer<C> {
                                 }
 
                                 self.assign_and_close_windows(msg, &actor_tx).await;
+                                pipeline_metrics()
+                                    .reduce
+                                    .active_windows
+                                    .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                                    .set(self.window_manager.active_window_count() as i64);
+                                pipeline_metrics()
+                                    .reduce
+                                    .closed_windows
+                                    .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                                    .set(self.window_manager.closed_window_count() as i64);
                             }
                             None => {
                                 // Stream ended
@@ -719,6 +745,15 @@ impl<C: NumaflowTypeConfig> UnalignedReducer<C> {
             msg.watermark
                 .unwrap_or(DateTime::from_timestamp_millis(-1).expect("Invalid timestamp")),
         );
+
+        // Update watermark gauge (skip -1 sentinel)
+        if self.current_watermark.timestamp_millis() != -1 {
+            pipeline_metrics()
+                .reduce
+                .current_watermark
+                .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+                .set(self.current_watermark.timestamp_millis() as f64);
+        }
 
         // Handle late messages
         if msg.is_late {

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
@@ -372,6 +372,17 @@ impl<C: NumaflowTypeConfig> ReduceTask<C> {
         for (_keys, window) in self.tracked_windows.drain() {
             self.window_manager.delete_window(window);
         }
+        // update gauges immediately so the metric reflects GC without waiting for the next message
+        pipeline_metrics()
+            .reduce
+            .active_windows
+            .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+            .set(self.window_manager.active_window_count() as i64);
+        pipeline_metrics()
+            .reduce
+            .closed_windows
+            .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
+            .set(self.window_manager.closed_window_count() as i64);
     }
 }
 
@@ -626,7 +637,7 @@ impl<C: NumaflowTypeConfig> UnalignedReducer<C> {
                                         // Only close windows if the idle watermark is greater than current watermark
                                         if idle_watermark > self.current_watermark {
                                             self.current_watermark = idle_watermark;
-                                            let lag = Utc::now().timestamp_millis() - self.current_watermark.timestamp_millis();
+                                            let lag = (Utc::now().timestamp_millis() - self.current_watermark.timestamp_millis()).max(0);
                                             pipeline_metrics()
                                                 .reduce
                                                 .watermark_lag
@@ -753,7 +764,8 @@ impl<C: NumaflowTypeConfig> UnalignedReducer<C> {
 
         // Update watermark lag gauge (skip -1 sentinel)
         if self.current_watermark.timestamp_millis() != -1 {
-            let lag = Utc::now().timestamp_millis() - self.current_watermark.timestamp_millis();
+            let lag =
+                (Utc::now().timestamp_millis() - self.current_watermark.timestamp_millis()).max(0);
             pipeline_metrics()
                 .reduce
                 .watermark_lag

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/reducer.rs
@@ -622,11 +622,12 @@ impl<C: NumaflowTypeConfig> UnalignedReducer<C> {
                                         // Only close windows if the idle watermark is greater than current watermark
                                         if idle_watermark > self.current_watermark {
                                             self.current_watermark = idle_watermark;
+                                            let lag = Utc::now().timestamp_millis() - self.current_watermark.timestamp_millis();
                                             pipeline_metrics()
                                                 .reduce
-                                                .current_watermark
+                                                .watermark_lag
                                                 .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
-                                                .set(self.current_watermark.timestamp_millis() as f64);
+                                                .set(lag as f64);
                                             self.close_windows_by_wm(idle_watermark, &actor_tx).await;
                                             pipeline_metrics()
                                                 .reduce
@@ -746,13 +747,14 @@ impl<C: NumaflowTypeConfig> UnalignedReducer<C> {
                 .unwrap_or(DateTime::from_timestamp_millis(-1).expect("Invalid timestamp")),
         );
 
-        // Update watermark gauge (skip -1 sentinel)
+        // Update watermark lag gauge (skip -1 sentinel)
         if self.current_watermark.timestamp_millis() != -1 {
+            let lag = Utc::now().timestamp_millis() - self.current_watermark.timestamp_millis();
             pipeline_metrics()
                 .reduce
-                .current_watermark
+                .watermark_lag
                 .get_or_create(pipeline_metric_labels(VERTEX_TYPE_REDUCE_UDF))
-                .set(self.current_watermark.timestamp_millis() as f64);
+                .set(lag as f64);
         }
 
         // Handle late messages

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/windower.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/windower.rs
@@ -194,6 +194,23 @@ impl UnalignedWindowManager {
             UnalignedWindowManager::Session(manager) => manager.oldest_window_end_time(),
         }
     }
+
+    /// Returns the number of currently active windows.
+    pub(crate) fn active_window_count(&self) -> usize {
+        match self {
+            UnalignedWindowManager::Accumulator(manager) => manager.active_window_count(),
+            UnalignedWindowManager::Session(manager) => manager.active_window_count(),
+        }
+    }
+
+    /// Returns the number of closed windows awaiting GC.
+    /// Accumulator doesn't track closed windows separately, so returns 0.
+    pub(crate) fn closed_window_count(&self) -> usize {
+        match self {
+            UnalignedWindowManager::Accumulator(_) => 0,
+            UnalignedWindowManager::Session(manager) => manager.closed_window_count(),
+        }
+    }
 }
 
 /// Combines keys into a single string for use as a map key

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/windower/accumulator.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/windower/accumulator.rs
@@ -218,6 +218,11 @@ impl AccumulatorWindowManager {
             .filter_map(|window_state| window_state.oldest_timestamp())
             .min()
     }
+
+    /// Returns the number of currently active windows (unique key slots).
+    pub(crate) fn active_window_count(&self) -> usize {
+        self.active_windows.read().expect("Poisoned lock").len()
+    }
 }
 
 #[cfg(test)]

--- a/rust/numaflow-core/src/reduce/reducer/unaligned/windower/session.rs
+++ b/rust/numaflow-core/src/reduce/reducer/unaligned/windower/session.rs
@@ -426,6 +426,21 @@ impl SessionWindowManager {
             .map(|window| window.end_time)
             .min()
     }
+
+    /// Returns the total number of currently active windows across all keys.
+    pub(crate) fn active_window_count(&self) -> usize {
+        self.active_windows
+            .read()
+            .expect("Poisoned lock")
+            .values()
+            .map(|s| s.len())
+            .sum()
+    }
+
+    /// Returns the number of closed windows awaiting GC.
+    pub(crate) fn closed_window_count(&self) -> usize {
+        self.closed_windows.read().expect("Poisoned lock").len()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### What this PR does / why we need it
  #### Metrics Added                                                                                                                                                    
                                                                                                                                                                      
  | Metric | Type | Description |                                                                                                                                   
  |--------|------|-------------|                                                                                                                                   
  | `reduce_active_windows` | Gauge | Number of currently open reduce windows |                                                                                       
  | `reduce_closed_windows` | Gauge | Number of closed windows awaiting GC |
  | `reduce_watermark_lag` | Gauge | Difference between wall clock and watermark (ms) |                                                                               
  | `reduce_window_processing_time` | Histogram | Window open-to-close latency (μs) |                                                                               
  | `reduce_pnf_process_time` | Histogram | UDF reduce function execution time per window (μs) |                                                                      
  | `reduce_pbq_write` | Counter | Total messages written to PBQ |

 - **Watermark exposed as lag, not raw epoch** — `wall_clock - watermark` in milliseconds is directly alertable (e.g., "lag > 5min")

- Updated **metrics.md** as well

### Related issues
Fixes #3234 

### Testing

 Test Pipelines                                                                                                                                                                                                 
                                                                                                                                                                                                                 

-    Aligned (fixed window) — examples/6-reduce-fixed-window.yaml — even-odd-sum with 60s fixed windows, 2 partitions, emptyDir storage                                                                          
-   Unaligned (session window) — examples/12-simple-session-pipeline.yaml — simple-session-counter with 120s session timeout, 1 partition, PVC storage 

Aligned (Fixed Window) — even-odd-sum Pipeline
Total inputs sent: 101 messages (1 priming + 100 batch)

| Metric                          | Replica 0              | Replica 1                 | Verdict                              |
|---------------------------------|------------------------|---------------------------|--------------------------------------|
| `reduce_pbq_write_total`        | **51**                 | **50**                    | ✅ Sum = 101, exactly matches input  |
| `reduce_active_windows`         | 1                      | 1                         | ✅                                   |
| `reduce_closed_windows`         | 0                      | 0                         | ✅                                   |
| `reduce_watermark_lag`          | 3703 ms                | 3705 ms                   | ✅ ~3.7s lag                         |
| `reduce_window_processing_time` | count=1, sum=12.0M μs  | (window not yet closed)   | ✅                                   |
| `reduce_pnf_process_time`       | count=1, sum=12.0M μs  | (window not yet closed)   | ✅                                   |

Unaligned (Session Window) — simple-session-counter Pipeline
Total inputs sent: 101 messages (1 priming + 100 batch)
After 60s idle: counter stays at 101 — no WMB inflation.

| Metric                          | Value       | Verdict                                     |
|---------------------------------|-------------|---------------------------------------------|
| `reduce_pbq_write_total`        | **101**     | ✅ Exactly matches input                    |
| `reduce_active_windows`         | 2           | ✅ Two keyed sessions (even/odd)            |
| `reduce_closed_windows`         | 0           | ✅                                          |
| `reduce_watermark_lag`          | 33953 ms    | ✅ ~34s, matches `maxDelay: 30s` config     |
| `reduce_window_processing_time` | not emitted | ✅ Aligned-only by design                   |
| `reduce_pnf_process_time`       | not emitted | ✅ Aligned-only by design                   |

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
