### PR TITLE
fix: Pod deletion (scale down) caused transient unhealthy vertex/mvtx

### DIFF
--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -47,6 +47,10 @@ func CheckPodsStatus(pods *corev1.PodList) (healthy bool, reason string, message
 // which would not end up with another reconciliation when it reaches the time limit,
 // but we have to trigger it explicitly.
 func isPodHealthy(pod *corev1.Pod) (healthy bool, reason string, isTransientUnhealthy bool) {
+	// Skip pods that are terminating or already completed
+	if pod.DeletionTimestamp != nil || pod.Status.Phase == corev1.PodSucceeded {
+		return true, "", false
+	}
 
 	// check both container and initContainer statuses
 	healthy, reason, isTransientUnhealthy = checkContainerStatuses(pod.Status.ContainerStatuses)

--- a/pkg/reconciler/util_test.go
+++ b/pkg/reconciler/util_test.go
@@ -122,6 +122,71 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 		assert.True(t, transient)
 	})
 
+	t.Run("Test skip terminating pod with DeletionTimestamp set", func(t *testing.T) {
+		now := metav1.Now()
+		pods := corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "terminating-pod", DeletionTimestamp: &now}, Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+				}},
+			},
+		}}
+		done, reason, message, _ := CheckPodsStatus(&pods)
+		assert.True(t, done)
+		assert.Equal(t, "Running", reason)
+		assert.Equal(t, "All pods are healthy", message)
+	})
+
+	t.Run("Test skip pod with Succeeded phase", func(t *testing.T) {
+		pods := corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "succeeded-pod"}, Status: corev1.PodStatus{
+				Phase: corev1.PodSucceeded,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed"}}},
+				}},
+			},
+		}}
+		done, reason, message, _ := CheckPodsStatus(&pods)
+		assert.True(t, done)
+		assert.Equal(t, "Running", reason)
+		assert.Equal(t, "All pods are healthy", message)
+	})
+
+	t.Run("Test failed pod is still considered unhealthy", func(t *testing.T) {
+		pods := corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "failed-pod"}, Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error"}}},
+				}},
+			},
+		}}
+		done, reason, message, _ := CheckPodsStatus(&pods)
+		assert.False(t, done)
+		assert.Equal(t, "PodError", reason)
+		assert.Equal(t, "Pod failed-pod is unhealthy", message)
+	})
+
+	t.Run("Test unhealthy pod is still detected among terminating pods", func(t *testing.T) {
+		now := metav1.Now()
+		pods := corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "terminating-pod", DeletionTimestamp: &now}, Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+				}},
+			},
+			{ObjectMeta: metav1.ObjectMeta{Name: "unhealthy-pod"}, Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+				}},
+			},
+		}}
+		done, reason, message, _ := CheckPodsStatus(&pods)
+		assert.False(t, done)
+		assert.Equal(t, "PodCrashLoopBackOff", reason)
+		assert.Equal(t, "Pod unhealthy-pod is unhealthy", message)
+	})
+
 	t.Run("Test vertex status as false with failed initContainer", func(t *testing.T) {
 		pods := corev1.PodList{
 			Items: []corev1.Pod{


### PR DESCRIPTION
### What this PR does / why we need it

Ignore the pod in termination status for health check.

When pod is in termination status, if any container does not correctly handle the sigterm correctly (e.g. exit with non-zero), the pod will be in `PodError` state (for a very short period of time) before it is gone, this causes the owner MonoVertex or Vertex in a transient `Degraded` status, which is very annoying.


```
  - lastTransitionTime: "2026-04-14T22:54:12Z"
    message: Pod xxxxxxx is unhealthy
    reason: PodError
    status: "False"
    type: PodsHealthy
```

### Related issues
Fixes #

### Testing
How was this tested (unit/integration/manual)? Include commands, links, or screenshots if applicable.

### Special notes for reviewers
Anything notable for review (risk, rollout, follow-ups).

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
