### PR TITLE
fix: allow token cancellation from streaming_read errors

### DIFF
--- a/rust/numaflow-core/src/pipeline/forwarder/reduce_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/reduce_forwarder.rs
@@ -34,6 +34,7 @@ use async_nats::jetstream::Context;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::fs;
+use tokio::task::JoinHandle;
 use tokio::time::{interval, timeout};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -68,8 +69,15 @@ impl<C: NumaflowTypeConfig> ReduceForwarder<C> {
             }
         };
 
+        let pbq_monitor = create_cancellable_handle(
+            pbq_handle,
+            cln_token.clone(),
+            "PBQ Handle panicked".to_string(),
+        )
+        .await;
+
         // Join the pbq and reducer
-        let (pbq_result, processor_result) = tokio::try_join!(pbq_handle, processor_handle)
+        let (pbq_result, processor_result) = tokio::try_join!(pbq_monitor, processor_handle)
             .map_err(|e| {
                 error!(?e, "Error while joining PBQ reader and reducer");
                 crate::error::Error::Forwarder(format!(
@@ -542,6 +550,24 @@ pub(crate) async fn start_reduce_forwarder(
             .await
         }
     }
+}
+
+/// Currently there exists no way for the PBQ streaming_read or the wrapped ISB streaming_read to
+/// cancel the cancellation token in case any error is encountered during streaming read.
+/// This method simply wraps the original join handle in a spawned task, unwraps the JoinError,
+/// and checks the inner Result<()> based on which the cancellation token is cancelled.
+async fn create_cancellable_handle(
+    join_handle: JoinHandle<Result<()>>,
+    cancel_token: CancellationToken,
+    panic_str: String,
+) -> JoinHandle<Result<()>> {
+    tokio::spawn(async move {
+        let result = join_handle.await.expect(panic_str.as_str());
+        if result.is_err() {
+            cancel_token.cancel();
+        }
+        result
+    })
 }
 
 #[cfg(test)]

--- a/rust/numaflow-core/src/pipeline/forwarder/reduce_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/reduce_forwarder.rs
@@ -69,12 +69,7 @@ impl<C: NumaflowTypeConfig> ReduceForwarder<C> {
             }
         };
 
-        let pbq_monitor = create_cancellable_handle(
-            pbq_handle,
-            cln_token.clone(),
-            "PBQ Handle panicked".to_string(),
-        )
-        .await;
+        let pbq_monitor = spawn_cancel_on_error(pbq_handle, cln_token.clone());
 
         // Join the pbq and reducer
         let (pbq_result, processor_result) = tokio::try_join!(pbq_monitor, processor_handle)
@@ -552,21 +547,29 @@ pub(crate) async fn start_reduce_forwarder(
     }
 }
 
-/// Currently there exists no way for the PBQ streaming_read or the wrapped ISB streaming_read to
-/// cancel the cancellation token in case any error is encountered during streaming read.
-/// This method simply wraps the original join handle in a spawned task, unwraps the JoinError,
-/// and checks the inner Result<()> based on which the cancellation token is cancelled.
-async fn create_cancellable_handle(
+/// Wraps a `JoinHandle<Result<()>>` in a monitor task that triggers `cancel_token` when the
+/// inner task fails (either by returning `Err` or by panicking/being cancelled at the task
+/// layer). This is used so that an error from the PBQ reader signals the reducer to finish,
+/// instead of the reducer hanging forever waiting for messages that will never arrive.
+fn spawn_cancel_on_error(
     join_handle: JoinHandle<Result<()>>,
     cancel_token: CancellationToken,
-    panic_str: String,
 ) -> JoinHandle<Result<()>> {
     tokio::spawn(async move {
-        let result = join_handle.await.expect(panic_str.as_str());
-        if result.is_err() {
-            cancel_token.cancel();
+        match join_handle.await {
+            Ok(inner) => {
+                if inner.is_err() {
+                    cancel_token.cancel();
+                }
+                inner
+            }
+            Err(join_err) => {
+                cancel_token.cancel();
+                Err(crate::error::Error::Forwarder(format!(
+                    "Spawn task failed to join: {join_err}"
+                )))
+            }
         }
-        result
     })
 }
 


### PR DESCRIPTION
### Related issues
Fixes #3334

The change proposed in the [PR 3361](https://github.com/numaproj/numaflow/pull/3361) for the concerned issue is not correct because it will gracefully close any active windows during the shutdown path as we start waiting for reduce tasks to finish. 

We do not want that because any data collected partially for a given window will be nicely packaged and shipped downstream. The behaviour should instead be to abandon what we're doing during shutdown, and recreate it after restart so that we only ship data to down stream when we have data for the full window. 

So, instead of dropping the active_stream's message_tx explicitly during `wait_for_all_tasks`, we should address the core problem that caused the referenced issue. Reader had errored out and exit, but the reducer kept waiting for tasks to finish. We can signal the reducer to finish it's processing by cancelling the cancellation token (similar to shutdown path). Currently we're not cancelling the token anywhere when the reader encounters an error. This PR aims to add that cancellation logic.  

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
