### PR TITLE
chore: components should cancel the token on critical errors

### DIFF
--- a/rust/numaflow-core/src/pipeline/forwarder/map_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/map_forwarder.rs
@@ -68,10 +68,14 @@ impl<C: crate::typ::NumaflowTypeConfig> MapForwarder<C> {
             .streaming_write(mapped_messages_stream, cln_token.clone())
             .await?;
 
-        // Join the reader, mapper, and writer
+        // Join the reader, mapper, and writer. Cancel on panic (JoinError).
         let (reader_result, mapper_result, writer_result) =
             tokio::try_join!(reader_handle, mapper_handle, writer_handle).map_err(|e| {
-                error!(?e, "Error while joining reader, mapper, and writer");
+                error!(
+                    ?e,
+                    "Reader, mapper, or writer task panicked, cancelling token"
+                );
+                cln_token.cancel();
                 Error::Forwarder(format!(
                     "Error while joining reader, mapper, and writer: {e}"
                 ))
@@ -245,9 +249,11 @@ pub async fn start_map_forwarder(
     )
     .await;
 
-    let results = try_join_all(forwarder_tasks)
-        .await
-        .map_err(|e| Error::Forwarder(e.to_string()))?;
+    let results = try_join_all(forwarder_tasks).await.map_err(|e| {
+        error!(?e, "A forwarder task panicked, cancelling token");
+        cln_token.cancel();
+        Error::Forwarder(e.to_string())
+    })?;
 
     for result in results {
         info!(?result, "Forwarder task completed");

--- a/rust/numaflow-core/src/pipeline/forwarder/reduce_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/reduce_forwarder.rs
@@ -68,10 +68,12 @@ impl<C: NumaflowTypeConfig> ReduceForwarder<C> {
             }
         };
 
-        // Join the pbq and reducer
+        // Join the pbq and reducer. If either task panics (JoinError), cancel the token so the
+        // other task is not left hanging.
         let (pbq_result, processor_result) = tokio::try_join!(pbq_handle, processor_handle)
             .map_err(|e| {
-                error!(?e, "Error while joining PBQ reader and reducer");
+                error!(?e, "PBQ or reducer task panicked, cancelling token");
+                cln_token.cancel();
                 crate::error::Error::Forwarder(format!(
                     "Error while joining PBQ reader and reducer: {e}"
                 ))

--- a/rust/numaflow-core/src/pipeline/forwarder/reduce_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/reduce_forwarder.rs
@@ -34,7 +34,6 @@ use async_nats::jetstream::Context;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::fs;
-use tokio::task::JoinHandle;
 use tokio::time::{interval, timeout};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};

--- a/rust/numaflow-core/src/pipeline/forwarder/reduce_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/reduce_forwarder.rs
@@ -69,10 +69,8 @@ impl<C: NumaflowTypeConfig> ReduceForwarder<C> {
             }
         };
 
-        let pbq_monitor = spawn_cancel_on_error(pbq_handle, cln_token.clone());
-
         // Join the pbq and reducer
-        let (pbq_result, processor_result) = tokio::try_join!(pbq_monitor, processor_handle)
+        let (pbq_result, processor_result) = tokio::try_join!(pbq_handle, processor_handle)
             .map_err(|e| {
                 error!(?e, "Error while joining PBQ reader and reducer");
                 crate::error::Error::Forwarder(format!(
@@ -545,32 +543,6 @@ pub(crate) async fn start_reduce_forwarder(
             .await
         }
     }
-}
-
-/// Wraps a `JoinHandle<Result<()>>` in a monitor task that triggers `cancel_token` when the
-/// inner task fails (either by returning `Err` or by panicking/being cancelled at the task
-/// layer). This is used so that an error from the PBQ reader signals the reducer to finish,
-/// instead of the reducer hanging forever waiting for messages that will never arrive.
-fn spawn_cancel_on_error(
-    join_handle: JoinHandle<Result<()>>,
-    cancel_token: CancellationToken,
-) -> JoinHandle<Result<()>> {
-    tokio::spawn(async move {
-        match join_handle.await {
-            Ok(inner) => {
-                if inner.is_err() {
-                    cancel_token.cancel();
-                }
-                inner
-            }
-            Err(join_err) => {
-                cancel_token.cancel();
-                Err(crate::error::Error::Forwarder(format!(
-                    "Spawn task failed to join: {join_err}"
-                )))
-            }
-        }
-    })
 }
 
 #[cfg(test)]

--- a/rust/numaflow-core/src/pipeline/forwarder/sink_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/sink_forwarder.rs
@@ -60,10 +60,11 @@ impl<C: crate::typ::NumaflowTypeConfig> SinkForwarder<C> {
             .streaming_write(read_messages_stream, cln_token.clone())
             .await?;
 
-        // Join the reader and sink writer
+        // Join the reader and sink writer. Cancel on panic (JoinError).
         let (reader_result, sink_writer_result) =
             tokio::try_join!(reader_handle, sink_writer_handle).map_err(|e| {
-                error!(?e, "Error while joining reader and sink writer");
+                error!(?e, "Reader or sink writer task panicked, cancelling token");
+                cln_token.cancel();
                 Error::Forwarder(format!("Error while joining reader and sink writer: {e}",))
             })?;
 
@@ -220,9 +221,11 @@ pub async fn start_sink_forwarder(
     )
     .await;
 
-    let results = try_join_all(forwarder_tasks)
-        .await
-        .map_err(|e| Error::Forwarder(e.to_string()))?;
+    let results = try_join_all(forwarder_tasks).await.map_err(|e| {
+        error!(?e, "A forwarder task panicked, cancelling token");
+        cln_token.cancel();
+        Error::Forwarder(e.to_string())
+    })?;
 
     for result in results {
         info!(?result, "Forwarder task completed");

--- a/rust/numaflow-core/src/pipeline/forwarder/source_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/source_forwarder.rs
@@ -48,9 +48,11 @@ impl<C: crate::typ::NumaflowTypeConfig> SourceForwarder<C> {
             .streaming_write(messages_stream, cln_token.clone())
             .await?;
 
+        // Cancel on panic (JoinError).
         let (reader_result, sink_writer_result) = tokio::try_join!(reader_handle, writer_handle)
             .map_err(|e| {
-                error!(?e, "Error while joining reader and sink writer");
+                error!(?e, "Reader or writer task panicked, cancelling token");
+                cln_token.cancel();
                 Error::Forwarder(format!("Error while joining reader and sink writer: {e}"))
             })?;
 

--- a/rust/numaflow-core/src/pipeline/isb/reader.rs
+++ b/rust/numaflow-core/src/pipeline/isb/reader.rs
@@ -126,49 +126,60 @@ impl<C: NumaflowTypeConfig> ISBReaderOrchestrator<C> {
         let handle: JoinHandle<Result<()>> = tokio::spawn(async move {
             let semaphore = Arc::new(Semaphore::new(max_ack_pending));
 
-            loop {
-                // stop reading if the token is cancelled. cancel is only honored here since it is
-                // the first block in the chain.
-                if cancel.is_cancelled() {
-                    break;
+            let result = async {
+                loop {
+                    // stop reading if the token is cancelled. cancel is only honored here since it is
+                    // the first block in the chain.
+                    if cancel.is_cancelled() {
+                        break;
+                    }
+
+                    // Acquire permits up-front to cap inflight messages
+                    let mut permits = Arc::clone(&semaphore)
+                        .acquire_many_owned(batch_size as u32)
+                        .await
+                        .map_err(|e| {
+                            Error::ISB(crate::pipeline::isb::error::ISBError::Other(format!(
+                                "Failed to acquire semaphore permit: {e}"
+                            )))
+                        })?;
+
+                    let start = Instant::now();
+                    // Apply rate limiting and fetch message batch
+                    let batch = self.apply_rate_limiting_and_fetch(batch_size).await;
+
+                    pipeline_metrics()
+                        .jetstream_isb
+                        .read_time_total
+                        .get_or_create(&jetstream_isb_metrics_labels(self.stream.name))
+                        .observe(start.elapsed().as_micros() as f64);
+
+                    // Handle idle watermarks
+                    self.handle_idle_watermarks(batch.is_empty(), &tx).await?;
+
+                    // Process each message in the batch
+                    self.process_message_batch(batch, &tx, &mut permits, cancel.clone(), start)
+                        .await?;
+
+                    pipeline_metrics()
+                        .forwarder
+                        .read_processing_time
+                        .get_or_create(&self.metric_labels)
+                        .observe(start.elapsed().as_micros() as f64);
                 }
 
-                // Acquire permits up-front to cap inflight messages
-                let mut permits = Arc::clone(&semaphore)
-                    .acquire_many_owned(batch_size as u32)
-                    .await
-                    .map_err(|e| {
-                        Error::ISB(crate::pipeline::isb::error::ISBError::Other(format!(
-                            "Failed to acquire semaphore permit: {e}"
-                        )))
-                    })?;
-
-                let start = Instant::now();
-                // Apply rate limiting and fetch message batch
-                let batch = self.apply_rate_limiting_and_fetch(batch_size).await;
-
-                pipeline_metrics()
-                    .jetstream_isb
-                    .read_time_total
-                    .get_or_create(&jetstream_isb_metrics_labels(self.stream.name))
-                    .observe(start.elapsed().as_micros() as f64);
-
-                // Handle idle watermarks
-                self.handle_idle_watermarks(batch.is_empty(), &tx).await?;
-
-                // Process each message in the batch
-                self.process_message_batch(batch, &tx, &mut permits, cancel.clone(), start)
-                    .await?;
-
-                pipeline_metrics()
-                    .forwarder
-                    .read_processing_time
-                    .get_or_create(&self.metric_labels)
-                    .observe(start.elapsed().as_micros() as f64);
+                // Cleanup on shutdown
+                self.cleanup_on_shutdown(semaphore, max_ack_pending).await
             }
+            .await;
 
-            // Cleanup on shutdown
-            self.cleanup_on_shutdown(semaphore, max_ack_pending).await
+            result.inspect_err(|e| {
+                error!(
+                    ?e,
+                    "ISBReaderOrchestrator encountered a critical error, cancelling token"
+                );
+                cancel.cancel();
+            })
         });
 
         Ok((ReceiverStream::new(rx), handle))

--- a/rust/numaflow-core/src/reduce/pbq.rs
+++ b/rust/numaflow-core/src/reduce/pbq.rs
@@ -11,7 +11,7 @@ use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{error, info};
 
 /// WAL for storing the data. If None, we will not persist the data.
 #[allow(clippy::upper_case_acronyms)]
@@ -65,15 +65,17 @@ impl<C: NumaflowTypeConfig> PBQ<C> {
     ) -> Result<(ReceiverStream<Message>, JoinHandle<Result<()>>)> {
         let (tx, rx) = mpsc::channel(100);
 
-        let handle = if let Some(wal) = self.wal {
-            tokio::spawn(async move {
-                Self::read_isb_with_wal(self.isb_reader, wal, tx, cancellation_token).await
+        let handle = tokio::spawn(async move {
+            let result = if let Some(wal) = self.wal {
+                Self::read_isb_with_wal(self.isb_reader, wal, tx, cancellation_token.clone()).await
+            } else {
+                Self::read_isb_without_wal(self.isb_reader, tx, cancellation_token.clone()).await
+            };
+            result.inspect_err(|e| {
+                error!(?e, "PBQ encountered a critical error, cancelling token");
+                cancellation_token.cancel();
             })
-        } else {
-            tokio::spawn(async move {
-                Self::read_isb_without_wal(self.isb_reader, tx, cancellation_token).await
-            })
-        };
+        });
 
         Ok((ReceiverStream::new(rx), handle))
     }
@@ -108,11 +110,12 @@ impl<C: NumaflowTypeConfig> PBQ<C> {
 
         // Process replayed messages
         while let Some(msg) = wal_rx.recv().await {
-            let msg: WalMessage = msg.try_into().expect("Failed to parse WAL message");
-            messages_tx
-                .send(msg.into())
-                .await
-                .expect("Receiver dropped");
+            let msg: WalMessage = msg.try_into().map_err(|e| {
+                crate::error::Error::Reduce(format!("Failed to parse WAL message: {e}"))
+            })?;
+            messages_tx.send(msg.into()).await.map_err(|_| {
+                crate::error::Error::Reduce("PBQ WAL replay: receiver dropped".to_string())
+            })?;
             replayed_count += 1;
         }
 
@@ -143,19 +146,34 @@ impl<C: NumaflowTypeConfig> PBQ<C> {
                     message: msg.clone(),
                 })
                 .await
-                .expect("Receiver dropped");
+                .map_err(|_| {
+                    crate::error::Error::Reduce("PBQ WAL writer: receiver dropped".to_string())
+                })?;
 
-            tx.send(msg).await.expect("Receiver dropped");
+            tx.send(msg).await.map_err(|_| {
+                crate::error::Error::Reduce(
+                    "PBQ ISB reader: downstream receiver dropped".to_string(),
+                )
+            })?;
         }
 
-        isb_handle.await.expect("task failed")?;
+        isb_handle
+            .await
+            .map_err(|e| crate::error::Error::Reduce(format!("ISB reader task panicked: {e}")))?
+            .map_err(|e| crate::error::Error::Reduce(format!("ISB reader task failed: {e}")))?;
 
         // drop the sender to signal the wal eof and wait for the wal task to exit gracefully
         drop(wal_tx);
-        wal_handle.await.expect("task failed")?;
+        wal_handle
+            .await
+            .map_err(|e| crate::error::Error::Reduce(format!("WAL writer task panicked: {e}")))?
+            .map_err(|e| crate::error::Error::Reduce(format!("WAL writer task failed: {e}")))?;
 
         // Wait for compaction task to exit gracefully
-        compaction_handle.await.expect("task failed")?;
+        compaction_handle
+            .await
+            .map_err(|e| crate::error::Error::Reduce(format!("Compaction task panicked: {e}")))?
+            .map_err(|e| crate::error::Error::Reduce(format!("Compaction task failed: {e}")))?;
 
         info!("PBQ streaming read completed");
         Ok(())
@@ -172,11 +190,18 @@ impl<C: NumaflowTypeConfig> PBQ<C> {
         // Process messages from ISB stream
         while let Some(msg) = isb_stream.next().await {
             // Forward the message to the output channel
-            tx.send(msg).await.expect("Receiver dropped");
+            tx.send(msg).await.map_err(|_| {
+                crate::error::Error::Reduce(
+                    "PBQ ISB reader: downstream receiver dropped".to_string(),
+                )
+            })?;
         }
 
         // Wait for the ISB reader task to complete
-        isb_handle.await.expect("ISB reader task failed")?;
+        isb_handle
+            .await
+            .map_err(|e| crate::error::Error::Reduce(format!("ISB reader task panicked: {e}")))?
+            .map_err(|e| crate::error::Error::Reduce(format!("ISB reader task failed: {e}")))?;
 
         Ok(())
     }


### PR DESCRIPTION
## Description                                                                                                                                                                              
                                                                                                                                                                                              
  Previously, `ISBReaderOrchestrator` and `PBQ` did not cancel the cancellation token on                                                                                                      
  critical errors, which could leave dependent components hanging. This PR makes them                                                                                                         
  consistent with other components (e.g., ISB writer) by cancelling the token on error at                                                                                                     
  the spawn boundary using `inspect_err`.                                                                                                                                                     
                                                                                                                                                                                              
  ## Changes

  - **`ISBReaderOrchestrator`**: cancel token on error in the `streaming_read` task                                                                                                           
  - **`PBQ`**: cancel token on error; replace panicking `.expect()` calls with proper error
    propagation; consolidate two spawns into one                                                                                                                                                           
  - **`ReduceForwarder`**: remove now-redundant `spawn_cancel_on_error` wrapper since PBQ
    handles cancellation itself  