### PR TITLE
fix: include udf in MonoVertex kustomize transformations. Closes #3322

### DIFF
--- a/docs/user-guide/reference/kustomize/numaflow-transformer-config.yaml
+++ b/docs/user-guide/reference/kustomize/numaflow-transformer-config.yaml
@@ -18,6 +18,8 @@ images:
     kind: MonoVertex
   - path: spec/source/transformer/container/image
     kind: MonoVertex
+  - path: spec/udf/container/image
+    kind: MonoVertex
   - path: spec/sink/udsink/container/image
     kind: MonoVertex
   - path: spec/sink/fallback/udsink/container/image


### PR DESCRIPTION
### What this PR does / why we need it
Updates the kustomize transformation configuration to include `udf` in `MonoVertex` so image name and tag substitutions are applied correctly.

### Related issues
Fixes #3322

### Testing
Manual

- verified `MonoVertex` uses `spec.udf.container.image`
- updated the kustomize transformer config to include the missing `MonoVertex` `udf` image path
- confirmed the change is consistent with the existing image transformation paths for Pipeline, MonoVertex, and ServingPipeline resources

### Special notes for reviewers
This is a scoped configuration fix for kustomize image transformation behavior.