### PR TITLE
fix: include onSuccess in kustomize transformations

### DIFF
--- a/docs/user-guide/reference/kustomize/numaflow-transformer-config.yaml
+++ b/docs/user-guide/reference/kustomize/numaflow-transformer-config.yaml
@@ -6,6 +6,8 @@ images:
     kind: Pipeline
   - path: spec/vertices/sink/udsink/container/image
     kind: Pipeline
+  - path: spec/vertices/sink/onSuccess/udsink/container/image
+    kind: Pipeline
   - path: spec/vertices/sink/fallback/udsink/container/image
     kind: Pipeline
   - path: spec/vertices/source/transformer/container/image
@@ -22,6 +24,8 @@ images:
     kind: MonoVertex
   - path: spec/sink/udsink/container/image
     kind: MonoVertex
+  - path: spec/sink/onSuccess/udsink/container/image
+    kind: MonoVertex
   - path: spec/sink/fallback/udsink/container/image
     kind: MonoVertex
   - path: spec/pipeline/vertices/udf/container/image
@@ -29,6 +33,8 @@ images:
   - path: spec/pipeline/vertices/sidecars/image
     kind: ServingPipeline
   - path: spec/pipeline/vertices/sink/udsink/container/image
+    kind: ServingPipeline
+  - path: spec/pipeline/vertices/sink/onSuccess/udsink/container/image
     kind: ServingPipeline
   - path: spec/pipeline/vertices/sink/fallback/udsink/container/image
     kind: ServingPipeline


### PR DESCRIPTION
### What this PR does / why we need it
Updates the kustomize transformation configuration to include `onSuccess` sink image paths so image name and tag substitutions are applied correctly for Pipeline, MonoVertex, and ServingPipeline resources.

### Related issues
Fixes #3383

### Testing
Manual

- verified the transformer config already included sink and fallback image paths
- added the missing `onSuccess` image transformation paths for Pipeline, MonoVertex, and ServingPipeline
- confirmed the new paths are consistent with the existing sink transformation patterns across all three resource types

### Special notes for reviewers
This is a scoped configuration fix for kustomize image transformation behaviour.