### PR TITLE
fix: remove unnecessary scrollbars in errors tab

### DIFF
--- a/ui/src/components/common/SlidingSidebar/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/index.tsx
@@ -314,7 +314,10 @@ export function SlidingSidebar({
           paddingLeft: "1.6rem",
           width: "100%",
           height: "calc(100% - 10.8rem)",
-          overflowX: "scroll",
+          overflowX: "hidden",
+          overflowY: "auto",
+          minWidth: 0,
+          boxSizing: "border-box",
         }}
       >
         <Box

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/partials/CollapsableError/style.css
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/partials/CollapsableError/style.css
@@ -9,6 +9,7 @@
   margin: 1rem 0;
   gap: 1rem;
   align-items: center;
+  min-width: 0;
 }
 
 .collapsable-error-common-title-text {
@@ -31,6 +32,7 @@
   height: 100%;
   padding: 2rem 0;
   gap: 1rem;
+  min-width: 0;
 }
 
 .collapsable-error-accordion-details-title {
@@ -41,5 +43,7 @@
 .collapsable-error-accordion-details-title-content {
   font-size: 1.4rem;
   height: 30rem;
-  overflow: scroll;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-width: 0;
 }

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/style.css
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/style.css
@@ -20,7 +20,7 @@
   margin-top: 0;
   height: 100%;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   box-sizing: border-box;
 }
 

--- a/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/style.css
+++ b/ui/src/components/common/SlidingSidebar/partials/VertexDetails/partials/Errors/style.css
@@ -6,6 +6,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  overflow-x: hidden;
 }
 
 .vertex-dropdown-title {
@@ -18,7 +19,9 @@
   padding: 4rem;
   margin-top: 0;
   height: 100%;
-  overflow: scroll;
+  overflow-y: auto;
+  overflow-x: hidden;
+  box-sizing: border-box;
 }
 
 .vertex-errors-selector-dropdown {


### PR DESCRIPTION
### What this PR does / why we need it
Fixes the Errors tab layout so scrollbars only appear where needed. The issue was caused by forced scrolling at multiple levels, including the parent sidebar content wrapper, the Errors container, and the inner details content.

### Related issues
Fixes #3319

### Testing
Manual

- inspected the Errors tab layout and identified forced scrolling at multiple levels
- updated the sidebar wrapper to prevent unnecessary horizontal scrolling
- updated the Errors container and details content to use vertical auto scrolling instead of forced scrolling
- added flex shrink guards (`min-width: 0`) to prevent horizontal overflow in the error rows and details layout

### Special notes for reviewers
This is a scoped UI layout fix for nested and unnecessary scrollbars in the Errors tab.