### PR TITLE
fix: Exit with non-zero status on error and log errors when we receive duplicate message sink UDF

### DIFF
--- a/rust/numaflow-core/src/lib.rs
+++ b/rust/numaflow-core/src/lib.rs
@@ -140,9 +140,9 @@ pub async fn run() -> Result<()> {
                 // increment the critical error metric
                 critical_error!("", "mvtx_runtime_error");
 
-                if let Error::Grpc(e) = e {
-                    error!(error=?e, "Monovertex failed because of UDF failure");
-                    runtime::persist_application_error(*e);
+                if let Error::Grpc(status) = &e {
+                    error!(error=?status, "Monovertex failed because of UDF failure");
+                    runtime::persist_application_error(status.as_ref().clone());
                 } else {
                     error!(?e, "Error running monovertex");
                     runtime::persist_application_error(Status::with_details(
@@ -155,6 +155,7 @@ pub async fn run() -> Result<()> {
                 if !shutdown_handle.is_finished() {
                     shutdown_handle.abort();
                 }
+                return Err(e);
             }
         }
         CustomResourceType::Pipeline(config) => {
@@ -163,9 +164,9 @@ pub async fn run() -> Result<()> {
             if let Err(e) = forwarder::start_forwarder(cln_token, *config).await {
                 critical_error!(vertex_type, "pipeline_runtime_error");
 
-                if let Error::Grpc(e) = e {
-                    error!(error=?e, "Pipeline failed because of UDF failure");
-                    runtime::persist_application_error(*e);
+                if let Error::Grpc(status) = &e {
+                    error!(error=?status, "Pipeline failed because of UDF failure");
+                    runtime::persist_application_error(status.as_ref().clone());
                 } else {
                     error!(?e, "Error running pipeline");
                     runtime::persist_application_error(Status::with_details(
@@ -178,6 +179,7 @@ pub async fn run() -> Result<()> {
                 if !shutdown_handle.is_finished() {
                     shutdown_handle.abort();
                 }
+                return Err(e);
             }
         }
     }

--- a/rust/numaflow-core/src/mapper/map.rs
+++ b/rust/numaflow-core/src/mapper/map.rs
@@ -455,7 +455,7 @@ impl From<&Message> for ParentMessageInfo {
             headers: Arc::clone(&message.headers),
             is_late: message.is_late,
             start_time: Instant::now(),
-            current_index: 0,
+            current_index: message.id.index,
             metadata: message.metadata.clone(),
         }
     }

--- a/rust/numaflow-core/src/sinker/actor.rs
+++ b/rust/numaflow-core/src/sinker/actor.rs
@@ -1,8 +1,8 @@
-use crate::Result;
 use crate::config::components::sink::{OnFailureStrategy, RetryConfig};
 use crate::message::Message;
 use crate::metadata::Metadata;
 use crate::sinker::sink::{ResponseStatusFromSink, Sink};
+use crate::{Error, Result};
 use backoff::strategy::exponential::Exponential;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -87,11 +87,17 @@ where
             // send batch to sink
             let responses = self.sink.sink(messages_to_retry.clone()).await?;
 
-            // Create a map of id to result
-            let mut result_map = responses
-                .into_iter()
-                .map(|resp| (resp.id, resp.status))
-                .collect::<HashMap<_, _>>();
+            // Create a map of id to result. Duplicate response IDs are a data-plane invariant
+            // violation because we cannot safely classify per-message outcomes.
+            let mut result_map = HashMap::with_capacity(responses.len());
+            for resp in responses {
+                if result_map.insert(resp.id.clone(), resp.status).is_some() {
+                    return Err(Error::Sink(format!(
+                        "duplicate response id from sink: {}",
+                        resp.id
+                    )));
+                }
+            }
 
             // Classify messages based on responses, preserving original ordering.
             // Take ownership of the current batch so we can iterate by move and push
@@ -151,8 +157,21 @@ where
                             on_success_messages.push(msg);
                         }
                     }
-                    None => unreachable!("should have response for all messages"),
+                    None => {
+                        return Err(Error::Sink(format!(
+                            "missing response from sink for message id: {msg_id}"
+                        )));
+                    }
                 }
+            }
+
+            if !result_map.is_empty() {
+                let mut ids = result_map.into_keys().collect::<Vec<_>>();
+                ids.sort();
+                return Err(Error::Sink(format!(
+                    "received responses for unknown message ids from sink: {}",
+                    ids.join(", ")
+                )));
             }
 
             if messages_to_retry.is_empty() {
@@ -238,5 +257,76 @@ where
         while let Some(msg) = self.actor_messages.recv().await {
             self.handle_message(msg).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{Message, MessageID};
+    use crate::sinker::sink::ResponseFromSink;
+
+    struct StaticResponseSink {
+        responses: Vec<ResponseFromSink>,
+    }
+
+    impl Sink for StaticResponseSink {
+        async fn sink(&mut self, _messages: Vec<Message>) -> Result<Vec<ResponseFromSink>> {
+            Ok(std::mem::take(&mut self.responses))
+        }
+    }
+
+    fn message(id: &str) -> Message {
+        Message {
+            id: MessageID {
+                vertex_name: "vertex".to_string().into(),
+                offset: id.to_string().into(),
+                index: 0,
+            },
+            ..Default::default()
+        }
+    }
+
+    fn response(id: &str) -> ResponseFromSink {
+        ResponseFromSink {
+            id: format!("vertex-{id}-0"),
+            status: ResponseStatusFromSink::Success,
+        }
+    }
+
+    async fn write_with_static_responses(
+        messages: Vec<Message>,
+        responses: Vec<ResponseFromSink>,
+    ) -> Result<SinkActorResponse> {
+        let (_tx, rx) = tokio::sync::mpsc::channel(1);
+        let mut actor =
+            SinkActor::new(rx, StaticResponseSink { responses }, RetryConfig::default());
+        actor
+            .write_messages_with_retry(messages, &CancellationToken::new())
+            .await
+    }
+
+    #[tokio::test]
+    async fn duplicate_sink_response_ids_return_error() {
+        let result =
+            write_with_static_responses(vec![message("1")], vec![response("1"), response("1")])
+                .await;
+
+        assert!(matches!(
+            result,
+            Err(Error::Sink(message)) if message.contains("duplicate response id from sink")
+        ));
+    }
+
+    #[tokio::test]
+    async fn missing_sink_response_ids_return_error() {
+        let result =
+            write_with_static_responses(vec![message("1"), message("2")], vec![response("1")])
+                .await;
+
+        assert!(matches!(
+            result,
+            Err(Error::Sink(message)) if message.contains("missing response from sink")
+        ));
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it
Exit with non-zero status on error and log errors when we receive duplicate message sink UDF.

```log
{"timestamp":"2026-04-29T09:29:45.034155Z","level":"WARN","message":"Nak received for offset","offset":"String(StringOffset { offset: b\"ZXZ0LTE1OGIyZDc3LWFkNDYtZjc5Yi1lZDQ5LTNhNGM3OWMxYTYxNg==\", partition_idx: 0 })","target":"numaflow_core::source"}
{"timestamp":"2026-04-29T09:29:45.034162Z","level":"WARN","message":"Nak received for offset","offset":"String(StringOffset { offset: b\"ZXZ0LTdhN2FiMTcyLTk5YjEtY2QyOC02NzE4LWZmOTg0MTM3MjE3NA==\", partition_idx: 0 })","target":"numaflow_core::source"}
{"timestamp":"2026-04-29T09:29:45.061466Z","level":"INFO","message":"Source returned None (end of stream). Stopping the source.","target":"numaflow_core::source"}
{"timestamp":"2026-04-29T09:29:45.061495Z","level":"INFO","message":"Source stopped, waiting for inflight messages to be acked/nacked","status":"Ok(())","target":"numaflow_core::source"}
{"timestamp":"2026-04-29T09:29:45.061503Z","level":"INFO","message":"All inflight messages are acked/nacked. Source stopped.","target":"numaflow_core::source"}
{"timestamp":"2026-04-29T09:29:45.061566Z","level":"INFO","message":"Map input stream ended, waiting for inflight messages to finish","target":"numaflow_core::mapper::map"}
{"timestamp":"2026-04-29T09:29:45.061574Z","level":"INFO","message":"Map component is completed","status":"Ok(())","target":"numaflow_core::mapper::map"}
{"timestamp":"2026-04-29T09:29:45.061607Z","level":"ERROR","message":"Error while writing messages","e":"Sink(\"duplicate response id from sink: monovertex-validation-ZXZ0LTA0MjBmYjk5LTY4Y2YtNmNkMC1iYTcyLTExNzJjOWI4ZjVlMw==-0-0\")","target":"numaflow_core::monovertex::forwarder"}
{"timestamp":"2026-04-29T09:29:45.061634Z","level":"INFO","message":"Stopped the Lag-Reader Expose tasks","target":"numaflow_core::metrics"}
{"timestamp":"2026-04-29T09:29:45.061649Z","level":"ERROR","message":"Error running monovertex","e":"Sink(\"duplicate response id from sink: monovertex-validation-ZXZ0LTA0MjBmYjk5LTY4Y2YtNmNkMC1iYTcyLTExNzJjOWI4ZjVlMw==-0-0\")","target":"numaflow_core"}
{"timestamp":"2026-04-29T09:29:45.061937Z","level":"ERROR","message":"\"Error running core binary: Sink(\\\"duplicate response id from sink: monovertex-validation-ZXZ0LTA0MjBmYjk5LTY4Y2YtNmNkMC1iYTcyLTExNzJjOWI4ZjVlMw==-0-0\\\")\"","target":"numaflow"}
```

### Related issues
Related to: https://github.com/numaproj/numaflow/issues/3391

### Testing
How was this tested (unit/integration/manual)? Include commands, links, or screenshots if applicable.

### Special notes for reviewers
Anything notable for review (risk, rollout, follow-ups).

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
