### PR TITLE
fix: use min event_time across in-flight msgs before publishing idle src wm

### DIFF
--- a/rust/numaflow-core/src/pipeline/forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder.rs
@@ -37,8 +37,6 @@
 //! [Actor Pattern]: https://ryhl.io/blog/actors-with-tokio/
 
 use crate::config::pipeline::PipelineConfig;
-use crate::config::pipeline::watermark::WatermarkConfig;
-use crate::watermark::source::SourceWatermarkHandle;
 use crate::{config, error, pipeline};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -67,27 +65,11 @@ pub(crate) async fn start_forwarder(
         config::pipeline::VertexConfig::Source(source) => {
             info!("Starting source forwarder");
 
-            // create watermark handle, if watermark is enabled
-            // Uses idle_config.step_interval (default 100ms) as the unified heartbeat interval
-            let source_watermark_handle = match &config.watermark_config {
-                Some(WatermarkConfig::Source(source_config)) => Some(
-                    SourceWatermarkHandle::new(
-                        js_context.clone(),
-                        &config.to_vertex_config,
-                        source_config,
-                        cln_token.clone(),
-                    )
-                    .await?,
-                ),
-                _ => None,
-            };
-
             source_forwarder::start_source_forwarder(
                 cln_token,
                 js_context,
                 config.clone(),
                 source.clone(),
-                source_watermark_handle,
             )
             .await?;
         }

--- a/rust/numaflow-core/src/pipeline/forwarder/source_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/source_forwarder.rs
@@ -7,6 +7,7 @@ use crate::metrics::{
 };
 use crate::pipeline::PipelineContext;
 
+use crate::config::pipeline::watermark::WatermarkConfig;
 use crate::pipeline::isb::writer::{ISBWriterOrchestrator, ISBWriterOrchestratorComponents};
 use crate::shared::create_components;
 use crate::shared::metrics::start_metrics_server;
@@ -73,7 +74,6 @@ pub(crate) async fn start_source_forwarder(
     js_context: Context,
     config: PipelineConfig,
     source_config: SourceVtxConfig,
-    source_watermark_handle: Option<SourceWatermarkHandle>,
 ) -> error::Result<()> {
     let serving_callback_handler = if let Some(cb_cfg) = &config.callback_config {
         Some(
@@ -90,6 +90,22 @@ pub(crate) async fn start_source_forwarder(
     };
 
     let tracker = Tracker::new(serving_callback_handler, cln_token.clone());
+
+    // create watermark handle, if watermark is enabled
+    // Uses idle_config.step_interval (default 100ms) as the unified heartbeat interval
+    let source_watermark_handle = match &config.watermark_config {
+        Some(WatermarkConfig::Source(source_config)) => Some(
+            SourceWatermarkHandle::new(
+                js_context.clone(),
+                &config.to_vertex_config,
+                source_config,
+                cln_token.clone(),
+                tracker.clone(),
+            )
+            .await?,
+        ),
+        _ => None,
+    };
 
     // Create the ISB factory from the JetStream context
     use crate::pipeline::isb::ISBFactory;
@@ -1117,9 +1133,6 @@ mod tests {
                 panic!("Expected source vertex config");
             };
 
-        // For this test, we don't have watermark config, so watermark handle is None
-        let source_watermark_handle = None;
-
         let cancellation_token = CancellationToken::new();
         let forwarder_task = tokio::spawn({
             let cancellation_token = cancellation_token.clone();
@@ -1130,7 +1143,6 @@ mod tests {
                     context,
                     pipeline_config,
                     source_vtx_config,
-                    source_watermark_handle,
                 )
                 .await
                 .unwrap();

--- a/rust/numaflow-core/src/tracker.rs
+++ b/rust/numaflow-core/src/tracker.rs
@@ -29,6 +29,8 @@ struct TrackerEntry {
     serving_callback_info: Option<ServingCallbackInfo>,
     /// Watermark for the message
     watermark: Option<DateTime<Utc>>,
+    /// EventTime for the message
+    event_time: DateTime<Utc>,
 }
 
 /// TrackerState holds the mutable state of the tracker.
@@ -211,6 +213,7 @@ impl Tracker {
             TrackerEntry {
                 serving_callback_info: callback_info,
                 watermark: message.watermark,
+                event_time: message.event_time,
             },
         );
         Ok(())
@@ -335,6 +338,19 @@ impl Tracker {
             })
             .min();
         Ok(watermark.unwrap_or(DateTime::from_timestamp_millis(-1).unwrap()))
+    }
+
+    /// Returns the lowest event_time among all the tracked offsets.
+    pub(crate) async fn lowest_event_time(&self) -> Result<DateTime<Utc>> {
+        let state = self.state.read().await;
+        // Get the lowest event_time across all partitions
+        let event_time = state
+            .entries
+            .values()
+            .flat_map(|partition_entries| partition_entries.values())
+            .map(|entry| entry.event_time)
+            .min();
+        Ok(event_time.unwrap_or(DateTime::from_timestamp_millis(-1).unwrap()))
     }
 
     /// Sets the idle status of the tracker. Setting idle offset to None means the partition is not

--- a/rust/numaflow-core/src/watermark/idle/source.rs
+++ b/rust/numaflow-core/src/watermark/idle/source.rs
@@ -274,11 +274,11 @@ mod tests {
         }
 
         // When idle with computed_wm = -1, should return -1 (no init_source_delay)
-        let wm = manager.compute_watermark(TEST_PARTITION, -1, -1);
+        let wm = manager.compute_watermark(TEST_PARTITION, -1, i64::MAX);
         assert_eq!(wm, -1);
 
         // When idle with a valid computed_wm, should increment
-        let wm = manager.compute_watermark(TEST_PARTITION, 1000, 1000);
+        let wm = manager.compute_watermark(TEST_PARTITION, 1000, i64::MAX);
         assert_eq!(wm, 1010);
     }
 
@@ -294,7 +294,7 @@ mod tests {
         manager.initialize_partitions(&[TEST_PARTITION]);
 
         // Partition is not idle, should return current watermark without increment
-        let wm = manager.compute_watermark(TEST_PARTITION, 1000, 1000);
+        let wm = manager.compute_watermark(TEST_PARTITION, 1000, i64::MAX);
         assert_eq!(wm, 1000);
     }
 
@@ -317,7 +317,7 @@ mod tests {
 
         // Partition is idle, computed_wm = -1, but init_source_delay (200ms) hasn't passed
         // since updated_ts was only 100ms ago. Should return -1.
-        let wm = manager.compute_watermark(TEST_PARTITION, -1, -1);
+        let wm = manager.compute_watermark(TEST_PARTITION, -1, i64::MAX);
         assert_eq!(wm, -1);
 
         // Now set updated_ts to 300ms ago so init_source_delay (200ms) has passed
@@ -326,7 +326,7 @@ mod tests {
         }
 
         // Since init_source_delay has passed, should return current time
-        let wm = manager.compute_watermark(TEST_PARTITION, -1, -1);
+        let wm = manager.compute_watermark(TEST_PARTITION, -1, i64::MAX);
         let expected_wm = manager
             .partition_states
             .get(&TEST_PARTITION)
@@ -336,7 +336,7 @@ mod tests {
         assert_eq!(wm, expected_wm);
 
         // With a valid computed_wm, should increment
-        let wm = manager.compute_watermark(TEST_PARTITION, 1000, 1000);
+        let wm = manager.compute_watermark(TEST_PARTITION, 1000, i64::MAX);
         assert_eq!(wm, 1010);
     }
 
@@ -359,7 +359,7 @@ mod tests {
         );
 
         // After computing watermark (which updates last published time), should be empty
-        manager.compute_watermark(TEST_PARTITION, 1000, 1000);
+        manager.compute_watermark(TEST_PARTITION, 1000, i64::MAX);
         assert!(manager.partitions_needing_publish().is_empty());
 
         // After step interval passes, should include the partition again

--- a/rust/numaflow-core/src/watermark/idle/source.rs
+++ b/rust/numaflow-core/src/watermark/idle/source.rs
@@ -161,7 +161,12 @@ impl SourceIdleDetector {
     /// Computes and returns the watermark value to publish for a partition.
     /// If partition is idle, increments the watermark. Otherwise returns the current value.
     /// Also updates the last published time.
-    pub(crate) fn compute_watermark(&mut self, partition: u16, computed_wm: i64) -> i64 {
+    pub(crate) fn compute_watermark(
+        &mut self,
+        partition: u16,
+        computed_wm: i64,
+        min_inflight_event_time: i64,
+    ) -> i64 {
         self.ensure_partition(partition);
 
         // If partition is not idle, just return the current watermark and update publish time
@@ -197,7 +202,7 @@ impl SourceIdleDetector {
         if let Some(state) = self.partition_states.get_mut(&partition) {
             state.last_wm_published_time = Utc::now();
         }
-        idle_wm
+        idle_wm.min(min_inflight_event_time)
     }
 }
 
@@ -269,11 +274,11 @@ mod tests {
         }
 
         // When idle with computed_wm = -1, should return -1 (no init_source_delay)
-        let wm = manager.compute_watermark(TEST_PARTITION, -1);
+        let wm = manager.compute_watermark(TEST_PARTITION, -1, -1);
         assert_eq!(wm, -1);
 
         // When idle with a valid computed_wm, should increment
-        let wm = manager.compute_watermark(TEST_PARTITION, 1000);
+        let wm = manager.compute_watermark(TEST_PARTITION, 1000, 1000);
         assert_eq!(wm, 1010);
     }
 
@@ -289,7 +294,7 @@ mod tests {
         manager.initialize_partitions(&[TEST_PARTITION]);
 
         // Partition is not idle, should return current watermark without increment
-        let wm = manager.compute_watermark(TEST_PARTITION, 1000);
+        let wm = manager.compute_watermark(TEST_PARTITION, 1000, 1000);
         assert_eq!(wm, 1000);
     }
 
@@ -312,7 +317,7 @@ mod tests {
 
         // Partition is idle, computed_wm = -1, but init_source_delay (200ms) hasn't passed
         // since updated_ts was only 100ms ago. Should return -1.
-        let wm = manager.compute_watermark(TEST_PARTITION, -1);
+        let wm = manager.compute_watermark(TEST_PARTITION, -1, -1);
         assert_eq!(wm, -1);
 
         // Now set updated_ts to 300ms ago so init_source_delay (200ms) has passed
@@ -321,7 +326,7 @@ mod tests {
         }
 
         // Since init_source_delay has passed, should return current time
-        let wm = manager.compute_watermark(TEST_PARTITION, -1);
+        let wm = manager.compute_watermark(TEST_PARTITION, -1, -1);
         let expected_wm = manager
             .partition_states
             .get(&TEST_PARTITION)
@@ -331,7 +336,7 @@ mod tests {
         assert_eq!(wm, expected_wm);
 
         // With a valid computed_wm, should increment
-        let wm = manager.compute_watermark(TEST_PARTITION, 1000);
+        let wm = manager.compute_watermark(TEST_PARTITION, 1000, 1000);
         assert_eq!(wm, 1010);
     }
 
@@ -354,7 +359,7 @@ mod tests {
         );
 
         // After computing watermark (which updates last published time), should be empty
-        manager.compute_watermark(TEST_PARTITION, 1000);
+        manager.compute_watermark(TEST_PARTITION, 1000, 1000);
         assert!(manager.partitions_needing_publish().is_empty());
 
         // After step interval passes, should include the partition again

--- a/rust/numaflow-core/src/watermark/source.rs
+++ b/rust/numaflow-core/src/watermark/source.rs
@@ -29,6 +29,7 @@ use crate::config::pipeline::watermark::SourceWatermarkConfig;
 use crate::config::pipeline::{ToVertexConfig, VertexType};
 use crate::error::Result;
 use crate::message::{IntOffset, MessageHandle, Offset};
+use crate::tracker::Tracker;
 use crate::watermark::idle::isb::ISBIdleDetector;
 use crate::watermark::idle::source::SourceIdleDetector;
 use crate::watermark::processor::manager::ProcessorManager;
@@ -74,6 +75,8 @@ struct SourceWatermarkState {
     /// Cache of partitions that have been active during the current interval.
     /// Used for ISB idle watermark publishing.
     active_input_partitions: HashMap<u16, bool>,
+    /// to reference the active in-flight messages
+    tracker: Tracker,
 }
 
 impl SourceWatermarkState {
@@ -83,6 +86,7 @@ impl SourceWatermarkState {
         fetcher: SourceWatermarkFetcher,
         isb_idle_manager: ISBIdleDetector,
         source_idle_manager: SourceIdleDetector,
+        tracker: Tracker,
     ) -> Self {
         Self {
             publisher,
@@ -90,6 +94,7 @@ impl SourceWatermarkState {
             isb_idle_manager,
             source_idle_manager,
             active_input_partitions: HashMap::new(),
+            tracker,
         }
     }
 
@@ -172,15 +177,28 @@ impl SourceWatermarkState {
         // publish to update KV entry timestamp which signals liveness to downstream vertices)
         let compute_wm = self.fetcher.fetch_source_watermark(None);
 
+        // Fetch min event_time from inflight messages.
+        let min_inflight_event_time = match self
+            .tracker
+            .lowest_event_time()
+            .await
+            .map(|v| v.timestamp_millis())
+        {
+            Ok(-1) | Err(_) => i64::MAX,
+            Ok(ts) => ts,
+        };
+
         // Process each partition that needs publishing
         for partition in partitions_needing_publish {
             // Check if this partition is truly idle (threshold passed)
             let is_idle = self.source_idle_manager.is_partition_idle(partition);
 
             // Compute the watermark value for this partition
-            let wm_value = self
-                .source_idle_manager
-                .compute_watermark(partition, compute_wm.timestamp_millis());
+            let wm_value = self.source_idle_manager.compute_watermark(
+                partition,
+                compute_wm.timestamp_millis(),
+                min_inflight_event_time,
+            );
 
             // Publish source watermark for this partition
             self.publisher
@@ -260,6 +278,7 @@ impl SourceWatermarkHandle {
         to_vertex_configs: &[ToVertexConfig],
         config: &SourceWatermarkConfig,
         cln_token: CancellationToken,
+        tracker: Tracker,
     ) -> Result<Self> {
         // Use step_interval from idle_config as the unified WMB delay
         let wmb_delay = config.idle_config.step_interval;
@@ -298,8 +317,13 @@ impl SourceWatermarkHandle {
         let isb_idle_manager =
             ISBIdleDetector::new(wmb_delay, to_vertex_configs, js_context.clone()).await;
 
-        let state =
-            SourceWatermarkState::new(publisher, fetcher, isb_idle_manager, source_idle_manager);
+        let state = SourceWatermarkState::new(
+            publisher,
+            fetcher,
+            isb_idle_manager,
+            source_idle_manager,
+            tracker,
+        );
 
         let source_watermark_handle = Self {
             state: Arc::new(Mutex::new(state)),
@@ -436,20 +460,18 @@ impl SourceWatermarkHandle {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
-    use async_nats::jetstream;
-    use async_nats::jetstream::kv::Config;
-    use async_nats::jetstream::stream;
-    use bytes::BytesMut;
-    use tokio::time::sleep;
-
     use super::*;
     use crate::config::pipeline::VertexType;
     use crate::config::pipeline::isb::BufferWriterConfig;
     use crate::config::pipeline::watermark::{BucketConfig, IdleConfig};
     use crate::message::IntOffset;
     use crate::watermark::wmb::WMB;
+    use async_nats::jetstream;
+    use async_nats::jetstream::kv::Config;
+    use async_nats::jetstream::stream;
+    use bytes::BytesMut;
+    use std::time::Duration;
+    use tokio::time::sleep;
 
     #[cfg(feature = "nats-tests")]
     #[tokio::test]
@@ -481,11 +503,14 @@ mod tests {
             .await
             .unwrap();
 
+        let cln_token = CancellationToken::new();
+
         let handle = SourceWatermarkHandle::new(
             js_context.clone(),
             Default::default(),
             &source_config,
-            CancellationToken::new(),
+            cln_token.clone(),
+            Tracker::new(None, cln_token),
         )
         .await
         .expect("Failed to create source watermark handle");
@@ -594,6 +619,8 @@ mod tests {
             .await
             .unwrap();
 
+        let cln_token = CancellationToken::new();
+
         let handle = SourceWatermarkHandle::new(
             js_context.clone(),
             &[ToVertexConfig {
@@ -612,7 +639,8 @@ mod tests {
                 ordered_processing_enabled: false,
             }],
             &source_config,
-            CancellationToken::new(),
+            cln_token.clone(),
+            Tracker::new(None, cln_token),
         )
         .await
         .expect("Failed to create source watermark handle");
@@ -759,6 +787,8 @@ mod tests {
             init_source_delay: None,
         };
 
+        let cln_token = CancellationToken::new();
+
         let handle = SourceWatermarkHandle::new(
             js_context.clone(),
             &to_vertex_configs,
@@ -768,7 +798,8 @@ mod tests {
                 to_vertex_bucket_config: vec![to_vertex_bucket_config],
                 idle_config: source_idle_config,
             },
-            CancellationToken::new(),
+            cln_token.clone(),
+            Tracker::new(None, cln_token),
         )
         .await
         .expect("Failed to create SourceWatermarkHandle");
@@ -912,6 +943,8 @@ mod tests {
             init_source_delay: None,
         };
 
+        let cln_token = CancellationToken::new();
+
         let handle = SourceWatermarkHandle::new(
             js_context.clone(),
             &to_vertex_configs,
@@ -921,7 +954,8 @@ mod tests {
                 to_vertex_bucket_config: vec![to_vertex_bucket_config],
                 idle_config: source_idle_config,
             },
-            CancellationToken::new(),
+            cln_token.clone(),
+            Tracker::new(None, cln_token),
         )
         .await
         .expect("Failed to create SourceWatermarkHandle");
@@ -1049,11 +1083,14 @@ mod tests {
             .await
             .unwrap();
 
+        let cln_token = CancellationToken::new();
+
         let handle = SourceWatermarkHandle::new(
             js_context.clone(),
             Default::default(),
             &source_config,
-            CancellationToken::new(),
+            cln_token.clone(),
+            Tracker::new(None, cln_token),
         )
         .await
         .expect("Failed to create source watermark handle");


### PR DESCRIPTION
### What this PR does / why we need it

As described in the linked issue, the background task responsible for publishing idle watermarks can increment the head WMB in source-OT, and subsequently in ISB-OT, even when there are messages in-flight, just that they're taking too long to be written to the ISB stream. 
The issue arises since the source idle manager only has the view of ```When was the last time any messages was published to a particular source partition?```, it doesn't care what is happening with the messages that have already been read and are still inflight. 

The ISB reader handles this correctly by finding out the [lowest watermark among in-flight messages](https://github.com/numaproj/numaflow/blob/27e11afbe8e05c115fe14d1e4ff24575d352dc5f/rust/numaflow-core/src/watermark/isb.rs#L193-L198) and incorporating that info as well when calculating the watermark to publish. 
```rust
// if window manager is not configured, we should use the lowest watermark among all the
// inflight messages.
self.get_lowest_watermark()
    .await
    .unwrap_or(Watermark::from_timestamp_millis(-1).unwrap())
```
 
This in turn calls the tracker to infer the lowest watermark:
```rust
/// Gets the lowest watermark among all the inflight requests using the tracker
async fn get_lowest_watermark(&self) -> Option<Watermark> {
    if let Ok(lowest_watermark) = self.tracker.lowest_watermark().await {
        Some(Watermark::from_timestamp_millis(lowest_watermark.timestamp_millis()).unwrap())
    } else {
        None
    }
}
```

At source, we cannot infer the lowest watermark using the tracker because at the time of message insertion into the tracker, we haven't assigned watermark to the messages yet, as they're fresh off of the [read call](https://github.com/numaproj/numaflow/blob/27e11afbe8e05c115fe14d1e4ff24575d352dc5f/rust/numaflow-core/src/source.rs#L502-L531).

Thus, we'll need to also track `event_time` of the messages in the tracker and use it for watermark publishing. But, since the event_times can be out of order at the source, we need to find the min `event_time` across all the in-flight messages in the tracker (and not just the ones with min offset like we do to get min watermark). 

### Related issues
Fixes #3399

### Testing
This PR was tested using the validation framework. 

### Special notes for reviewers
Anything notable for review (risk, rollout, follow-ups).

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
