### PR TITLE
fix: race between udf server processing and msg id insertion in map for tracking

### DIFF
--- a/rust/numaflow-core/src/mapper/map/batch.rs
+++ b/rust/numaflow-core/src/mapper/map/batch.rs
@@ -1,6 +1,6 @@
 use super::{
-    ParentMessageInfo, UserDefinedMessage, create_response_stream, update_udf_error_metric,
-    update_udf_process_time_metric, update_udf_read_metric, update_udf_write_metric,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
+    update_udf_write_metric, ParentMessageInfo, UserDefinedMessage,
 };
 use crate::config::is_mono_vertex;
 use crate::config::pipeline::VERTEX_TYPE_MAP_UDF;
@@ -9,7 +9,7 @@ use crate::message::{Message, MessageHandle};
 use crate::monovertex::bypass_router::MvtxBypassRouter;
 use crate::tracker::Tracker;
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
+use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -17,8 +17,8 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::Streaming;
 use tonic::transport::Channel;
+use tonic::Streaming;
 use tracing::{error, warn};
 
 /// Type alias for the batch response - raw results from the UDF
@@ -262,10 +262,13 @@ impl UserDefinedBatchMap {
         };
 
         if let Some(sender) = sender_entry {
-            sender.send(Ok(resp.results)).expect(
-                "Failed to send server response from receiver to batch task. \
-                Receiver will shutdown now",
-            );
+            if let Err(e) = sender.send(Ok(resp.results)) {
+                return Err(Error::Mapper(format!(
+                    "Failed to send server response from receiver to batch task \
+                    for ID: {} with error: {:?}. Receiver should shutdown now",
+                    msg_id, e
+                )));
+            };
         } else {
             return Err(Error::Mapper(format!(
                 "No such req/resp ID found in batch ResponseSenderMap: {}",

--- a/rust/numaflow-core/src/mapper/map/batch.rs
+++ b/rust/numaflow-core/src/mapper/map/batch.rs
@@ -294,8 +294,8 @@ impl UserDefinedBatchMap {
             // send the message to the server
             if let Err(e) = self.read_tx.send(request).await {
                 error!(?e, "Failed to send message to server");
-                // We should ideally remove the resp.id from the SenderMap to
-                // avoid potential memory leaks.
+                // We should ideally remove the resp.id from the SenderMap to avoid potential
+                // memory leaks as well as to avoid holding the corresponding receiver waiting
                 let sender_entry = {
                     self.senders
                         .lock()

--- a/rust/numaflow-core/src/mapper/map/batch.rs
+++ b/rust/numaflow-core/src/mapper/map/batch.rs
@@ -224,12 +224,7 @@ impl UserDefinedBatchMap {
                     }
 
                     if let Err(e) = Self::process_response(&sender_map, resp) {
-                        error!(
-                            "received error while processing batch response: {}. \
-                        Exiting receiver task",
-                            e
-                        );
-                        break;
+                        warn!("received error while processing batch response: {}", e);
                     }
                 }
                 Err(e) => {
@@ -262,11 +257,10 @@ impl UserDefinedBatchMap {
         };
 
         if let Some(sender) = sender_entry {
-            if let Err(e) = sender.send(Ok(resp.results)) {
+            if sender.send(Ok(resp.results)).is_err() {
                 return Err(Error::Mapper(format!(
-                    "Failed to send server response from receiver to batch task \
-                    for ID: {} with error: {:?}. Receiver should shutdown now",
-                    msg_id, e
+                    "Failed to send server response from receiver to batch task for ID: {}",
+                    msg_id
                 )));
             };
         } else {
@@ -312,7 +306,7 @@ impl UserDefinedBatchMap {
 
             // send the message to the server
             if let Err(e) = self.read_tx.send(request).await {
-                error!(?e, "Failed to send message to server");
+                warn!(?e, "Failed to send message to server");
                 // We should ideally remove the resp.id from the SenderMap to avoid potential
                 // memory leaks as well as to avoid holding the corresponding receiver waiting
                 let sender_entry = {

--- a/rust/numaflow-core/src/mapper/map/batch.rs
+++ b/rust/numaflow-core/src/mapper/map/batch.rs
@@ -247,9 +247,10 @@ impl UserDefinedBatchMap {
         };
 
         if let Some(sender) = sender_entry {
-            sender
-                .send(Ok(resp.results))
-                .expect("failed to send response");
+            sender.send(Ok(resp.results)).expect(
+                "Failed to send server response from receiver to batch task. \
+                Receiver will shutdown now",
+            );
         } else {
             warn!(
                 ?msg_id,

--- a/rust/numaflow-core/src/mapper/map/batch.rs
+++ b/rust/numaflow-core/src/mapper/map/batch.rs
@@ -372,15 +372,21 @@ impl UserDefinedBatchMap {
 
 #[cfg(test)]
 mod tests {
-    use crate::mapper::map::batch::UserDefinedBatchMap;
+    use crate::error::Error as MapError;
+    use crate::mapper::map::batch::{BatchSenderMapState, UserDefinedBatchMap};
     use crate::shared::grpc::create_rpc_channel;
     use numaflow::batchmap;
     use numaflow::batchmap::Server;
     use numaflow::shared::ServerExtras;
     use numaflow_pb::clients::map::map_client::MapClient;
+    use numaflow_pb::clients::map::{MapRequest, MapResponse};
     use std::error::Error;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tempfile::TempDir;
+    use tokio::sync::{mpsc, oneshot};
+    use tokio_util::sync::CancellationToken;
+    use tokio_util::task::AbortOnDropHandle;
 
     struct SimpleBatchMap;
 
@@ -503,5 +509,128 @@ mod tests {
             "Expected gRPC server to have shut down"
         );
         Ok(())
+    }
+
+    fn make_response(id: &str) -> MapResponse {
+        MapResponse {
+            results: vec![],
+            id: id.to_string(),
+            handshake: None,
+            status: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn process_response_returns_error_when_no_sender_entry() {
+        let sender_map = Arc::new(Mutex::new(BatchSenderMapState::default()));
+
+        let result = UserDefinedBatchMap::process_response(&sender_map, make_response("missing"));
+
+        let err = result.expect_err("expected error when sender entry missing");
+        assert!(matches!(err, MapError::Mapper(_)));
+        assert!(
+            err.to_string()
+                .contains("No such req/resp ID found in batch ResponseSenderMap"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_response_returns_error_when_oneshot_send_fails() {
+        let sender_map = Arc::new(Mutex::new(BatchSenderMapState::default()));
+        let (tx, rx) = oneshot::channel();
+        // Drop the receiver so the next send on tx fails.
+        drop(rx);
+        sender_map.lock().unwrap().map.insert("0".to_string(), tx);
+
+        let result = UserDefinedBatchMap::process_response(&sender_map, make_response("0"));
+
+        let err = result.expect_err("expected error when oneshot send fails");
+        assert!(matches!(err, MapError::Mapper(_)));
+        assert!(
+            err.to_string()
+                .contains("Failed to send server response from receiver to batch task"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn broadcast_error_marks_closed_and_errors_all_senders() {
+        let sender_map = Arc::new(Mutex::new(BatchSenderMapState::default()));
+        let (tx_a, rx_a) = oneshot::channel();
+        let (tx_b, rx_b) = oneshot::channel();
+        {
+            let mut guard = sender_map.lock().unwrap();
+            guard.map.insert("a".to_string(), tx_a);
+            guard.map.insert("b".to_string(), tx_b);
+        }
+
+        UserDefinedBatchMap::broadcast_error(&sender_map, tonic::Status::aborted("test"));
+
+        {
+            let guard = sender_map.lock().unwrap();
+            assert!(guard.closed, "broadcast_error should set closed = true");
+            assert!(guard.map.is_empty(), "all senders should be drained");
+        }
+
+        for rx in [rx_a, rx_b] {
+            let received = rx.await.expect("oneshot sender should have delivered");
+            let err = received.expect_err("expected Err variant");
+            assert!(matches!(err, MapError::Grpc(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_method_cleans_up_on_read_tx_send_failure() {
+        // Build a UserDefinedBatchMap whose read_tx receiver has been dropped,
+        // so that read_tx.send(..) inside `batch` fails immediately.
+        let (read_tx, read_rx) = mpsc::channel::<MapRequest>(10);
+        drop(read_rx);
+
+        let dummy_handle = tokio::spawn(async {});
+        let _abort_handle = Arc::new(AbortOnDropHandle::new(dummy_handle));
+
+        let senders = Arc::new(Mutex::new(BatchSenderMapState::default()));
+        let mapper = UserDefinedBatchMap {
+            read_tx,
+            senders: Arc::clone(&senders),
+            _handle: _abort_handle,
+        };
+
+        let request = MapRequest {
+            request: Some(numaflow_pb::clients::map::map_request::Request {
+                keys: vec!["k".into()],
+                value: b"v".to_vec(),
+                event_time: None,
+                watermark: None,
+                headers: Default::default(),
+                metadata: None,
+            }),
+            id: "42".to_string(),
+            handshake: None,
+            status: None,
+        };
+
+        let results = mapper.batch(vec![request], CancellationToken::new()).await;
+
+        // batch() returns vec![error] on first failure (early return).
+        assert_eq!(results.len(), 1);
+        let err = results
+            .into_iter()
+            .next()
+            .unwrap()
+            .expect_err("expected Mapper error from batch()");
+        assert!(matches!(err, MapError::Mapper(_)));
+        assert!(
+            err.to_string()
+                .contains("failed to send message to batch map server"),
+            "unexpected error message: {err}"
+        );
+
+        // The senders map must no longer contain the failed request id.
+        assert!(
+            !senders.lock().unwrap().map.contains_key("42"),
+            "senders map should be cleaned up on read_tx send failure"
+        );
     }
 }

--- a/rust/numaflow-core/src/mapper/map/batch.rs
+++ b/rust/numaflow-core/src/mapper/map/batch.rs
@@ -226,6 +226,7 @@ impl UserDefinedBatchMap {
                     if let Err(e) = Self::process_response(&sender_map, resp) {
                         error!("received error while processing batch response: {}. \
                         Exiting receiver task", e);
+                        Self::broadcast_error(&sender_map, tonic::Status::aborted("receiver stream dropped"));
                         break;
                     }
                 }

--- a/rust/numaflow-core/src/mapper/map/batch.rs
+++ b/rust/numaflow-core/src/mapper/map/batch.rs
@@ -19,7 +19,7 @@ use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
 use tonic::Streaming;
 use tonic::transport::Channel;
-use tracing::error;
+use tracing::{error, warn};
 
 /// Type alias for the batch response - raw results from the UDF
 pub(in crate::mapper) type BatchMapResponse = Vec<map::map_response::Result>;
@@ -223,7 +223,7 @@ impl UserDefinedBatchMap {
                         continue;
                     }
 
-                    Self::process_response(&sender_map, resp).await
+                    Self::process_response(&sender_map, resp)
                 }
                 Err(e) => {
                     error!(?e, "Error reading message from batch map gRPC stream");
@@ -235,19 +235,26 @@ impl UserDefinedBatchMap {
 
     /// Processes the response from the server and sends it to the appropriate oneshot sender
     /// based on the message id entry in the map.
-    async fn process_response(sender_map: &Arc<Mutex<BatchSenderMapState>>, resp: MapResponse) {
+    fn process_response(sender_map: &Arc<Mutex<BatchSenderMapState>>, resp: MapResponse) {
         let msg_id = resp.id;
 
-        let sender_entry = sender_map
-            .lock()
-            .expect("failed to acquire poisoned lock")
-            .map
-            .remove(&msg_id);
+        let sender_entry = {
+            sender_map
+                .lock()
+                .expect("failed to acquire poisoned lock")
+                .map
+                .remove(&msg_id)
+        };
 
         if let Some(sender) = sender_entry {
             sender
                 .send(Ok(resp.results))
                 .expect("failed to send response");
+        } else {
+            warn!(
+                ?msg_id,
+                "No such req/resp ID found in batch ResponseSenderMap"
+            );
         }
     }
 
@@ -264,27 +271,50 @@ impl UserDefinedBatchMap {
         for (request, sender) in requests.into_iter().zip(senders) {
             let key = request.id.clone();
 
-            // only insert if we are able to send the message to the server
+            // Move the senders_guard out of the scope to drop the guard when done.
+            // Do this before we send the message to the server to avoid the race condition
+            // where the server processes the message faster than the corresponding sender
+            // is added to the SenderMap.
+            {
+                let mut senders_guard = self
+                    .senders
+                    .lock()
+                    .expect("failed to acquire poisoned lock");
+                if !senders_guard.closed {
+                    senders_guard.map.insert(key.clone(), sender);
+                } else {
+                    let _ = sender
+                        .send(Err(Error::Mapper("batch mapper closed".to_string())))
+                        .inspect(|_| warn!("failed to send error to oneshot receiver"));
+                    continue;
+                }
+            };
+
+            // send the message to the server
             if let Err(e) = self.read_tx.send(request).await {
                 error!(?e, "Failed to send message to server");
-                let _ = sender.send(Err(Error::Mapper(format!(
-                    "failed to send message to batch map server: {e}"
-                ))));
+                // We should ideally remove the resp.id from the SenderMap to
+                // avoid potential memory leaks.
+                let sender_entry = {
+                    self.senders
+                        .lock()
+                        .expect("failed to acquire poisoned lock")
+                        .map
+                        .remove(&key)
+                };
+
+                // We should send error on the sender so the first receiver receiving the error
+                // returns early with the collected results.
+                if let Some(sender) = sender_entry {
+                    let _ = sender
+                        .send(Err(Error::Mapper(format!(
+                            "failed to send message to batch map server: {e}"
+                        ))))
+                        .inspect(|_| warn!("failed to send error to oneshot receiver"));
+                }
                 // Continue collecting results for remaining receivers
                 break;
             }
-
-            let mut senders_guard = self
-                .senders
-                .lock()
-                .expect("failed to acquire poisoned lock");
-
-            if senders_guard.closed {
-                let _ = sender.send(Err(Error::Mapper("mapper closed".to_string())));
-                continue;
-            }
-
-            senders_guard.map.insert(key, sender);
         }
 
         // send eot request

--- a/rust/numaflow-core/src/mapper/map/batch.rs
+++ b/rust/numaflow-core/src/mapper/map/batch.rs
@@ -226,7 +226,6 @@ impl UserDefinedBatchMap {
                     if let Err(e) = Self::process_response(&sender_map, resp) {
                         error!("received error while processing batch response: {}. \
                         Exiting receiver task", e);
-                        Self::broadcast_error(&sender_map, tonic::Status::aborted("receiver stream dropped"));
                         break;
                     }
                 }
@@ -236,6 +235,8 @@ impl UserDefinedBatchMap {
                 }
             }
         }
+
+        Self::broadcast_error(&sender_map, tonic::Status::aborted("receiver stream dropped"));
     }
 
     /// Processes the response from the server and sends it to the appropriate oneshot sender

--- a/rust/numaflow-core/src/mapper/map/batch.rs
+++ b/rust/numaflow-core/src/mapper/map/batch.rs
@@ -1,6 +1,6 @@
 use super::{
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
-    update_udf_write_metric, ParentMessageInfo, UserDefinedMessage,
+    ParentMessageInfo, UserDefinedMessage, create_response_stream, update_udf_error_metric,
+    update_udf_process_time_metric, update_udf_read_metric, update_udf_write_metric,
 };
 use crate::config::is_mono_vertex;
 use crate::config::pipeline::VERTEX_TYPE_MAP_UDF;
@@ -9,7 +9,7 @@ use crate::message::{Message, MessageHandle};
 use crate::monovertex::bypass_router::MvtxBypassRouter;
 use crate::tracker::Tracker;
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
+use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -17,8 +17,8 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::transport::Channel;
 use tonic::Streaming;
+use tonic::transport::Channel;
 use tracing::{error, warn};
 
 /// Type alias for the batch response - raw results from the UDF
@@ -224,8 +224,11 @@ impl UserDefinedBatchMap {
                     }
 
                     if let Err(e) = Self::process_response(&sender_map, resp) {
-                        error!("received error while processing batch response: {}. \
-                        Exiting receiver task", e);
+                        error!(
+                            "received error while processing batch response: {}. \
+                        Exiting receiver task",
+                            e
+                        );
                         break;
                     }
                 }
@@ -236,12 +239,18 @@ impl UserDefinedBatchMap {
             }
         }
 
-        Self::broadcast_error(&sender_map, tonic::Status::aborted("receiver stream dropped"));
+        Self::broadcast_error(
+            &sender_map,
+            tonic::Status::aborted("receiver stream dropped"),
+        );
     }
 
     /// Processes the response from the server and sends it to the appropriate oneshot sender
     /// based on the message id entry in the map.
-    fn process_response(sender_map: &Arc<Mutex<BatchSenderMapState>>, resp: MapResponse) -> Result<()> {
+    fn process_response(
+        sender_map: &Arc<Mutex<BatchSenderMapState>>,
+        resp: MapResponse,
+    ) -> Result<()> {
         let msg_id = resp.id;
 
         let sender_entry = {
@@ -258,7 +267,10 @@ impl UserDefinedBatchMap {
                 Receiver will shutdown now",
             );
         } else {
-            return Err(Error::Mapper(format!("No such req/resp ID found in batch ResponseSenderMap: {}", msg_id)));
+            return Err(Error::Mapper(format!(
+                "No such req/resp ID found in batch ResponseSenderMap: {}",
+                msg_id
+            )));
         }
         Ok(())
     }

--- a/rust/numaflow-core/src/mapper/map/batch.rs
+++ b/rust/numaflow-core/src/mapper/map/batch.rs
@@ -1,6 +1,6 @@
 use super::{
-    ParentMessageInfo, UserDefinedMessage, create_response_stream, update_udf_error_metric,
-    update_udf_process_time_metric, update_udf_read_metric, update_udf_write_metric,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
+    update_udf_write_metric, ParentMessageInfo, UserDefinedMessage,
 };
 use crate::config::is_mono_vertex;
 use crate::config::pipeline::VERTEX_TYPE_MAP_UDF;
@@ -9,7 +9,7 @@ use crate::message::{Message, MessageHandle};
 use crate::monovertex::bypass_router::MvtxBypassRouter;
 use crate::tracker::Tracker;
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
+use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -17,8 +17,8 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::Streaming;
 use tonic::transport::Channel;
+use tonic::Streaming;
 use tracing::{error, warn};
 
 /// Type alias for the batch response - raw results from the UDF
@@ -223,7 +223,11 @@ impl UserDefinedBatchMap {
                         continue;
                     }
 
-                    Self::process_response(&sender_map, resp)
+                    if let Err(e) = Self::process_response(&sender_map, resp) {
+                        error!("received error while processing batch response: {}. \
+                        Exiting receiver task", e);
+                        break;
+                    }
                 }
                 Err(e) => {
                     error!(?e, "Error reading message from batch map gRPC stream");
@@ -235,7 +239,7 @@ impl UserDefinedBatchMap {
 
     /// Processes the response from the server and sends it to the appropriate oneshot sender
     /// based on the message id entry in the map.
-    fn process_response(sender_map: &Arc<Mutex<BatchSenderMapState>>, resp: MapResponse) {
+    fn process_response(sender_map: &Arc<Mutex<BatchSenderMapState>>, resp: MapResponse) -> Result<()> {
         let msg_id = resp.id;
 
         let sender_entry = {
@@ -252,11 +256,9 @@ impl UserDefinedBatchMap {
                 Receiver will shutdown now",
             );
         } else {
-            warn!(
-                ?msg_id,
-                "No such req/resp ID found in batch ResponseSenderMap"
-            );
+            return Err(Error::Mapper(format!("No such req/resp ID found in batch ResponseSenderMap: {}", msg_id)));
         }
+        Ok(())
     }
 
     /// Sends a batch of messages to the UDF and returns the raw response results.

--- a/rust/numaflow-core/src/mapper/map/batch.rs
+++ b/rust/numaflow-core/src/mapper/map/batch.rs
@@ -1,6 +1,6 @@
 use super::{
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
-    update_udf_write_metric, ParentMessageInfo, UserDefinedMessage,
+    ParentMessageInfo, UserDefinedMessage, create_response_stream, update_udf_error_metric,
+    update_udf_process_time_metric, update_udf_read_metric, update_udf_write_metric,
 };
 use crate::config::is_mono_vertex;
 use crate::config::pipeline::VERTEX_TYPE_MAP_UDF;
@@ -9,7 +9,7 @@ use crate::message::{Message, MessageHandle};
 use crate::monovertex::bypass_router::MvtxBypassRouter;
 use crate::tracker::Tracker;
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
+use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -17,8 +17,8 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::transport::Channel;
 use tonic::Streaming;
+use tonic::transport::Channel;
 use tracing::{error, warn};
 
 /// Type alias for the batch response - raw results from the UDF

--- a/rust/numaflow-core/src/mapper/map/batch.rs
+++ b/rust/numaflow-core/src/mapper/map/batch.rs
@@ -299,7 +299,7 @@ impl UserDefinedBatchMap {
                 } else {
                     let _ = sender
                         .send(Err(Error::Mapper("batch mapper closed".to_string())))
-                        .inspect(|_| warn!("failed to send error to oneshot receiver"));
+                        .inspect_err(|_| warn!("failed to send error to oneshot receiver"));
                     continue;
                 }
             };
@@ -324,7 +324,7 @@ impl UserDefinedBatchMap {
                         .send(Err(Error::Mapper(format!(
                             "failed to send message to batch map server: {e}"
                         ))))
-                        .inspect(|_| warn!("failed to send error to oneshot receiver"));
+                        .inspect_err(|_| warn!("failed to send error to oneshot receiver"));
                 }
                 // Continue collecting results for remaining receivers
                 break;

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -229,16 +229,41 @@ impl UserDefinedStreamMap {
                     }
 
                     if let Some(response_sender) = response_sender_entry {
-                        Self::process_stream_response(
-                            &sender_map,
-                            resp.id,
-                            response_sender,
-                            resp.results,
-                        )
-                        .await
+                        // move the senders_guard out of the scope to drop the guard before sending the response
+                        // Insert the sender back into the SenderMap to avoid yielding back control
+                        // to the tokio runtime during send on the actual sender
+                        let mapper_closed = {
+                            let mut senders_guard =
+                                sender_map.lock().expect("failed to acquire poisoned lock");
+                            if !senders_guard.closed {
+                                // Write the sender back to the map, because we need to send
+                                // more responses for the same request
+                                senders_guard
+                                    .map
+                                    .insert(resp.id.clone(), response_sender.clone());
+                            }
+                            senders_guard.closed
+                        };
+
+                        if mapper_closed {
+                            let _ = response_sender
+                                .send(Err(Error::Mapper("mapper closed".to_string())))
+                                .await;
+                        }
+
+                        if let Err(e) = response_sender.send(Ok(resp.results)).await {
+                            error!(?e, "Failed to send map response to stream actor");
+                            {
+                                sender_map
+                                    .lock()
+                                    .expect("failed to acquire poisoned lock")
+                                    .map
+                                    .remove(&resp.id);
+                            }
+                        }
                     } else {
                         warn!(
-                            ?resp,
+                            ?resp.id,
                             "No such req/resp ID found in StreamResponseSenderMap. \
                             No further responses will be streamed for this ID"
                         );
@@ -329,36 +354,6 @@ impl UserDefinedStreamMap {
         }
 
         rx
-    }
-
-    /// Processes stream responses and sends them to the appropriate mpsc sender
-    async fn process_stream_response(
-        sender_map: &Arc<Mutex<StreamSenderMapState>>,
-        msg_id: String,
-        response_sender: mpsc::Sender<Result<StreamMapResponse>>,
-        results: Vec<map::map_response::Result>,
-    ) {
-        response_sender
-            .send(Ok(results))
-            .await
-            .expect("failed to send response");
-
-        // move the senders_guard out of the scope to drop the guard before sending the response
-        let mapper_closed = {
-            let mut senders_guard = sender_map.lock().expect("failed to acquire poisoned lock");
-            if !senders_guard.closed {
-                // Write the sender back to the map, because we need to send
-                // more responses for the same request
-                senders_guard.map.insert(msg_id, response_sender.clone());
-            }
-            senders_guard.closed
-        };
-
-        if mapper_closed {
-            let _ = response_sender
-                .send(Err(Error::Mapper("mapper closed".to_string())))
-                .await;
-        }
     }
 }
 

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -371,7 +371,7 @@ impl UserDefinedStreamMap {
                     "failed to send message to map stream server: {e}"
                 ))))
                 .await
-                .inspect(|_| warn!("failed to send error to receiver"));
+                .inspect_err(|_| warn!("failed to send error to receiver"));
         }
 
         rx

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -214,8 +214,7 @@ impl UserDefinedStreamMap {
             match resp {
                 Ok(resp) => {
                     if let Err(e) = Self::process_response(&sender_map, resp).await {
-                        error!("received error while processing stream response: {}", e);
-                        break;
+                        warn!("received error while processing stream response: {}", e);
                     }
                 }
                 Err(e) => {
@@ -234,6 +233,13 @@ impl UserDefinedStreamMap {
         .await;
     }
 
+    /// This method processes the response received from the stream map udf server
+    ///
+    /// The reason this method hasn't been subdivided is that we don't want to yield
+    /// back to the tokio runtime at any point between these three operations:
+    /// * remove id from sender map
+    /// * check for EOT
+    /// * re-insert id into sender map
     async fn process_response(
         sender_map: &Arc<Mutex<StreamSenderMapState>>,
         resp: MapResponse,
@@ -275,38 +281,23 @@ impl UserDefinedStreamMap {
                     .await;
             }
 
-            if let Err(e) = response_sender.send(Ok(resp.results)).await {
+            if response_sender.send(Ok(resp.results)).await.is_err() {
                 {
                     let mut sender_guard =
                         sender_map.lock().expect("failed to acquire poisoned lock");
 
                     // Remove the sender to avoid keeping the corresponding receiver waiting
                     sender_guard.map.remove(&resp.id);
-
-                    // Mark the sender map closed for any further insertions
-                    sender_guard.closed = true;
                 }
 
-                // Initiate exit out of the receiver task to let any future senders
-                // error out and teardown the map stream client
                 return Err(Error::Mapper(format!(
-                    "Failed to send map response to stream task due to error: {:?}. Exiting receiver task",
-                    e
+                    "Failed to send map response to stream task for ID: {:?}",
+                    resp.id
                 )));
             }
         } else {
-            {
-                // Mark the sender map closed for any further insertions
-                sender_map
-                    .lock()
-                    .expect("failed to acquire poisoned lock")
-                    .closed = true;
-            }
-            // Initiate exit out of the receiver task to let any future senders
-            // error out and teardown the map stream client
             return Err(Error::Mapper(format!(
-                "No such req/resp ID found in StreamResponseSenderMap: {}. \
-                            Exiting receiver task",
+                "No such req/resp ID found in StreamResponseSenderMap: {}",
                 resp.id
             )));
         }

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -213,80 +213,8 @@ impl UserDefinedStreamMap {
         while let Some(resp) = resp_stream.next().await {
             match resp {
                 Ok(resp) => {
-                    // TODO: move this whole block into a process_response method
-                    let response_sender_entry = {
-                        sender_map
-                            .lock()
-                            .expect("failed to acquire poisoned lock")
-                            .map
-                            .remove(&resp.id)
-                    };
-
-                    // once we get eot, we can drop the sender to let the callee
-                    // know that we are done sending responses
-                    if let Some(map::TransmissionStatus { eot: true }) = resp.status {
-                        update_udf_process_time_metric(is_mono_vertex());
-                        continue;
-                    }
-
-                    if let Some(response_sender) = response_sender_entry {
-                        // move the senders_guard out of the scope to drop the guard before sending the response
-                        // Insert the sender back into the SenderMap to avoid yielding back control
-                        // to the tokio runtime during send on the actual sender
-                        let mapper_closed = {
-                            let mut senders_guard =
-                                sender_map.lock().expect("failed to acquire poisoned lock");
-                            if !senders_guard.closed {
-                                // Write the sender back to the map, because we need to send
-                                // more responses for the same request
-                                senders_guard
-                                    .map
-                                    .insert(resp.id.clone(), response_sender.clone());
-                            }
-                            senders_guard.closed
-                        };
-
-                        if mapper_closed {
-                            let _ = response_sender
-                                .send(Err(Error::Mapper("mapper closed".to_string())))
-                                .await;
-                        }
-
-                        if let Err(e) = response_sender.send(Ok(resp.results)).await {
-                            error!(
-                                ?e,
-                                "Failed to send map response to stream task. Exiting receiver task"
-                            );
-                            {
-                                let mut sender_guard =
-                                    sender_map.lock().expect("failed to acquire poisoned lock");
-
-                                // Remove the sender to avoid keeping the corresponding receiver waiting
-                                sender_guard.map.remove(&resp.id);
-
-                                // Mark the sender map closed for any further insertions
-                                sender_guard.closed = true;
-                            }
-
-                            // Exit out of the receiver task to let any future senders error out and teardown
-                            // the map stream client
-                            break;
-                        }
-                    } else {
-                        error!(
-                            ?resp.id,
-                            "No such req/resp ID found in StreamResponseSenderMap. \
-                            Exiting receiver task"
-                        );
-                        {
-                            // Mark the sender map closed for any further insertions
-                            sender_map
-                                .lock()
-                                .expect("failed to acquire poisoned lock")
-                                .closed = true;
-                        }
-                        // Exit out of the receiver task to let any future senders error
-                        // out and teardown the map stream client
+                    if let Err(e) = Self::process_response(&sender_map, resp).await {
+                        error!("received error while processing stream response: {}", e);
                         break;
                     }
                 }
@@ -297,15 +225,93 @@ impl UserDefinedStreamMap {
             }
         }
 
-        // broadcast error for all pending senders that might've gotten added while the stream was draining
+        // broadcast error for all pending senders that might've gotten
+        // added while the stream was draining
         Self::broadcast_error(
             &sender_map,
             tonic::Status::aborted("receiver stream dropped"),
         )
         .await;
+    }
 
-        // TODO: REMOVE
-        warn!(?resp_stream, "udf receiver stream dropped");
+    async fn process_response(
+        sender_map: &Arc<Mutex<StreamSenderMapState>>,
+        resp: MapResponse,
+    ) -> Result<()> {
+        let response_sender_entry = {
+            sender_map
+                .lock()
+                .expect("failed to acquire poisoned lock")
+                .map
+                .remove(&resp.id)
+        };
+
+        // once we get eot, we can drop the sender to let the callee
+        // know that we are done sending responses
+        if let Some(map::TransmissionStatus { eot: true }) = resp.status {
+            update_udf_process_time_metric(is_mono_vertex());
+            return Ok(());
+        }
+
+        if let Some(response_sender) = response_sender_entry {
+            // move the senders_guard out of the scope to drop the guard before sending the response
+            // Insert the sender back into the SenderMap to avoid yielding back control
+            // to the tokio runtime during send on the actual sender
+            let mapper_closed = {
+                let mut senders_guard = sender_map.lock().expect("failed to acquire poisoned lock");
+                if !senders_guard.closed {
+                    // Write the sender back to the map, because we need to send
+                    // more responses for the same request
+                    senders_guard
+                        .map
+                        .insert(resp.id.clone(), response_sender.clone());
+                }
+                senders_guard.closed
+            };
+
+            if mapper_closed {
+                let _ = response_sender
+                    .send(Err(Error::Mapper("mapper closed".to_string())))
+                    .await;
+            }
+
+            if let Err(e) = response_sender.send(Ok(resp.results)).await {
+                {
+                    let mut sender_guard =
+                        sender_map.lock().expect("failed to acquire poisoned lock");
+
+                    // Remove the sender to avoid keeping the corresponding receiver waiting
+                    sender_guard.map.remove(&resp.id);
+
+                    // Mark the sender map closed for any further insertions
+                    sender_guard.closed = true;
+                }
+
+                // Initiate exit out of the receiver task to let any future senders
+                // error out and teardown the map stream client
+                return Err(Error::Mapper(format!(
+                    "Failed to send map response to stream task due to error: {:?}. Exiting receiver task",
+                    e
+                )));
+            }
+        } else {
+            {
+                // Mark the sender map closed for any further insertions
+                sender_map
+                    .lock()
+                    .expect("failed to acquire poisoned lock")
+                    .closed = true;
+            }
+            // Initiate exit out of the receiver task to let any future senders
+            // error out and teardown the map stream client
+            return Err(Error::Mapper(format!(
+                "No such req/resp ID found in StreamResponseSenderMap: {}. \
+                            Exiting receiver task",
+                resp.id
+            )));
+        }
+
+        Ok(())
     }
 
     /// Sends a request to the UDF and returns a receiver for raw response results.

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -213,12 +213,13 @@ impl UserDefinedStreamMap {
         while let Some(resp) = resp_stream.next().await {
             match resp {
                 Ok(resp) => {
-                    let response_sender = sender_map
-                        .lock()
-                        .expect("failed to acquire poisoned lock")
-                        .map
-                        .remove(&resp.id)
-                        .expect("map entry should always be present");
+                    let response_sender_entry = {
+                        sender_map
+                            .lock()
+                            .expect("failed to acquire poisoned lock")
+                            .map
+                            .remove(&resp.id)
+                    };
 
                     // once we get eot, we can drop the sender to let the callee
                     // know that we are done sending responses
@@ -227,13 +228,21 @@ impl UserDefinedStreamMap {
                         continue;
                     }
 
-                    Self::process_stream_response(
-                        &sender_map,
-                        resp.id,
-                        response_sender,
-                        resp.results,
-                    )
-                    .await
+                    if let Some(response_sender) = response_sender_entry {
+                        Self::process_stream_response(
+                            &sender_map,
+                            resp.id,
+                            response_sender,
+                            resp.results,
+                        )
+                        .await
+                    } else {
+                        warn!(
+                            ?resp,
+                            "No such req/resp ID found in StreamResponseSenderMap. \
+                            No further responses will be streamed for this ID"
+                        );
+                    }
                 }
                 Err(e) => {
                     error!(?e, "Error reading message from stream map gRPC stream");
@@ -272,19 +281,10 @@ impl UserDefinedStreamMap {
 
         let key = request.id.clone();
 
-        // only insert if we are able to send the message to the server
-        if let Err(e) = self.read_tx.send(request).await {
-            error!(?e, "Failed to send message to server");
-            let _ = tx
-                .send(Err(Error::Mapper(format!(
-                    "failed to send message to stream map server: {e}"
-                ))))
-                .await
-                .inspect(|_| warn!("failed to send error to oneshot receiver"));
-            return rx;
-        }
-
-        // move the senders_guard out of the scope to drop the guard before sending the response
+        // Move the senders_guard out of the scope to drop the guard before sending the response
+        // Do this before we send the message to the server to avoid the race condition
+        // where the server processes the message faster than the corresponding sender
+        // is added to the SenderMap.
         let mapper_closed = {
             let mut senders_guard = self
                 .senders
@@ -302,6 +302,30 @@ impl UserDefinedStreamMap {
             let _ = tx
                 .send(Err(Error::Mapper("mapper closed".to_string())))
                 .await;
+        }
+
+        // only insert if we are able to send the message to the server
+        if let Err(e) = self.read_tx.send(request).await {
+            error!(?e, "Failed to send message to map stream udf server");
+            // We should ideally remove the resp.id from the SenderMap to
+            // avoid potential memory leaks. We don't care about the return value
+            // since we already have access to the 'tx'
+            {
+                let _ = self
+                    .senders
+                    .lock()
+                    .expect("failed to acquire poisoned lock")
+                    .map
+                    .remove(&key);
+            };
+
+            // send error on 'tx'
+            let _ = tx
+                .send(Err(Error::Mapper(format!(
+                    "failed to send message to map stream server: {e}"
+                ))))
+                .await
+                .inspect(|_| warn!("failed to send error to receiver"));
         }
 
         rx

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -252,14 +252,25 @@ impl UserDefinedStreamMap {
                         }
 
                         if let Err(e) = response_sender.send(Ok(resp.results)).await {
-                            error!(?e, "Failed to send map response to stream actor");
+                            error!(
+                                ?e,
+                                "Failed to send map response to stream task. Exiting receiver task"
+                            );
                             {
-                                sender_map
-                                    .lock()
-                                    .expect("failed to acquire poisoned lock")
-                                    .map
-                                    .remove(&resp.id);
+                                let mut sender_guard =
+                                    sender_map.lock().expect("failed to acquire poisoned lock");
+
+                                // Remove the sender to avoid keeping the corresponding receiver waiting
+                                sender_guard.map.remove(&resp.id);
+
+                                // Mark the sender map closed for any further insertions
+                                sender_guard.closed = true;
                             }
+
+                            // Encountered error during sending message back to the stream execute task
+                            // Exit out of the receiver task to let any future senders error out and teardown
+                            // the map stream client
+                            break;
                         }
                     } else {
                         warn!(
@@ -282,6 +293,9 @@ impl UserDefinedStreamMap {
             tonic::Status::aborted("receiver stream dropped"),
         )
         .await;
+
+        // TODO: REMOVE
+        error!(?resp_stream, "udf receiver stream dropped");
     }
 
     /// Sends a request to the UDF and returns a receiver for raw response results.

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -381,14 +381,20 @@ impl UserDefinedStreamMap {
 
 #[cfg(test)]
 mod tests {
-    use crate::mapper::map::stream::UserDefinedStreamMap;
+    use crate::error::Error as MapError;
+    use crate::mapper::map::stream::{StreamSenderMapState, UserDefinedStreamMap};
     use crate::shared::grpc::create_rpc_channel;
     use numaflow::mapstream;
     use numaflow::shared::ServerExtras;
     use numaflow_pb::clients::map::map_client::MapClient;
+    use numaflow_pb::clients::map::{MapRequest, MapResponse, TransmissionStatus};
     use std::error::Error;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tempfile::TempDir;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+    use tokio_util::task::AbortOnDropHandle;
 
     struct FlatmapStream;
 
@@ -484,5 +490,188 @@ mod tests {
             "Expected gRPC server to have shut down"
         );
         Ok(())
+    }
+
+    fn make_response(id: &str, eot: bool) -> MapResponse {
+        MapResponse {
+            results: vec![],
+            id: id.to_string(),
+            handshake: None,
+            status: if eot {
+                Some(TransmissionStatus { eot: true })
+            } else {
+                None
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn process_response_returns_error_when_no_sender_entry() {
+        let sender_map = Arc::new(Mutex::new(StreamSenderMapState::default()));
+
+        let result =
+            UserDefinedStreamMap::process_response(&sender_map, make_response("missing", false))
+                .await;
+
+        let err = result.expect_err("expected error when sender entry missing");
+        assert!(matches!(err, MapError::Mapper(_)));
+        assert!(
+            err.to_string()
+                .contains("No such req/resp ID found in StreamResponseSenderMap"),
+            "unexpected error message: {err}"
+        );
+        assert!(sender_map.lock().unwrap().map.is_empty());
+    }
+
+    #[tokio::test]
+    async fn process_response_returns_error_when_response_sender_send_fails() {
+        let sender_map = Arc::new(Mutex::new(StreamSenderMapState::default()));
+        let (tx, rx) = mpsc::channel(1);
+        // Drop the receiver so the next send on tx fails.
+        drop(rx);
+        sender_map.lock().unwrap().map.insert("0".to_string(), tx);
+
+        let result =
+            UserDefinedStreamMap::process_response(&sender_map, make_response("0", false)).await;
+
+        let err = result.expect_err("expected error when send to response sender fails");
+        assert!(matches!(err, MapError::Mapper(_)));
+        assert!(
+            err.to_string()
+                .contains("Failed to send map response to stream task"),
+            "unexpected error message: {err}"
+        );
+        // The entry must be removed so the wrapper does not leak senders.
+        assert!(
+            !sender_map.lock().unwrap().map.contains_key("0"),
+            "sender entry should have been removed after send failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_response_signals_closed_mapper_on_response_sender() {
+        let sender_map = Arc::new(Mutex::new(StreamSenderMapState::default()));
+        let (tx, mut rx) = mpsc::channel(1);
+        {
+            let mut guard = sender_map.lock().unwrap();
+            guard.map.insert("0".to_string(), tx);
+            guard.closed = true;
+        }
+
+        let result =
+            UserDefinedStreamMap::process_response(&sender_map, make_response("0", false)).await;
+        assert!(result.is_ok(), "expected Ok when mapper is closed");
+
+        // Caller should see a "mapper closed" error on the response channel.
+        let received = rx.recv().await.expect("expected error on response channel");
+        let err = received.expect_err("expected Err variant");
+        assert!(matches!(err, MapError::Mapper(_)));
+        assert!(err.to_string().contains("mapper closed"));
+
+        // Closed-mapper path must not re-insert the sender.
+        assert!(
+            !sender_map.lock().unwrap().map.contains_key("0"),
+            "sender should not be re-inserted when mapper is closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_response_drops_sender_on_eot_without_error() {
+        let sender_map = Arc::new(Mutex::new(StreamSenderMapState::default()));
+        let (tx, mut rx) = mpsc::channel(1);
+        sender_map.lock().unwrap().map.insert("0".to_string(), tx);
+
+        let result =
+            UserDefinedStreamMap::process_response(&sender_map, make_response("0", true)).await;
+        assert!(result.is_ok(), "EOT path should return Ok");
+
+        // EOT does not deliver a payload to the response sender.
+        assert!(matches!(
+            rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected)
+        ));
+
+        // EOT removes the sender from the map (and never re-inserts it),
+        // letting the corresponding receiver loop terminate.
+        assert!(
+            !sender_map.lock().unwrap().map.contains_key("0"),
+            "sender entry should be removed after EOT"
+        );
+    }
+
+    #[tokio::test]
+    async fn broadcast_error_marks_closed_and_errors_all_senders() {
+        let sender_map = Arc::new(Mutex::new(StreamSenderMapState::default()));
+        let (tx_a, mut rx_a) = mpsc::channel(1);
+        let (tx_b, mut rx_b) = mpsc::channel(1);
+        {
+            let mut guard = sender_map.lock().unwrap();
+            guard.map.insert("a".to_string(), tx_a);
+            guard.map.insert("b".to_string(), tx_b);
+        }
+
+        UserDefinedStreamMap::broadcast_error(&sender_map, tonic::Status::aborted("test")).await;
+
+        {
+            let guard = sender_map.lock().unwrap();
+            assert!(guard.closed, "broadcast_error should set closed = true");
+            assert!(guard.map.is_empty(), "all senders should be drained");
+        }
+
+        for rx in [&mut rx_a, &mut rx_b] {
+            let received = rx.recv().await.expect("expected error broadcast");
+            let err = received.expect_err("expected Err variant");
+            assert!(matches!(err, MapError::Grpc(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_method_cleans_up_on_read_tx_send_failure() {
+        // Build a UserDefinedStreamMap whose read_tx receiver has been dropped,
+        // so that read_tx.send(..) inside `stream` fails immediately.
+        let (read_tx, read_rx) = mpsc::channel::<MapRequest>(10);
+        drop(read_rx);
+
+        let dummy_handle = tokio::spawn(async {});
+        let _abort_handle = Arc::new(AbortOnDropHandle::new(dummy_handle));
+
+        let senders = Arc::new(Mutex::new(StreamSenderMapState::default()));
+        let mapper = UserDefinedStreamMap {
+            read_tx,
+            senders: Arc::clone(&senders),
+            _handle: _abort_handle,
+        };
+
+        let request = MapRequest {
+            request: Some(numaflow_pb::clients::map::map_request::Request {
+                keys: vec!["k".into()],
+                value: b"v".to_vec(),
+                event_time: None,
+                watermark: None,
+                headers: Default::default(),
+                metadata: None,
+            }),
+            id: "42".to_string(),
+            handshake: None,
+            status: None,
+        };
+
+        let mut rx = mapper.stream(request, CancellationToken::new()).await;
+
+        // The receiver must observe the read_tx failure as a Mapper error.
+        let first = rx.recv().await.expect("expected error on stream rx");
+        let err = first.expect_err("expected Err variant");
+        assert!(matches!(err, MapError::Mapper(_)));
+        assert!(
+            err.to_string()
+                .contains("failed to send message to map stream server"),
+            "unexpected error message: {err}"
+        );
+
+        // The senders map must no longer contain the failed request id.
+        assert!(
+            !senders.lock().unwrap().map.contains_key("42"),
+            "senders map should be cleaned up on read_tx send failure"
+        );
     }
 }

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -279,6 +279,7 @@ impl UserDefinedStreamMap {
                 let _ = response_sender
                     .send(Err(Error::Mapper("mapper closed".to_string())))
                     .await;
+                return Ok(());
             }
 
             if response_sender.send(Ok(resp.results)).await.is_err() {

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -213,6 +213,7 @@ impl UserDefinedStreamMap {
         while let Some(resp) = resp_stream.next().await {
             match resp {
                 Ok(resp) => {
+                    // TODO: move this whole block into a process_response method
                     let response_sender_entry = {
                         sender_map
                             .lock()
@@ -267,17 +268,26 @@ impl UserDefinedStreamMap {
                                 sender_guard.closed = true;
                             }
 
-                            // Encountered error during sending message back to the stream execute task
                             // Exit out of the receiver task to let any future senders error out and teardown
                             // the map stream client
                             break;
                         }
                     } else {
-                        warn!(
+                        error!(
                             ?resp.id,
                             "No such req/resp ID found in StreamResponseSenderMap. \
-                            No further responses will be streamed for this ID"
+                            Exiting receiver task"
                         );
+                        {
+                            // Mark the sender map closed for any further insertions
+                            sender_map
+                                .lock()
+                                .expect("failed to acquire poisoned lock")
+                                .closed = true;
+                        }
+                        // Exit out of the receiver task to let any future senders error
+                        // out and teardown the map stream client
+                        break;
                     }
                 }
                 Err(e) => {
@@ -295,7 +305,7 @@ impl UserDefinedStreamMap {
         .await;
 
         // TODO: REMOVE
-        error!(?resp_stream, "udf receiver stream dropped");
+        warn!(?resp_stream, "udf receiver stream dropped");
     }
 
     /// Sends a request to the UDF and returns a receiver for raw response results.
@@ -346,9 +356,9 @@ impl UserDefinedStreamMap {
         // only insert if we are able to send the message to the server
         if let Err(e) = self.read_tx.send(request).await {
             error!(?e, "Failed to send message to map stream udf server");
-            // We should ideally remove the resp.id from the SenderMap to
-            // avoid potential memory leaks. We don't care about the return value
-            // since we already have access to the 'tx'
+            // We should ideally remove the resp.id from the SenderMap to avoid potential
+            // memory leaks as well as to avoid holding the corresponding receiver waiting.
+            // We don't care about the return value since we already have access to the 'tx'
             {
                 let _ = self
                     .senders

--- a/rust/numaflow-core/src/mapper/map/unary.rs
+++ b/rust/numaflow-core/src/mapper/map/unary.rs
@@ -6,18 +6,18 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
-use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit};
+use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
+use tokio::sync::{OwnedSemaphorePermit, mpsc, oneshot};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::transport::Channel;
 use tonic::Streaming;
+use tonic::transport::Channel;
 use tracing::{error, warn};
 
 use super::{
-    create_response_stream, update_udf_error_metric, update_udf_read_metric, update_udf_write_metric,
-    ParentMessageInfo, SharedMapTaskContext, UserDefinedMessage,
+    ParentMessageInfo, SharedMapTaskContext, UserDefinedMessage, create_response_stream,
+    update_udf_error_metric, update_udf_read_metric, update_udf_write_metric,
 };
 
 /// Type alias for the response - raw results from the UDF

--- a/rust/numaflow-core/src/mapper/map/unary.rs
+++ b/rust/numaflow-core/src/mapper/map/unary.rs
@@ -210,6 +210,7 @@ impl UserDefinedUnaryMap {
                     if let Err(e) = Self::process_unary_response(&sender_map, resp) {
                         error!("received error while processing unary response: {}. \
                         Exiting receiver task", e);
+                        Self::broadcast_error(&sender_map, tonic::Status::aborted("receiver stream dropped"));
                         break;
                     }
                 },

--- a/rust/numaflow-core/src/mapper/map/unary.rs
+++ b/rust/numaflow-core/src/mapper/map/unary.rs
@@ -254,7 +254,8 @@ impl UserDefinedUnaryMap {
         if let Err(e) = self.read_tx.send(request).await {
             error!(?e, "Failed to send message to server");
             // We should remove the resp.id from the SenderMap to avoid potential
-            // memory leaks. We don't care about sending the error on the sender popped
+            // memory leaks as well as to avoid holding the corresponding receiver waiting.
+            // We don't care about sending the error on the sender popped
             // from the map since we're returning early with error anyway.
             {
                 let _ = self

--- a/rust/numaflow-core/src/mapper/map/unary.rs
+++ b/rust/numaflow-core/src/mapper/map/unary.rs
@@ -6,18 +6,18 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
-use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit};
+use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
+use tokio::sync::{OwnedSemaphorePermit, mpsc, oneshot};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::transport::Channel;
 use tonic::Streaming;
+use tonic::transport::Channel;
 use tracing::{error, warn};
 
 use super::{
-    create_response_stream, update_udf_error_metric, update_udf_read_metric, update_udf_write_metric,
-    ParentMessageInfo, SharedMapTaskContext, UserDefinedMessage,
+    ParentMessageInfo, SharedMapTaskContext, UserDefinedMessage, create_response_stream,
+    update_udf_error_metric, update_udf_read_metric, update_udf_write_metric,
 };
 
 /// Type alias for the response - raw results from the UDF
@@ -208,11 +208,14 @@ impl UserDefinedUnaryMap {
             match resp {
                 Ok(resp) => {
                     if let Err(e) = Self::process_unary_response(&sender_map, resp) {
-                        error!("received error while processing unary response: {}. \
-                        Exiting receiver task", e);
+                        error!(
+                            "received error while processing unary response: {}. \
+                        Exiting receiver task",
+                            e
+                        );
                         break;
                     }
-                },
+                }
                 Err(e) => {
                     error!(?e, "Error reading message from unary map gRPC stream");
                     Self::broadcast_error(&sender_map, e);
@@ -299,7 +302,7 @@ impl UserDefinedUnaryMap {
     pub(super) fn process_unary_response(
         sender_map: &Arc<Mutex<UnarySenderMapState>>,
         resp: MapResponse,
-    ) -> Result<()>{
+    ) -> Result<()> {
         let msg_id = resp.id;
 
         let sender_entry = {
@@ -316,7 +319,10 @@ impl UserDefinedUnaryMap {
                 Receiver will shutdown now",
             );
         } else {
-            return Err(Error::Mapper(format!("No such req/resp ID found in unary ResponseSenderMap: {}", msg_id)));
+            return Err(Error::Mapper(format!(
+                "No such req/resp ID found in unary ResponseSenderMap: {}",
+                msg_id
+            )));
         }
 
         Ok(())

--- a/rust/numaflow-core/src/mapper/map/unary.rs
+++ b/rust/numaflow-core/src/mapper/map/unary.rs
@@ -6,18 +6,18 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
-use tokio::sync::{OwnedSemaphorePermit, mpsc, oneshot};
+use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
+use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::Streaming;
 use tonic::transport::Channel;
+use tonic::Streaming;
 use tracing::{error, warn};
 
 use super::{
-    ParentMessageInfo, SharedMapTaskContext, UserDefinedMessage, create_response_stream,
-    update_udf_error_metric, update_udf_read_metric, update_udf_write_metric,
+    create_response_stream, update_udf_error_metric, update_udf_read_metric, update_udf_write_metric,
+    ParentMessageInfo, SharedMapTaskContext, UserDefinedMessage,
 };
 
 /// Type alias for the response - raw results from the UDF
@@ -206,7 +206,13 @@ impl UserDefinedUnaryMap {
     ) {
         while let Some(resp) = resp_stream.next().await {
             match resp {
-                Ok(resp) => Self::process_unary_response(&sender_map, resp),
+                Ok(resp) => {
+                    if let Err(e) = Self::process_unary_response(&sender_map, resp) {
+                        error!("received error while processing unary response: {}. \
+                        Exiting receiver task", e);
+                        break;
+                    }
+                },
                 Err(e) => {
                     error!(?e, "Error reading message from unary map gRPC stream");
                     Self::broadcast_error(&sender_map, e);
@@ -293,7 +299,7 @@ impl UserDefinedUnaryMap {
     pub(super) fn process_unary_response(
         sender_map: &Arc<Mutex<UnarySenderMapState>>,
         resp: MapResponse,
-    ) {
+    ) -> Result<()>{
         let msg_id = resp.id;
 
         let sender_entry = {
@@ -310,11 +316,10 @@ impl UserDefinedUnaryMap {
                 Receiver will shutdown now",
             );
         } else {
-            warn!(
-                ?msg_id,
-                "No such req/resp ID found in unary ResponseSenderMap"
-            );
+            return Err(Error::Mapper(format!("No such req/resp ID found in unary ResponseSenderMap: {}", msg_id)));
         }
+
+        Ok(())
     }
 }
 

--- a/rust/numaflow-core/src/mapper/map/unary.rs
+++ b/rust/numaflow-core/src/mapper/map/unary.rs
@@ -333,15 +333,20 @@ impl UserDefinedUnaryMap {
 
 #[cfg(test)]
 mod tests {
-    use crate::mapper::map::unary::UserDefinedUnaryMap;
+    use crate::error::Error as MapError;
+    use crate::mapper::map::unary::{UnarySenderMapState, UserDefinedUnaryMap};
     use crate::shared::grpc::create_rpc_channel;
     use numaflow::map;
     use numaflow::shared::ServerExtras;
     use numaflow_pb::clients::map::map_client::MapClient;
+    use numaflow_pb::clients::map::{MapRequest, MapResponse};
     use std::error::Error;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tempfile::TempDir;
+    use tokio::sync::{mpsc, oneshot};
     use tokio_util::sync::CancellationToken;
+    use tokio_util::task::AbortOnDropHandle;
 
     struct Cat;
 
@@ -415,5 +420,122 @@ mod tests {
             "Expected gRPC server to have shut down"
         );
         Ok(())
+    }
+
+    fn make_response(id: &str) -> MapResponse {
+        MapResponse {
+            results: vec![],
+            id: id.to_string(),
+            handshake: None,
+            status: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn process_unary_response_returns_error_when_no_sender_entry() {
+        let sender_map = Arc::new(Mutex::new(UnarySenderMapState::default()));
+
+        let result =
+            UserDefinedUnaryMap::process_unary_response(&sender_map, make_response("missing"));
+
+        let err = result.expect_err("expected error when sender entry missing");
+        assert!(matches!(err, MapError::Mapper(_)));
+        assert!(
+            err.to_string()
+                .contains("No such req/resp ID found in unary ResponseSenderMap"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_unary_response_returns_error_when_oneshot_send_fails() {
+        let sender_map = Arc::new(Mutex::new(UnarySenderMapState::default()));
+        let (tx, rx) = oneshot::channel();
+        // Drop the receiver so the next send on tx fails.
+        drop(rx);
+        sender_map.lock().unwrap().map.insert("0".to_string(), tx);
+
+        let result = UserDefinedUnaryMap::process_unary_response(&sender_map, make_response("0"));
+
+        let err = result.expect_err("expected error when oneshot send fails");
+        assert!(matches!(err, MapError::Mapper(_)));
+        assert!(
+            err.to_string()
+                .contains("Failed to send server response from receiver to unary task"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn broadcast_error_marks_closed_and_errors_all_senders() {
+        let sender_map = Arc::new(Mutex::new(UnarySenderMapState::default()));
+        let (tx_a, rx_a) = oneshot::channel();
+        let (tx_b, rx_b) = oneshot::channel();
+        {
+            let mut guard = sender_map.lock().unwrap();
+            guard.map.insert("a".to_string(), tx_a);
+            guard.map.insert("b".to_string(), tx_b);
+        }
+
+        UserDefinedUnaryMap::broadcast_error(&sender_map, tonic::Status::aborted("test"));
+
+        {
+            let guard = sender_map.lock().unwrap();
+            assert!(guard.closed, "broadcast_error should set closed = true");
+            assert!(guard.map.is_empty(), "all senders should be drained");
+        }
+
+        for rx in [rx_a, rx_b] {
+            let received = rx.await.expect("oneshot sender should have delivered");
+            let err = received.expect_err("expected Err variant");
+            assert!(matches!(err, MapError::Grpc(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn unary_method_cleans_up_on_read_tx_send_failure() {
+        // Build a UserDefinedUnaryMap whose read_tx receiver has been dropped,
+        // so that read_tx.send(..) inside `unary` fails immediately.
+        let (read_tx, read_rx) = mpsc::channel::<MapRequest>(10);
+        drop(read_rx);
+
+        let dummy_handle = tokio::spawn(async {});
+        let _abort_handle = Arc::new(AbortOnDropHandle::new(dummy_handle));
+
+        let senders = Arc::new(Mutex::new(UnarySenderMapState::default()));
+        let mapper = UserDefinedUnaryMap {
+            read_tx,
+            senders: Arc::clone(&senders),
+            _handle: _abort_handle,
+        };
+
+        let request = MapRequest {
+            request: Some(numaflow_pb::clients::map::map_request::Request {
+                keys: vec!["k".into()],
+                value: b"v".to_vec(),
+                event_time: None,
+                watermark: None,
+                headers: Default::default(),
+                metadata: None,
+            }),
+            id: "42".to_string(),
+            handshake: None,
+            status: None,
+        };
+
+        let result = mapper.unary(request, CancellationToken::new()).await;
+        let err = result.expect_err("expected Mapper error from unary()");
+        assert!(matches!(err, MapError::Mapper(_)));
+        assert!(
+            err.to_string()
+                .contains("failed to send message to unary map server"),
+            "unexpected error message: {err}"
+        );
+
+        // The senders map must no longer contain the failed request id.
+        assert!(
+            !senders.lock().unwrap().map.contains_key("42"),
+            "senders map should be cleaned up on read_tx send failure"
+        );
     }
 }

--- a/rust/numaflow-core/src/mapper/map/unary.rs
+++ b/rust/numaflow-core/src/mapper/map/unary.rs
@@ -210,7 +210,6 @@ impl UserDefinedUnaryMap {
                     if let Err(e) = Self::process_unary_response(&sender_map, resp) {
                         error!("received error while processing unary response: {}. \
                         Exiting receiver task", e);
-                        Self::broadcast_error(&sender_map, tonic::Status::aborted("receiver stream dropped"));
                         break;
                     }
                 },

--- a/rust/numaflow-core/src/mapper/map/unary.rs
+++ b/rust/numaflow-core/src/mapper/map/unary.rs
@@ -304,9 +304,10 @@ impl UserDefinedUnaryMap {
         };
 
         if let Some(sender) = sender_entry {
-            sender
-                .send(Ok(resp.results))
-                .expect("failed to send response");
+            sender.send(Ok(resp.results)).expect(
+                "Failed to send server response from receiver to unary task. \
+                Receiver will shutdown now",
+            );
         } else {
             warn!(
                 ?msg_id,

--- a/rust/numaflow-core/src/mapper/map/unary.rs
+++ b/rust/numaflow-core/src/mapper/map/unary.rs
@@ -6,18 +6,18 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
-use tokio::sync::{OwnedSemaphorePermit, mpsc, oneshot};
+use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
+use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::Streaming;
 use tonic::transport::Channel;
+use tonic::Streaming;
 use tracing::{error, warn};
 
 use super::{
-    ParentMessageInfo, SharedMapTaskContext, UserDefinedMessage, create_response_stream,
-    update_udf_error_metric, update_udf_read_metric, update_udf_write_metric,
+    create_response_stream, update_udf_error_metric, update_udf_read_metric, update_udf_write_metric,
+    ParentMessageInfo, SharedMapTaskContext, UserDefinedMessage,
 };
 
 /// Type alias for the response - raw results from the UDF
@@ -314,10 +314,13 @@ impl UserDefinedUnaryMap {
         };
 
         if let Some(sender) = sender_entry {
-            sender.send(Ok(resp.results)).expect(
-                "Failed to send server response from receiver to unary task. \
-                Receiver will shutdown now",
-            );
+            if let Err(e) = sender.send(Ok(resp.results)) {
+                return Err(Error::Mapper(format!(
+                    "Failed to send server response from receiver to unary task \
+                    for ID: {} with error: {:?}. Receiver should shutdown now",
+                    msg_id, e
+                )));
+            };
         } else {
             return Err(Error::Mapper(format!(
                 "No such req/resp ID found in unary ResponseSenderMap: {}",

--- a/rust/numaflow-core/src/mapper/map/unary.rs
+++ b/rust/numaflow-core/src/mapper/map/unary.rs
@@ -206,7 +206,7 @@ impl UserDefinedUnaryMap {
     ) {
         while let Some(resp) = resp_stream.next().await {
             match resp {
-                Ok(resp) => Self::process_unary_response(&sender_map, resp).await,
+                Ok(resp) => Self::process_unary_response(&sender_map, resp),
                 Err(e) => {
                     error!(?e, "Error reading message from unary map gRPC stream");
                     Self::broadcast_error(&sender_map, e);
@@ -232,15 +232,10 @@ impl UserDefinedUnaryMap {
         let (tx, rx) = oneshot::channel();
         let key = request.id.clone();
 
-        // only insert if we are able to send the message to the server
-        if let Err(e) = self.read_tx.send(request).await {
-            error!(?e, "Failed to send message to server");
-            return Err(Error::Mapper(format!(
-                "failed to send message to unary map server: {e}"
-            )));
-        }
-
-        // move the senders_guard out of the scope to drop the guard when done
+        // Move the senders_guard out of the scope to drop the guard when done
+        // Do this before we send the message to the server to avoid the race condition
+        // where the server processes the message faster than the corresponding sender
+        // is added to the SenderMap.
         {
             let mut senders_guard = self
                 .senders
@@ -254,6 +249,25 @@ impl UserDefinedUnaryMap {
                     .inspect(|_| warn!("failed to send error to oneshot receiver"));
             }
         };
+
+        // send message to the server
+        if let Err(e) = self.read_tx.send(request).await {
+            error!(?e, "Failed to send message to server");
+            // We should remove the resp.id from the SenderMap to avoid potential
+            // memory leaks. We don't care about sending the error on the sender popped
+            // from the map since we're returning early with error anyway.
+            {
+                let _ = self
+                    .senders
+                    .lock()
+                    .expect("failed to acquire poisoned lock")
+                    .map
+                    .remove(&key);
+            };
+            return Err(Error::Mapper(format!(
+                "failed to send message to unary map server: {e}"
+            )));
+        }
 
         tokio::select! {
             result = rx => {
@@ -275,22 +289,29 @@ impl UserDefinedUnaryMap {
 
     /// Processes the response from the server and sends it to the appropriate oneshot sender
     /// based on the message id entry in the map.
-    pub(super) async fn process_unary_response(
+    pub(super) fn process_unary_response(
         sender_map: &Arc<Mutex<UnarySenderMapState>>,
         resp: MapResponse,
     ) {
         let msg_id = resp.id;
 
-        let sender_entry = sender_map
-            .lock()
-            .expect("failed to acquire poisoned lock")
-            .map
-            .remove(&msg_id);
+        let sender_entry = {
+            sender_map
+                .lock()
+                .expect("failed to acquire poisoned lock")
+                .map
+                .remove(&msg_id)
+        };
 
         if let Some(sender) = sender_entry {
             sender
                 .send(Ok(resp.results))
                 .expect("failed to send response");
+        } else {
+            warn!(
+                ?msg_id,
+                "No such req/resp ID found in unary ResponseSenderMap"
+            );
         }
     }
 }

--- a/rust/numaflow-core/src/mapper/map/unary.rs
+++ b/rust/numaflow-core/src/mapper/map/unary.rs
@@ -210,10 +210,9 @@ impl UserDefinedUnaryMap {
                     if let Err(e) = Self::process_unary_response(&sender_map, resp) {
                         error!(
                             "received error while processing unary response: {}. \
-                        Exiting receiver task",
+                            Exiting receiver task",
                             e
                         );
-                        break;
                     }
                 }
                 Err(e) => {
@@ -317,7 +316,7 @@ impl UserDefinedUnaryMap {
             if let Err(e) = sender.send(Ok(resp.results)) {
                 return Err(Error::Mapper(format!(
                     "Failed to send server response from receiver to unary task \
-                    for ID: {} with error: {:?}. Receiver should shutdown now",
+                    for ID: {} with error: {:?}",
                     msg_id, e
                 )));
             };

--- a/rust/numaflow-core/src/mapper/map/unary.rs
+++ b/rust/numaflow-core/src/mapper/map/unary.rs
@@ -254,7 +254,7 @@ impl UserDefinedUnaryMap {
             } else {
                 let _ = tx
                     .send(Err(Error::Mapper("mapper closed".to_string())))
-                    .inspect(|_| warn!("failed to send error to oneshot receiver"));
+                    .inspect_err(|_| warn!("failed to send error to oneshot receiver"));
             }
         };
 


### PR DESCRIPTION
### What this PR does / why we need it
Receiver task for listening on responses from map udf server may process messages faster than the corresponding response id is added to the ResponseSenderMap. 
This race condition may lead to messages received from the map udf server not getting forwarded downstream / ack for the message never being sent. 

Changes:
* Introduce proper error handling for each mapper type, instead of banking on 'except()' usage. Currently, all the errors raised are marked as mapper errors (except the ones in `broadcast_error`) and hence being only logged currently.
* Rearrange the order of following processes in each mapper type to prevent the mentioned race issue:
  * Earlier we had
    * Send message to udf server
    * Insert message id to senders map for tracking by receiver task
  * Now we have:
    * Insert message id to senders map for tracking by receiver task
    * Send message to udf server
    * Remove message id from senders map if message sending fails

### Related issues
Fixes #3402

### Testing
Will be run on validation framework and results reported here. 

### Special notes for reviewers
Anything notable for review (risk, rollout, follow-ups).

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
