### PR TITLE
fix: return result status to cause monovertex controller requeue

### DIFF
--- a/pkg/reconciler/monovertex/controller.go
+++ b/pkg/reconciler/monovertex/controller.go
@@ -168,7 +168,7 @@ func (mr *monoVertexReconciler) reconcile(ctx context.Context, monoVtx *dfv1.Mon
 	if ctrlResult, err := mr.checkChildrenResourceStatus(ctx, monoVtx); err != nil {
 		return ctrlResult, fmt.Errorf("failed to check mono vertex children resource status, %w", err)
 	} else {
-		return ctrl.Result{}, nil
+		return ctrlResult, nil
 	}
 }
 


### PR DESCRIPTION
### What this PR does / why we need it

While investigating the bug that the PodsHealthy Condition for MonoVertex is getting stuck False with reason `RecentRestart`, I realized that the result from `checkChildrenResourceStatus()` is not being passed back up the call stack. This is what causes a requeue to happen.  

Note [this](https://github.com/numaproj/numaflow/blob/main/pkg/reconciler/util.go#L90) is where `isTransientUnhealthy` gets set true. And based on that value, [here](https://github.com/numaproj/numaflow/blob/v1.7.5/pkg/reconciler/monovertex/controller.go#L643) is where we requeue if that's true. So, the issue is that we're not passing that result up the call stack.



<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
