### PR TITLE
fix: use podman as fallback when docker is not available in numaflow

### DIFF
--- a/rust/numaflow-models/Makefile
+++ b/rust/numaflow-models/Makefile
@@ -7,7 +7,8 @@ SDK_VERSION := $(shell if [[ "$(VERSION)" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*  ]]; the
 # Somehow type-mappings stopped working starting from v7.4.0
 GENERATOR_VERSION := v7.3.0
 
-DOCKER = docker run --rm --user $(shell id -u):$(shell id -g) -v `pwd -P`:/base --workdir /base
+DOCKER_BIN := $(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
+DOCKER = $(DOCKER_BIN) run --rm --user $(shell id -u):$(shell id -g) -v `pwd -P`:/base --workdir /base
 
 publish: generate
 	echo TODO


### PR DESCRIPTION
 ### What this PR does / why we need it                                                                                                                               
  The `rust/numaflow-models/Makefile` hardcodes `docker`, causing `make codegen` to fail                                                                               
  when only `podman` is available. This patch auto-detects `podman` as a fallback,                                                                                     
  consistent with the root `Makefile` which already does this.                                                                                                       
                                                                                                                                                                       
  ### Related issues                                                                                                                                                   
  N/A
                                                                                                                                                                       
  ### Testing                                                                                                                                                        
  Ran `make codegen` successfully on macOS with `podman` installed and `docker` not installed.

  ### Special notes for reviewers
  Low risk — only affects local dev environment tooling, not production code.