### PR TITLE
fix: implement stronger status logic for getPipelineStatus

### DIFF
--- a/server/apis/v1/handler.go
+++ b/server/apis/v1/handler.go
@@ -275,7 +275,10 @@ func (h *handler) GetClusterSummary(c *gin.Context) {
 			h.respondWithError(c, fmt.Sprintf("Failed to fetch cluster summary, %s", err.Error()))
 			return
 		}
-		if status == dfv1.PipelineStatusInactive {
+		// Pipelines with inactive, unknown, or deleting status are not actively processing data
+		if status == dfv1.PipelineStatusInactive ||
+			status == dfv1.PipelineStatusUnknown ||
+			status == dfv1.PipelineStatusDeleting {
 			summary.pipelineSummary.Inactive++
 		} else {
 			summary.pipelineSummary.Active.increment(status)
@@ -1480,16 +1483,33 @@ func getMonoVertices(h *handler, namespace string) (MonoVertices, error) {
 // TODO(API): Change the Daemon service to return the consolidated status of the pipeline
 // to save on multiple calls to the daemon service
 func getPipelineStatus(pipeline *dfv1.Pipeline) (string, error) {
-	retStatus := dfv1.PipelineStatusHealthy
-	// Check if the pipeline is paused, if so, return inactive status
-	if pipeline.GetDesiredPhase() == dfv1.PipelinePhasePaused {
-		retStatus = dfv1.PipelineStatusInactive
-	} else if pipeline.GetDesiredPhase() == dfv1.PipelinePhaseRunning {
-		retStatus = dfv1.PipelineStatusHealthy
-	} else if pipeline.GetDesiredPhase() == dfv1.PipelinePhaseFailed {
-		retStatus = dfv1.PipelineStatusCritical
+	switch pipeline.Status.Phase {
+	case dfv1.PipelinePhaseUnknown:
+		// Phase not yet set by the controller — reconciliation is pending
+		return dfv1.PipelineStatusUnknown, nil
+	case dfv1.PipelinePhaseFailed:
+		return dfv1.PipelineStatusCritical, nil
+	case dfv1.PipelinePhasePaused:
+		return dfv1.PipelineStatusInactive, nil
+	case dfv1.PipelinePhaseRunning:
+		// Check desired phase to catch the pausing-in-progress case:
+		// the user has requested a pause but the controller has not yet updated Status.Phase
+		if pipeline.GetDesiredPhase() == dfv1.PipelinePhasePaused {
+			return dfv1.PipelineStatusInactive, nil
+		}
+		if !pipeline.Status.IsHealthy() {
+			return dfv1.PipelineStatusWarning, nil
+		}
+		return dfv1.PipelineStatusHealthy, nil
+	case dfv1.PipelinePhasePausing:
+		// Pipeline is draining before pausing — treat as inactive
+		return dfv1.PipelineStatusInactive, nil
+	case dfv1.PipelinePhaseDeleting:
+		return dfv1.PipelineStatusDeleting, nil
+	default:
+		// Unhandled phase — status is not deterministic
+		return dfv1.PipelineStatusUnknown, nil
 	}
-	return retStatus, nil
 }
 
 // getIsbServiceStatus determines the status of a given InterStepBufferService

--- a/server/apis/v1/handler_test.go
+++ b/server/apis/v1/handler_test.go
@@ -1192,3 +1192,115 @@ func TestGetMonoVertexStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPipelineStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		pipeline *dfv1.Pipeline
+		expected string
+	}{
+		{
+			name: "running and healthy",
+			pipeline: func() *dfv1.Pipeline {
+				pl := &dfv1.Pipeline{}
+				pl.Status.InitConditions()
+				pl.Status.MarkPhaseRunning()
+				pl.Status.MarkConfigured()
+				pl.Status.MarkDeployed()
+				pl.Status.MarkDaemonServiceHealthy()
+				pl.Status.MarkSideInputsManagersHealthy()
+				pl.Status.MarkVerticesHealthy()
+				return pl
+			}(),
+			expected: dfv1.PipelineStatusHealthy,
+		},
+		{
+			name: "running but vertices unhealthy",
+			pipeline: func() *dfv1.Pipeline {
+				pl := &dfv1.Pipeline{}
+				pl.Status.InitConditions()
+				pl.Status.MarkPhaseRunning()
+				pl.Status.MarkConfigured()
+				pl.Status.MarkDeployed()
+				pl.Status.MarkDaemonServiceHealthy()
+				pl.Status.MarkSideInputsManagersHealthy()
+				pl.Status.MarkVerticesUnHealthy("VertexNotReady", "vertex pod not running")
+				return pl
+			}(),
+			expected: dfv1.PipelineStatusWarning,
+		},
+		{
+			name: "running but pausing in progress",
+			pipeline: func() *dfv1.Pipeline {
+				pl := &dfv1.Pipeline{}
+				pl.Status.InitConditions()
+				pl.Status.MarkPhaseRunning()
+				pl.Status.MarkConfigured()
+				pl.Status.MarkDeployed()
+				pl.Status.MarkDaemonServiceHealthy()
+				pl.Status.MarkSideInputsManagersHealthy()
+				pl.Status.MarkVerticesHealthy()
+				pl.Spec.Lifecycle.DesiredPhase = dfv1.PipelinePhasePaused
+				return pl
+			}(),
+			expected: dfv1.PipelineStatusInactive,
+		},
+		{
+			name: "paused",
+			pipeline: func() *dfv1.Pipeline {
+				pl := &dfv1.Pipeline{}
+				pl.Status.InitConditions()
+				pl.Status.MarkPhasePaused()
+				return pl
+			}(),
+			expected: dfv1.PipelineStatusInactive,
+		},
+		{
+			name: "pausing",
+			pipeline: func() *dfv1.Pipeline {
+				pl := &dfv1.Pipeline{}
+				pl.Status.InitConditions()
+				pl.Status.MarkPhasePausing()
+				return pl
+			}(),
+			expected: dfv1.PipelineStatusInactive,
+		},
+		{
+			name: "failed",
+			pipeline: func() *dfv1.Pipeline {
+				pl := &dfv1.Pipeline{}
+				pl.Status.InitConditions()
+				pl.Status.MarkDeployFailed("DeployFailed", "deployment error")
+				return pl
+			}(),
+			expected: dfv1.PipelineStatusCritical,
+		},
+		{
+			name: "deleting",
+			pipeline: func() *dfv1.Pipeline {
+				pl := &dfv1.Pipeline{}
+				pl.Status.InitConditions()
+				pl.Status.MarkPhaseDeleting()
+				return pl
+			}(),
+			expected: dfv1.PipelineStatusDeleting,
+		},
+		{
+			name: "unknown phase",
+			pipeline: func() *dfv1.Pipeline {
+				pl := &dfv1.Pipeline{}
+				pl.Status.InitConditions()
+				return pl
+			}(),
+			expected: dfv1.PipelineStatusUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, err := getPipelineStatus(tt.pipeline)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, status)
+		})
+	}
+}

--- a/test/api-e2e/api_test.go
+++ b/test/api-e2e/api_test.go
@@ -196,6 +196,17 @@ func (s *APISuite) TestAPIsForIsbAndPipelineAndMonoVertex() {
 		return strings.Contains(body, `"status":"healthy"`)
 	}, 3*time.Minute, 5*time.Second, "mono vertex did not become healthy in time")
 
+	// wait for both pipelines to be running and healthy before checking cluster summary.
+	// getPipelineStatus now returns real status based on phase and conditions,
+	// so we must wait for all conditions to be True before asserting Healthy:2.
+	assert.Eventually(s.T(), func() bool {
+		body1 := HTTPExpect(s.T(), "https://localhost:8145").GET(fmt.Sprintf("/api/v1/namespaces/%s/pipelines/%s", Namespace, testPipeline1Name)).
+			Expect().Status(200).Body().Raw()
+		body2 := HTTPExpect(s.T(), "https://localhost:8145").GET(fmt.Sprintf("/api/v1/namespaces/%s/pipelines/%s", Namespace, testPipeline2Name)).
+			Expect().Status(200).Body().Raw()
+		return strings.Contains(body1, `"status":"healthy"`) && strings.Contains(body2, `"status":"healthy"`)
+	}, 3*time.Minute, 5*time.Second, "pipelines did not become healthy in time")
+
 	clusterSummaryBody := HTTPExpect(s.T(), "https://localhost:8145").GET("/api/v1/cluster-summary").
 		Expect().
 		Status(200).Body().Raw()

--- a/test/api-e2e/api_test.go
+++ b/test/api-e2e/api_test.go
@@ -187,18 +187,16 @@ func (s *APISuite) TestAPIsForIsbAndPipelineAndMonoVertex() {
 	var createMonoVertexSuccessExpect = `"data":null`
 	assert.Contains(s.T(), createMonoVertex, createMonoVertexSuccessExpect)
 
-	// wait for the mono vertex to be running and healthy before checking cluster summary.
-	// getMonoVertexStatus now returns real status based on phase and conditions,
-	// so we must wait for all conditions to be True before asserting Healthy:1.
+	// getMonoVertexStatus derives status from actual phase and health conditions, not just desired phase.
+	// Poll until the mono vertex reports "healthy" so the cluster summary assertion sees Healthy:1 and not Warning.
 	assert.Eventually(s.T(), func() bool {
 		body := HTTPExpect(s.T(), "https://localhost:8145").GET(fmt.Sprintf("/api/v1/namespaces/%s/mono-vertices/%s", Namespace, testMonoVertex1Name)).
 			Expect().Status(200).Body().Raw()
 		return strings.Contains(body, `"status":"healthy"`)
 	}, 3*time.Minute, 5*time.Second, "mono vertex did not become healthy in time")
 
-	// wait for both pipelines to be running and healthy before checking cluster summary.
-	// getPipelineStatus now returns real status based on phase and conditions,
-	// so we must wait for all conditions to be True before asserting Healthy:2.
+	// getPipelineStatus derives status from actual phase and health conditions, not just desired phase.
+	// Poll until both pipelines report "healthy" so the cluster summary assertion sees Healthy:2 and not Warning.
 	assert.Eventually(s.T(), func() bool {
 		body1 := HTTPExpect(s.T(), "https://localhost:8145").GET(fmt.Sprintf("/api/v1/namespaces/%s/pipelines/%s", Namespace, testPipeline1Name)).
 			Expect().Status(200).Body().Raw()


### PR DESCRIPTION
## What this PR does / why we need it                                                                                                                                
                                          
  `getPipelineStatus` was using `GetDesiredPhase()` (user intent) with only 3 cases and a default of `Healthy` — weak logic that could misreport pipeline health. This refactors it to switch on `pipeline.Status.Phase` (actual state) with explicit handling for all phases, matching the stronger pattern introduced for `getMonoVertexStatus` in #3408. Also fixes `GetClusterSummary` to count `Unknown` and `Deleting` pipelines as inactive rather than active.                           
                                          
## Related issues

  Fixes #3414

  ## Testing

  Unit tests added for all 8 phase cases (`Running`/healthy, `Running`/unhealthy vertices, `Running`/pausing-in-progress, `Paused`, `Pausing`, `Failed`, `Deleting`,   
  `Unknown`):
                                                                                                                                                                       
  ```bash                                 
  go test -v -race -short -timeout 60s ./server/apis/v1/ -run TestGetPipelineStatus
```

  All pass.                                                                                                                                                            
   
 ## Special notes for reviewers                                                                                                                                          
                                          
  This is a direct follow-up to #3408 — the logic mirrors getMonoVertexStatus exactly. Key behavioral changes vs. the old code:

  - Pausing phase now correctly returns Inactive (was falling through to Healthy)                                                                                      
  - Deleting phase now returns Deleting (was falling through to Healthy)
  - Unknown phase now returns Unknown (was defaulting to Healthy)                                                                                                      
  - Status is derived from actual phase, not desired phase
