### PR TITLE
fix: handle redelivered messages in map stream

### DIFF
--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -6,23 +6,27 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
-use tokio::sync::{OwnedSemaphorePermit, mpsc};
+use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
+use tokio::sync::{mpsc, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::Streaming;
 use tonic::transport::Channel;
+use tonic::Streaming;
 use tracing::{error, warn};
 
 use super::{
-    ParentMessageInfo, STREAMING_MAP_RESP_CHANNEL_SIZE, SharedMapTaskContext, UserDefinedMessage,
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric,
-    update_udf_read_metric, update_udf_write_only_metric,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
+    update_udf_write_only_metric, ParentMessageInfo, SharedMapTaskContext,
+    UserDefinedMessage, STREAMING_MAP_RESP_CHANNEL_SIZE,
 };
 
 /// Type alias for the stream response - raw results from the UDF
-pub(in crate::mapper) type StreamMapResponse = Vec<map::map_response::Result>;
+#[derive(Debug)]
+pub(in crate::mapper) enum StreamMapResponse {
+    Data(Vec<map::map_response::Result>),
+    Eot,
+}
 
 /// Type aliases for HashMap used to track the oneshot response sender for each request keyed by
 /// message id.
@@ -87,50 +91,62 @@ impl MapStreamTask {
         loop {
             let result = receiver.recv().await;
             match result {
-                Some(Ok(results)) => {
-                    // Convert raw results to Messages using parent info
-                    for result in results {
-                        let mapped_message: Message =
-                            UserDefinedMessage(result, &parent_info, parent_info.current_index)
+                Some(Ok(stream_resp)) => {
+                    match stream_resp {
+                        StreamMapResponse::Data(results) => {
+                            // Convert raw results to Messages using parent info
+                            for result in results {
+                                let mapped_message: Message = UserDefinedMessage(
+                                    result,
+                                    &parent_info,
+                                    parent_info.current_index,
+                                )
                                 .into();
-                        parent_info.current_index += 1;
+                                parent_info.current_index += 1;
 
-                        update_udf_write_only_metric(self.shared_ctx.is_mono_vertex);
+                                update_udf_write_only_metric(self.shared_ctx.is_mono_vertex);
 
-                        self.shared_ctx
-                            .tracker
-                            .serving_append(
-                                mapped_message.offset.clone(),
-                                mapped_message.tags.clone(),
-                            )
-                            .await
-                            .expect("failed to update tracker");
-
-                        // Each downstream handle shares the original ack tracking — ACK is
-                        // deferred until all mapped messages are written to ISB/sink.
-                        let msg_handle = self.msg_handle.with_message(mapped_message);
-
-                        // Try to bypass the message. If bypassed, try_bypass takes ownership and returns None.
-                        // If not bypassed, it returns Some(msg_handle) for us to send downstream.
-                        let msg_handle =
-                            if let Some(ref bypass_router) = self.shared_ctx.bypass_router {
-                                match bypass_router
-                                    .try_bypass(msg_handle)
+                                self.shared_ctx
+                                    .tracker
+                                    .serving_append(
+                                        mapped_message.offset.clone(),
+                                        mapped_message.tags.clone(),
+                                    )
                                     .await
-                                    .expect("failed to send message to bypass channel")
-                                {
-                                    Some(msg) => msg,
-                                    None => continue, // Message was bypassed, move to next
-                                }
-                            } else {
-                                msg_handle
-                            };
+                                    .expect("failed to update tracker");
 
-                        self.shared_ctx
-                            .output_tx
-                            .send(msg_handle)
-                            .await
-                            .expect("failed to send response");
+                                // Each downstream handle shares the original ack tracking — ACK is
+                                // deferred until all mapped messages are written to ISB/sink.
+                                let msg_handle = self.msg_handle.with_message(mapped_message);
+
+                                // Try to bypass the message. If bypassed, try_bypass takes ownership and returns None.
+                                // If not bypassed, it returns Some(msg_handle) for us to send downstream.
+                                let msg_handle = if let Some(ref bypass_router) =
+                                    self.shared_ctx.bypass_router
+                                {
+                                    match bypass_router
+                                        .try_bypass(msg_handle)
+                                        .await
+                                        .expect("failed to send message to bypass channel")
+                                    {
+                                        Some(msg) => msg,
+                                        None => continue, // Message was bypassed, move to next
+                                    }
+                                } else {
+                                    msg_handle
+                                };
+
+                                self.shared_ctx
+                                    .output_tx
+                                    .send(msg_handle)
+                                    .await
+                                    .expect("failed to send response");
+                            }
+                        }
+                        // received EOT response, ok to end monitoring the stream
+                        StreamMapResponse::Eot => {
+                            break;
+                        }
                     }
                 }
                 Some(Err(e)) => {
@@ -140,9 +156,12 @@ impl MapStreamTask {
                     return;
                 }
                 None => {
-                    // Channel closed — stream ended cleanly (e.g., UDF returned empty results or
-                    // finished after sending all results). Fall through to mark_success below.
-                    break;
+                    // Channel closed — stream ended abruptly
+                    let e = Error::Mapper("Did not receive EOT from stream receiver task".into());
+                    error!(?e, "failed to map message");
+                    mark_failed!(self.msg_handle, &e);
+                    let _ = self.shared_ctx.error_tx.send(e).await;
+                    return;
                 }
             }
         }
@@ -252,14 +271,16 @@ impl UserDefinedStreamMap {
                 .remove(&resp.id)
         };
 
-        // once we get eot, we can drop the sender to let the callee
-        // know that we are done sending responses
-        if let Some(map::TransmissionStatus { eot: true }) = resp.status {
-            update_udf_process_time_metric(is_mono_vertex());
-            return Ok(());
-        }
-
         if let Some(response_sender) = response_sender_entry {
+            // once we get eot from UDF, we'll also send an eot to the execute task,
+            // to let the listener know we're done sending responses.
+            // Safe to drop the sender after this
+            if let Some(map::TransmissionStatus { eot: true }) = resp.status {
+                update_udf_process_time_metric(is_mono_vertex());
+                let _ = response_sender.send(Ok(StreamMapResponse::Eot)).await;
+                return Ok(());
+            }
+
             // move the senders_guard out of the scope to drop the guard before sending the response
             // Insert the sender back into the SenderMap to avoid yielding back control
             // to the tokio runtime during send on the actual sender
@@ -282,7 +303,11 @@ impl UserDefinedStreamMap {
                 return Ok(());
             }
 
-            if response_sender.send(Ok(resp.results)).await.is_err() {
+            if response_sender
+                .send(Ok(StreamMapResponse::Data(resp.results)))
+                .await
+                .is_err()
+            {
                 {
                     let mut sender_guard =
                         sender_map.lock().expect("failed to acquire poisoned lock");
@@ -462,12 +487,21 @@ mod tests {
         let cln_token = tokio_util::sync::CancellationToken::new();
         let mut rx = client.stream(request, cln_token).await;
 
-        // Collect all response batches
+        // Collect all response batches until we observe EOT.
         let mut all_results = vec![];
+        let mut saw_eot = false;
         while let Some(response) = rx.recv().await {
-            let results = response?;
-            all_results.extend(results);
+            match response? {
+                crate::mapper::map::stream::StreamMapResponse::Data(results) => {
+                    all_results.extend(results);
+                }
+                crate::mapper::map::stream::StreamMapResponse::Eot => {
+                    saw_eot = true;
+                    break;
+                }
+            }
         }
+        assert!(saw_eot, "expected explicit EOT from stream receiver task");
 
         assert_eq!(all_results.len(), 3);
         // convert the bytes value to string and compare
@@ -576,7 +610,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn process_response_drops_sender_on_eot_without_error() {
+    async fn process_response_forwards_eot_to_response_sender() {
+        use crate::mapper::map::stream::StreamMapResponse;
+
         let sender_map = Arc::new(Mutex::new(StreamSenderMapState::default()));
         let (tx, mut rx) = mpsc::channel(1);
         sender_map.lock().unwrap().map.insert("0".to_string(), tx);
@@ -585,11 +621,18 @@ mod tests {
             UserDefinedStreamMap::process_response(&sender_map, make_response("0", true)).await;
         assert!(result.is_ok(), "EOT path should return Ok");
 
-        // EOT does not deliver a payload to the response sender.
-        assert!(matches!(
-            rx.try_recv(),
-            Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected)
-        ));
+        // EOT must be delivered to the response sender so the consumer loop can
+        // distinguish a clean end-of-stream from an abrupt channel close.
+        let received = rx.recv().await.expect("expected EOT on response channel");
+        let resp = received.expect("EOT delivery should be Ok");
+        assert!(
+            matches!(resp, StreamMapResponse::Eot),
+            "expected StreamMapResponse::Eot, got {resp:?}"
+        );
+
+        // After dropping the EOT payload, the sender goes out of scope and the
+        // channel closes — confirm no further messages arrive.
+        assert!(rx.recv().await.is_none());
 
         // EOT removes the sender from the map (and never re-inserts it),
         // letting the corresponding receiver loop terminate.

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -7,19 +7,19 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
-use tokio::sync::{OwnedSemaphorePermit, mpsc};
+use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
+use tokio::sync::{mpsc, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::Streaming;
 use tonic::transport::Channel;
+use tonic::Streaming;
 use tracing::{error, warn};
 
 use super::{
-    ParentMessageInfo, STREAMING_MAP_RESP_CHANNEL_SIZE, SharedMapTaskContext, UserDefinedMessage,
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric,
-    update_udf_read_metric, update_udf_write_only_metric,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
+    update_udf_write_only_metric, ParentMessageInfo, SharedMapTaskContext,
+    UserDefinedMessage, STREAMING_MAP_RESP_CHANNEL_SIZE,
 };
 
 /// Type alias for the stream response - raw results from the UDF
@@ -107,9 +107,10 @@ impl MapStreamTask {
     }
 
     /// Materializes each raw UDF result into a [`Message`] (stamped with a monotonic
-    /// `current_index` for unique child offsets), appends it to the tracker so the
-    /// parent's ACK is deferred until all children are written, then either routes it
-    /// through `bypass_router` (consumed if bypassed) or forwards it to `output_tx`.
+    /// `current_index` for unique child offsets), create a child msg_handle from child
+    /// message and parent msg_handle so the parent's ACK is deferred until all children
+    /// are written, then either routes it through `bypass_router` (consumed if bypassed)
+    /// or forwards it to `output_tx`.
     ///
     /// `parent_info.current_index` is mutated and persists across calls for the same parent.
     async fn process_results(

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -1,5 +1,5 @@
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -7,19 +7,19 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
-use tokio::sync::{mpsc, OwnedSemaphorePermit};
+use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
+use tokio::sync::{OwnedSemaphorePermit, mpsc};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::transport::Channel;
 use tonic::Streaming;
+use tonic::transport::Channel;
 use tracing::{error, info, warn};
 
 use super::{
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
-    update_udf_write_only_metric, ParentMessageInfo, SharedMapTaskContext,
-    UserDefinedMessage, STREAMING_MAP_RESP_CHANNEL_SIZE,
+    ParentMessageInfo, STREAMING_MAP_RESP_CHANNEL_SIZE, SharedMapTaskContext, UserDefinedMessage,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric,
+    update_udf_read_metric, update_udf_write_only_metric,
 };
 
 /// Type alias for the stream response - raw results from the UDF

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -1,5 +1,5 @@
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -7,19 +7,19 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
-use tokio::sync::{mpsc, OwnedSemaphorePermit};
+use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
+use tokio::sync::{OwnedSemaphorePermit, mpsc};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::transport::Channel;
 use tonic::Streaming;
+use tonic::transport::Channel;
 use tracing::{error, warn};
 
 use super::{
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
-    update_udf_write_only_metric, ParentMessageInfo, SharedMapTaskContext,
-    UserDefinedMessage, STREAMING_MAP_RESP_CHANNEL_SIZE,
+    ParentMessageInfo, STREAMING_MAP_RESP_CHANNEL_SIZE, SharedMapTaskContext, UserDefinedMessage,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric,
+    update_udf_read_metric, update_udf_write_only_metric,
 };
 
 /// Type alias for the stream response - raw results from the UDF

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -7,19 +7,19 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
-use tokio::sync::{OwnedSemaphorePermit, mpsc};
+use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
+use tokio::sync::{mpsc, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::Streaming;
 use tonic::transport::Channel;
+use tonic::Streaming;
 use tracing::{error, warn};
 
 use super::{
-    ParentMessageInfo, STREAMING_MAP_RESP_CHANNEL_SIZE, SharedMapTaskContext, UserDefinedMessage,
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric,
-    update_udf_read_metric, update_udf_write_only_metric,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
+    update_udf_write_only_metric, ParentMessageInfo, SharedMapTaskContext,
+    UserDefinedMessage, STREAMING_MAP_RESP_CHANNEL_SIZE,
 };
 
 /// Type alias for the stream response - raw results from the UDF
@@ -89,14 +89,14 @@ impl MapStreamTask {
                     self.process_results(&mut parent_info, results).await;
                 }
                 Some(Err(e)) => {
-                    error!(parent_id = ?self.msg_handle.message.id, ?e, "failed to map message");
+                    error!(msg_id = ?self.msg_handle.message.id, ?e, "failed to map message");
                     mark_failed!(self.msg_handle, &e);
                     let _ = self.shared_ctx.error_tx.send(e).await;
                     return;
                 }
                 None => {
-                    // Channel closed — stream ended cleanly
-                    // Fall through to mark_success below.
+                    // Channel closed — stream ended cleanly (e.g., UDF returned empty results or
+                    // finished after sending all results). Fall through to mark_success below.
                     break;
                 }
             }
@@ -106,12 +106,17 @@ impl MapStreamTask {
         mark_success!(self.msg_handle);
     }
 
+    /// Materializes each raw UDF result into a [`Message`] (stamped with a monotonic
+    /// `current_index` for unique child offsets), appends it to the tracker so the
+    /// parent's ACK is deferred until all children are written, then either routes it
+    /// through `bypass_router` (consumed if bypassed) or forwards it to `output_tx`.
+    ///
+    /// `parent_info.current_index` is mutated and persists across calls for the same parent.
     async fn process_results(
         &self,
         parent_info: &mut ParentMessageInfo,
         results: Vec<map::map_response::Result>,
     ) {
-        // Convert raw results to Messages using parent info
         for result in results {
             let mapped_message: Message =
                 UserDefinedMessage(result, parent_info, parent_info.current_index).into();
@@ -253,9 +258,8 @@ impl UserDefinedStreamMap {
                 .remove(&resp.id)
         };
 
-        // once we get eot from UDF, we'll drop the sender to let the
-        // receiver know that we're done processing responses
-        // Safe to drop the sender after this.
+        // once we get eot, we can drop the sender to let the callee
+        // know that we are done sending responses
         if let Some(map::TransmissionStatus { eot: true }) = resp.status {
             update_udf_process_time_metric(is_mono_vertex());
             return Ok(());

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -6,19 +6,19 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
-use tokio::sync::{mpsc, OwnedSemaphorePermit};
+use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
+use tokio::sync::{OwnedSemaphorePermit, mpsc};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::transport::Channel;
 use tonic::Streaming;
+use tonic::transport::Channel;
 use tracing::{error, info, warn};
 
 use super::{
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
-    update_udf_write_only_metric, ParentMessageInfo, SharedMapTaskContext,
-    UserDefinedMessage, STREAMING_MAP_RESP_CHANNEL_SIZE,
+    ParentMessageInfo, STREAMING_MAP_RESP_CHANNEL_SIZE, SharedMapTaskContext, UserDefinedMessage,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric,
+    update_udf_read_metric, update_udf_write_only_metric,
 };
 
 /// Type alias for the stream response - raw results from the UDF
@@ -90,6 +90,9 @@ impl MapStreamTask {
 
         info!(?self.msg_handle.message.id, "Received message id");
 
+        let mut produced_count: u32 = 0;
+        let mut sent_count: u32 = 0;
+
         loop {
             tokio::select! {
                 result = receiver.recv() => {
@@ -106,6 +109,7 @@ impl MapStreamTask {
                                         )
                                         .into();
                                         parent_info.current_index += 1;
+                                        produced_count += 1;
 
                                         update_udf_write_only_metric(self.shared_ctx.is_mono_vertex);
 
@@ -139,23 +143,34 @@ impl MapStreamTask {
                                             msg_handle
                                         };
 
-                                        info!(?msg_handle.message.id, "Sending message id");
+                                        info!(
+                                            parent_id = ?self.msg_handle.message.id,
+                                            child_id = ?msg_handle.message.id,
+                                            "Sending message id"
+                                        );
 
                                         self.shared_ctx
                                             .output_tx
                                             .send(msg_handle)
                                             .await
                                             .expect("failed to send response");
+                                        sent_count += 1;
                                     }
                                 }
                                 // received EOT response, ok to end monitoring the stream
                                 StreamMapResponse::Eot => {
+                                    info!(
+                                        parent_id = ?self.msg_handle.message.id,
+                                        produced = produced_count,
+                                        sent = sent_count,
+                                        "stream complete"
+                                    );
                                     break;
                                 }
                             }
                         }
                         Some(Err(e)) => {
-                            error!(?e, "failed to map message");
+                            error!(parent_id = ?self.msg_handle.message.id, ?e, "failed to map message");
                             mark_failed!(self.msg_handle, &e);
                             let _ = self.shared_ctx.error_tx.send(e).await;
                             return;
@@ -163,7 +178,7 @@ impl MapStreamTask {
                         None => {
                             // Channel closed — stream ended abruptly
                             let e = Error::Mapper("Did not receive EOT from stream receiver task".into());
-                            error!(?e, "failed to map message");
+                            error!(parent_id = ?self.msg_handle.message.id, ?e, "failed to map message");
                             mark_failed!(self.msg_handle, &e);
                             let _ = self.shared_ctx.error_tx.send(e).await;
                             return;
@@ -172,7 +187,7 @@ impl MapStreamTask {
                 }
                 _ = self.shared_ctx.hard_shutdown_token.cancelled() => {
                     let e = Error::Mapper("Map Stream cancelled, current message will be nacked".into());
-                    warn!(?e, "failed to map message");
+                    warn!(parent_id = ?self.msg_handle.message.id, ?e, "failed to map message");
                     mark_failed!(self.msg_handle, &e);
                     return;
                 }

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -44,6 +44,7 @@ pub(in crate::mapper) struct StreamSenderMapState {
 /// MapStreamTask encapsulates all the context needed to execute a stream map operation.
 pub(in crate::mapper) struct MapStreamTask {
     pub mapper: UserDefinedStreamMap,
+    // Held for the lifetime of execute(); dropping self releases the slot back to the semaphore.
     #[allow(dead_code)]
     pub permit: OwnedSemaphorePermit,
     pub msg_handle: MessageHandle,
@@ -351,7 +352,7 @@ impl UserDefinedStreamMap {
                 .lock()
                 .expect("failed to acquire poisoned lock");
             if senders_guard.closed {
-                Some("mapper closed".to_string())
+                Some("stream mapper closed".to_string())
             } else {
                 match senders_guard.map.entry(key.clone()) {
                     Entry::Occupied(_) => Some(format!(
@@ -370,7 +371,7 @@ impl UserDefinedStreamMap {
             return rx;
         }
 
-        // only insert if we are able to send the message to the server
+        // Sender is already registered in the map; forward the request to the UDF server.
         if let Err(e) = self.read_tx.send(request).await {
             error!(?e, "Failed to send message to map stream udf server");
             // We should ideally remove the resp.id from the SenderMap to avoid potential

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -14,7 +14,7 @@ use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
 use tonic::Streaming;
 use tonic::transport::Channel;
-use tracing::{error, info, warn};
+use tracing::{error, warn};
 
 use super::{
     ParentMessageInfo, STREAMING_MAP_RESP_CHANNEL_SIZE, SharedMapTaskContext, UserDefinedMessage,
@@ -23,11 +23,7 @@ use super::{
 };
 
 /// Type alias for the stream response - raw results from the UDF
-#[derive(Debug)]
-pub(in crate::mapper) enum StreamMapResponse {
-    Data(Vec<map::map_response::Result>),
-    Eot,
-}
+pub(in crate::mapper) type StreamMapResponse = Vec<map::map_response::Result>;
 
 /// Type aliases for HashMap used to track the oneshot response sender for each request keyed by
 /// message id.
@@ -48,6 +44,7 @@ pub(in crate::mapper) struct StreamSenderMapState {
 /// MapStreamTask encapsulates all the context needed to execute a stream map operation.
 pub(in crate::mapper) struct MapStreamTask {
     pub mapper: UserDefinedStreamMap,
+    #[allow(dead_code)]
     pub permit: OwnedSemaphorePermit,
     pub msg_handle: MessageHandle,
     pub shared_ctx: Arc<SharedMapTaskContext>,
@@ -64,9 +61,6 @@ impl MapStreamTask {
 
     /// Executes the stream map operation.
     async fn execute(self) {
-        // Hold the permit until the task completes
-        let _permit = self.permit;
-
         // Store parent message info before sending to UDF
         // parent_info contains offset, so we don't need to clone it separately
         let mut parent_info: ParentMessageInfo = self.msg_handle.message().into();
@@ -89,120 +83,73 @@ impl MapStreamTask {
             .await
             .expect("failed to reset tracker");
 
-        info!(?self.msg_handle.message.id, "Received message id");
-
-        let mut produced_count: u32 = 0;
-        let mut sent_count: u32 = 0;
-
         loop {
-            tokio::select! {
-                result = receiver.recv() => {
-                    match result {
-                        Some(Ok(stream_resp)) => {
-                            match stream_resp {
-                                StreamMapResponse::Data(results) => {
-                                    // Convert raw results to Messages using parent info
-                                    for result in results {
-                                        let mapped_message: Message = UserDefinedMessage(
-                                            result,
-                                            &parent_info,
-                                            parent_info.current_index,
-                                        )
-                                        .into();
-                                        parent_info.current_index += 1;
-                                        produced_count += 1;
-
-                                        update_udf_write_only_metric(self.shared_ctx.is_mono_vertex);
-
-                                        self.shared_ctx
-                                            .tracker
-                                            .serving_append(
-                                                mapped_message.offset.clone(),
-                                                mapped_message.tags.clone(),
-                                            )
-                                            .await
-                                            .expect("failed to update tracker");
-
-                                        // Each downstream handle shares the original ack tracking — ACK is
-                                        // deferred until all mapped messages are written to ISB/sink.
-                                        let msg_handle = self.msg_handle.with_message(mapped_message);
-
-                                        // Try to bypass the message. If bypassed, try_bypass takes ownership and returns None.
-                                        // If not bypassed, it returns Some(msg_handle) for us to send downstream.
-                                        let msg_handle = if let Some(ref bypass_router) =
-                                            self.shared_ctx.bypass_router
-                                        {
-                                            match bypass_router
-                                                .try_bypass(msg_handle)
-                                                .await
-                                                .expect("failed to send message to bypass channel")
-                                            {
-                                                Some(msg) => msg,
-                                                None => continue, // Message was bypassed, move to next
-                                            }
-                                        } else {
-                                            msg_handle
-                                        };
-
-                                        info!(
-                                            parent_id = ?self.msg_handle.message.id,
-                                            child_id = ?msg_handle.message.id,
-                                            "Sending message id"
-                                        );
-
-                                        self.shared_ctx
-                                            .output_tx
-                                            .send(msg_handle)
-                                            .await
-                                            .expect("failed to send response");
-                                        sent_count += 1;
-                                    }
-                                }
-                                // received EOT response, ok to end monitoring the stream
-                                StreamMapResponse::Eot => {
-                                    info!(
-                                        parent_id = ?self.msg_handle.message.id,
-                                        produced = produced_count,
-                                        sent = sent_count,
-                                        "stream complete"
-                                    );
-                                    break;
-                                }
-                            }
-                        }
-                        Some(Err(e)) => {
-                            error!(parent_id = ?self.msg_handle.message.id, ?e, "failed to map message");
-                            mark_failed!(self.msg_handle, &e);
-                            let _ = self.shared_ctx.error_tx.send(e).await;
-                            return;
-                        }
-                        None => {
-                            // Channel closed — stream ended abruptly
-                            let e = Error::Mapper("Did not receive EOT from stream receiver task".into());
-                            error!(parent_id = ?self.msg_handle.message.id, ?e, "failed to map message");
-                            mark_failed!(self.msg_handle, &e);
-                            let _ = self.shared_ctx.error_tx.send(e).await;
-                            return;
-                        }
-                    }
+            match receiver.recv().await {
+                Some(Ok(results)) => {
+                    self.process_results(&mut parent_info, results).await;
                 }
-                _ = self.shared_ctx.hard_shutdown_token.cancelled() => {
-                    let e = Error::Mapper("Map Stream cancelled, current message will be nacked".into());
-                    warn!(parent_id = ?self.msg_handle.message.id, ?e, "failed to map message");
+                Some(Err(e)) => {
+                    error!(parent_id = ?self.msg_handle.message.id, ?e, "failed to map message");
                     mark_failed!(self.msg_handle, &e);
+                    let _ = self.shared_ctx.error_tx.send(e).await;
                     return;
+                }
+                None => {
+                    // Channel closed — stream ended cleanly
+                    // Fall through to mark_success below.
+                    break;
                 }
             }
         }
 
-        info!(
-            parent_id = ?self.msg_handle.message.id,
-            produced = produced_count,
-            sent = sent_count,
-            "marking message as successful"
-        );
         // Decrement the original ref_count now that we've accounted for all downstream messages.
         mark_success!(self.msg_handle);
+    }
+
+    async fn process_results(
+        &self,
+        parent_info: &mut ParentMessageInfo,
+        results: Vec<map::map_response::Result>,
+    ) {
+        // Convert raw results to Messages using parent info
+        for result in results {
+            let mapped_message: Message =
+                UserDefinedMessage(result, parent_info, parent_info.current_index).into();
+            parent_info.current_index += 1;
+
+            update_udf_write_only_metric(self.shared_ctx.is_mono_vertex);
+
+            self.shared_ctx
+                .tracker
+                .serving_append(mapped_message.offset.clone(), mapped_message.tags.clone())
+                .await
+                .expect("failed to update tracker");
+
+            // Each downstream handle shares the original ack tracking — ACK is
+            // deferred until all mapped messages are written to ISB/sink.
+            let msg_handle = self.msg_handle.with_message(mapped_message);
+
+            // Try to bypass the message. If bypassed, try_bypass takes ownership and returns None.
+            // If not bypassed, it returns Some(msg_handle) for us to send downstream.
+            let msg_handle = if let Some(ref bypass_router) = self.shared_ctx.bypass_router {
+                match bypass_router
+                    .try_bypass(msg_handle)
+                    .await
+                    .expect("failed to send message to bypass channel")
+                {
+                    Some(msg) => msg,
+                    None => continue, // Message was bypassed, move to next
+                }
+            } else {
+                msg_handle
+            };
+
+            self.shared_ctx
+                .output_tx
+                .send(msg_handle)
+                .await
+                .expect("failed to send response");
+        }
     }
 }
 
@@ -306,25 +253,15 @@ impl UserDefinedStreamMap {
                 .remove(&resp.id)
         };
 
-        if let Some(response_sender) = response_sender_entry {
-            // once we get eot from UDF, we'll also send an eot to the execute task,
-            // to let the listener know we're done sending responses.
-            // Safe to drop the sender after this
-            if let Some(map::TransmissionStatus { eot: true }) = resp.status {
-                update_udf_process_time_metric(is_mono_vertex());
-                if response_sender
-                    .send(Ok(StreamMapResponse::Eot))
-                    .await
-                    .is_err()
-                {
-                    return Err(Error::Mapper(format!(
-                        "Failed to send EOT to stream task for ID: {:?}",
-                        resp.id
-                    )));
-                };
-                return Ok(());
-            }
+        // once we get eot from UDF, we'll drop the sender to let the
+        // receiver know that we're done processing responses
+        // Safe to drop the sender after this.
+        if let Some(map::TransmissionStatus { eot: true }) = resp.status {
+            update_udf_process_time_metric(is_mono_vertex());
+            return Ok(());
+        }
 
+        if let Some(response_sender) = response_sender_entry {
             // move the senders_guard out of the scope to drop the guard before sending the response
             // Insert the sender back into the SenderMap to avoid yielding back control
             // to the tokio runtime during send on the actual sender
@@ -347,11 +284,7 @@ impl UserDefinedStreamMap {
                 return Ok(());
             }
 
-            if response_sender
-                .send(Ok(StreamMapResponse::Data(resp.results)))
-                .await
-                .is_err()
-            {
+            if response_sender.send(Ok(resp.results)).await.is_err() {
                 {
                     let mut sender_guard =
                         sender_map.lock().expect("failed to acquire poisoned lock");
@@ -543,21 +476,12 @@ mod tests {
         let cln_token = tokio_util::sync::CancellationToken::new();
         let mut rx = client.stream(request, cln_token).await;
 
-        // Collect all response batches until we observe EOT.
+        // Collect all response batches
         let mut all_results = vec![];
-        let mut saw_eot = false;
         while let Some(response) = rx.recv().await {
-            match response? {
-                crate::mapper::map::stream::StreamMapResponse::Data(results) => {
-                    all_results.extend(results);
-                }
-                crate::mapper::map::stream::StreamMapResponse::Eot => {
-                    saw_eot = true;
-                    break;
-                }
-            }
+            let results = response?;
+            all_results.extend(results);
         }
-        assert!(saw_eot, "expected explicit EOT from stream receiver task");
 
         assert_eq!(all_results.len(), 3);
         // convert the bytes value to string and compare
@@ -666,9 +590,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn process_response_forwards_eot_to_response_sender() {
-        use crate::mapper::map::stream::StreamMapResponse;
-
+    async fn process_response_drops_sender_on_eot_without_error() {
         let sender_map = Arc::new(Mutex::new(StreamSenderMapState::default()));
         let (tx, mut rx) = mpsc::channel(1);
         sender_map.lock().unwrap().map.insert("0".to_string(), tx);
@@ -677,18 +599,11 @@ mod tests {
             UserDefinedStreamMap::process_response(&sender_map, make_response("0", true)).await;
         assert!(result.is_ok(), "EOT path should return Ok");
 
-        // EOT must be delivered to the response sender so the consumer loop can
-        // distinguish a clean end-of-stream from an abrupt channel close.
-        let received = rx.recv().await.expect("expected EOT on response channel");
-        let resp = received.expect("EOT delivery should be Ok");
-        assert!(
-            matches!(resp, StreamMapResponse::Eot),
-            "expected StreamMapResponse::Eot, got {resp:?}"
-        );
-
-        // After dropping the EOT payload, the sender goes out of scope and the
-        // channel closes — confirm no further messages arrive.
-        assert!(rx.recv().await.is_none());
+        // EOT does not deliver a payload to the response sender.
+        assert!(matches!(
+            rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected)
+        ));
 
         // EOT removes the sender from the map (and never re-inserts it),
         // letting the corresponding receiver loop terminate.

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -6,19 +6,19 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
-use tokio::sync::{mpsc, OwnedSemaphorePermit};
+use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
+use tokio::sync::{OwnedSemaphorePermit, mpsc};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::transport::Channel;
 use tonic::Streaming;
+use tonic::transport::Channel;
 use tracing::{error, warn};
 
 use super::{
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
-    update_udf_write_only_metric, ParentMessageInfo, SharedMapTaskContext,
-    UserDefinedMessage, STREAMING_MAP_RESP_CHANNEL_SIZE,
+    ParentMessageInfo, STREAMING_MAP_RESP_CHANNEL_SIZE, SharedMapTaskContext, UserDefinedMessage,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric,
+    update_udf_read_metric, update_udf_write_only_metric,
 };
 
 /// Type alias for the stream response - raw results from the UDF
@@ -277,7 +277,16 @@ impl UserDefinedStreamMap {
             // Safe to drop the sender after this
             if let Some(map::TransmissionStatus { eot: true }) = resp.status {
                 update_udf_process_time_metric(is_mono_vertex());
-                let _ = response_sender.send(Ok(StreamMapResponse::Eot)).await;
+                if response_sender
+                    .send(Ok(StreamMapResponse::Eot))
+                    .await
+                    .is_err()
+                {
+                    return Err(Error::Mapper(format!(
+                        "Failed to send EOT to stream task for ID: {:?}",
+                        resp.id
+                    )));
+                };
                 return Ok(());
             }
 

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -89,78 +89,87 @@ impl MapStreamTask {
             .expect("failed to reset tracker");
 
         loop {
-            let result = receiver.recv().await;
-            match result {
-                Some(Ok(stream_resp)) => {
-                    match stream_resp {
-                        StreamMapResponse::Data(results) => {
-                            // Convert raw results to Messages using parent info
-                            for result in results {
-                                let mapped_message: Message = UserDefinedMessage(
-                                    result,
-                                    &parent_info,
-                                    parent_info.current_index,
-                                )
-                                .into();
-                                parent_info.current_index += 1;
+            tokio::select! {
+                result = receiver.recv() => {
+                    match result {
+                        Some(Ok(stream_resp)) => {
+                            match stream_resp {
+                                StreamMapResponse::Data(results) => {
+                                    // Convert raw results to Messages using parent info
+                                    for result in results {
+                                        let mapped_message: Message = UserDefinedMessage(
+                                            result,
+                                            &parent_info,
+                                            parent_info.current_index,
+                                        )
+                                        .into();
+                                        parent_info.current_index += 1;
 
-                                update_udf_write_only_metric(self.shared_ctx.is_mono_vertex);
+                                        update_udf_write_only_metric(self.shared_ctx.is_mono_vertex);
 
-                                self.shared_ctx
-                                    .tracker
-                                    .serving_append(
-                                        mapped_message.offset.clone(),
-                                        mapped_message.tags.clone(),
-                                    )
-                                    .await
-                                    .expect("failed to update tracker");
+                                        self.shared_ctx
+                                            .tracker
+                                            .serving_append(
+                                                mapped_message.offset.clone(),
+                                                mapped_message.tags.clone(),
+                                            )
+                                            .await
+                                            .expect("failed to update tracker");
 
-                                // Each downstream handle shares the original ack tracking — ACK is
-                                // deferred until all mapped messages are written to ISB/sink.
-                                let msg_handle = self.msg_handle.with_message(mapped_message);
+                                        // Each downstream handle shares the original ack tracking — ACK is
+                                        // deferred until all mapped messages are written to ISB/sink.
+                                        let msg_handle = self.msg_handle.with_message(mapped_message);
 
-                                // Try to bypass the message. If bypassed, try_bypass takes ownership and returns None.
-                                // If not bypassed, it returns Some(msg_handle) for us to send downstream.
-                                let msg_handle = if let Some(ref bypass_router) =
-                                    self.shared_ctx.bypass_router
-                                {
-                                    match bypass_router
-                                        .try_bypass(msg_handle)
-                                        .await
-                                        .expect("failed to send message to bypass channel")
-                                    {
-                                        Some(msg) => msg,
-                                        None => continue, // Message was bypassed, move to next
+                                        // Try to bypass the message. If bypassed, try_bypass takes ownership and returns None.
+                                        // If not bypassed, it returns Some(msg_handle) for us to send downstream.
+                                        let msg_handle = if let Some(ref bypass_router) =
+                                            self.shared_ctx.bypass_router
+                                        {
+                                            match bypass_router
+                                                .try_bypass(msg_handle)
+                                                .await
+                                                .expect("failed to send message to bypass channel")
+                                            {
+                                                Some(msg) => msg,
+                                                None => continue, // Message was bypassed, move to next
+                                            }
+                                        } else {
+                                            msg_handle
+                                        };
+
+                                        self.shared_ctx
+                                            .output_tx
+                                            .send(msg_handle)
+                                            .await
+                                            .expect("failed to send response");
                                     }
-                                } else {
-                                    msg_handle
-                                };
-
-                                self.shared_ctx
-                                    .output_tx
-                                    .send(msg_handle)
-                                    .await
-                                    .expect("failed to send response");
+                                }
+                                // received EOT response, ok to end monitoring the stream
+                                StreamMapResponse::Eot => {
+                                    break;
+                                }
                             }
                         }
-                        // received EOT response, ok to end monitoring the stream
-                        StreamMapResponse::Eot => {
-                            break;
+                        Some(Err(e)) => {
+                            error!(?e, "failed to map message");
+                            mark_failed!(self.msg_handle, &e);
+                            let _ = self.shared_ctx.error_tx.send(e).await;
+                            return;
+                        }
+                        None => {
+                            // Channel closed — stream ended abruptly
+                            let e = Error::Mapper("Did not receive EOT from stream receiver task".into());
+                            error!(?e, "failed to map message");
+                            mark_failed!(self.msg_handle, &e);
+                            let _ = self.shared_ctx.error_tx.send(e).await;
+                            return;
                         }
                     }
                 }
-                Some(Err(e)) => {
-                    error!(?e, "failed to map message");
+                _ = self.shared_ctx.hard_shutdown_token.cancelled() => {
+                    let e = Error::Mapper("Map Stream cancelled, current message will be nacked".into());
+                    warn!(?e, "failed to map message");
                     mark_failed!(self.msg_handle, &e);
-                    let _ = self.shared_ctx.error_tx.send(e).await;
-                    return;
-                }
-                None => {
-                    // Channel closed — stream ended abruptly
-                    let e = Error::Mapper("Did not receive EOT from stream receiver task".into());
-                    error!(?e, "failed to map message");
-                    mark_failed!(self.msg_handle, &e);
-                    let _ = self.shared_ctx.error_tx.send(e).await;
                     return;
                 }
             }
@@ -383,6 +392,8 @@ impl UserDefinedStreamMap {
             let _ = tx
                 .send(Err(Error::Mapper("mapper closed".to_string())))
                 .await;
+
+            return rx;
         }
 
         // only insert if we are able to send the message to the server

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -6,19 +6,19 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
-use tokio::sync::{mpsc, OwnedSemaphorePermit};
+use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
+use tokio::sync::{OwnedSemaphorePermit, mpsc};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::transport::Channel;
 use tonic::Streaming;
+use tonic::transport::Channel;
 use tracing::{error, info, warn};
 
 use super::{
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
-    update_udf_write_only_metric, ParentMessageInfo, SharedMapTaskContext,
-    UserDefinedMessage, STREAMING_MAP_RESP_CHANNEL_SIZE,
+    ParentMessageInfo, STREAMING_MAP_RESP_CHANNEL_SIZE, SharedMapTaskContext, UserDefinedMessage,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric,
+    update_udf_read_metric, update_udf_write_only_metric,
 };
 
 /// Type alias for the stream response - raw results from the UDF

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -341,7 +341,7 @@ impl UserDefinedStreamMap {
 
             if mapper_closed {
                 let _ = response_sender
-                    .send(Err(Error::Mapper("mapper closed".to_string())))
+                    .send(Err(Error::Mapper("stream mapper closed".to_string())))
                     .await;
                 return Ok(());
             }

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -6,19 +6,19 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
-use tokio::sync::{OwnedSemaphorePermit, mpsc};
+use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
+use tokio::sync::{mpsc, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::Streaming;
 use tonic::transport::Channel;
+use tonic::Streaming;
 use tracing::{error, info, warn};
 
 use super::{
-    ParentMessageInfo, STREAMING_MAP_RESP_CHANNEL_SIZE, SharedMapTaskContext, UserDefinedMessage,
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric,
-    update_udf_read_metric, update_udf_write_only_metric,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
+    update_udf_write_only_metric, ParentMessageInfo, SharedMapTaskContext,
+    UserDefinedMessage, STREAMING_MAP_RESP_CHANNEL_SIZE,
 };
 
 /// Type alias for the stream response - raw results from the UDF
@@ -194,6 +194,12 @@ impl MapStreamTask {
             }
         }
 
+        info!(
+            parent_id = ?self.msg_handle.message.id,
+            produced = produced_count,
+            sent = sent_count,
+            "marking message as successful"
+        );
         // Decrement the original ref_count now that we've accounted for all downstream messages.
         mark_success!(self.msg_handle);
     }

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -6,19 +6,19 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
-use tokio::sync::{OwnedSemaphorePermit, mpsc};
+use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
+use tokio::sync::{mpsc, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::Streaming;
 use tonic::transport::Channel;
-use tracing::{error, warn};
+use tonic::Streaming;
+use tracing::{error, info, warn};
 
 use super::{
-    ParentMessageInfo, STREAMING_MAP_RESP_CHANNEL_SIZE, SharedMapTaskContext, UserDefinedMessage,
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric,
-    update_udf_read_metric, update_udf_write_only_metric,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
+    update_udf_write_only_metric, ParentMessageInfo, SharedMapTaskContext,
+    UserDefinedMessage, STREAMING_MAP_RESP_CHANNEL_SIZE,
 };
 
 /// Type alias for the stream response - raw results from the UDF
@@ -88,6 +88,8 @@ impl MapStreamTask {
             .await
             .expect("failed to reset tracker");
 
+        info!(?self.msg_handle.message.id, "Received message id");
+
         loop {
             tokio::select! {
                 result = receiver.recv() => {
@@ -136,6 +138,8 @@ impl MapStreamTask {
                                         } else {
                                             msg_handle
                                         };
+
+                                        info!(?msg_handle.message.id, "Sending message id");
 
                                         self.shared_ctx
                                             .output_tx

--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -6,19 +7,19 @@ use crate::config::is_mono_vertex;
 use crate::error::{Error, Result};
 use crate::message::{Message, MessageHandle};
 use crate::{mark_failed, mark_success};
-use numaflow_pb::clients::map::{self, MapRequest, MapResponse, map_client::MapClient};
-use tokio::sync::{OwnedSemaphorePermit, mpsc};
+use numaflow_pb::clients::map::{self, map_client::MapClient, MapRequest, MapResponse};
+use tokio::sync::{mpsc, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tonic::Streaming;
 use tonic::transport::Channel;
+use tonic::Streaming;
 use tracing::{error, info, warn};
 
 use super::{
-    ParentMessageInfo, STREAMING_MAP_RESP_CHANNEL_SIZE, SharedMapTaskContext, UserDefinedMessage,
-    create_response_stream, update_udf_error_metric, update_udf_process_time_metric,
-    update_udf_read_metric, update_udf_write_only_metric,
+    create_response_stream, update_udf_error_metric, update_udf_process_time_metric, update_udf_read_metric,
+    update_udf_write_only_metric, ParentMessageInfo, SharedMapTaskContext,
+    UserDefinedMessage, STREAMING_MAP_RESP_CHANNEL_SIZE,
 };
 
 /// Type alias for the stream response - raw results from the UDF
@@ -396,28 +397,38 @@ impl UserDefinedStreamMap {
 
         let key = request.id.clone();
 
-        // Move the senders_guard out of the scope to drop the guard before sending the response
+        // Move the senders_guard out of the scope to drop the guard before sending the response.
         // Do this before we send the message to the server to avoid the race condition
         // where the server processes the message faster than the corresponding sender
         // is added to the SenderMap.
-        let mapper_closed = {
+        //
+        // If an entry for `key` already exists, another task is in flight for the same
+        // request id (typically caused by a duplicate source read). We MUST NOT overwrite —
+        // doing so silently destroys the in-flight task's response sender and reroutes its
+        // remaining gRPC frames to this task's channel. Fail fast on this rx instead and
+        // let the caller NAK upstream.
+        let early_error = {
             let mut senders_guard = self
                 .senders
                 .lock()
                 .expect("failed to acquire poisoned lock");
-            if !senders_guard.closed {
-                // Write the sender back to the map, because we need to send
-                // more responses for the same request
-                senders_guard.map.insert(key.clone(), tx.clone());
+            if senders_guard.closed {
+                Some("mapper closed".to_string())
+            } else {
+                match senders_guard.map.entry(key.clone()) {
+                    Entry::Occupied(_) => Some(format!(
+                        "duplicate in-flight request id: {key}; refusing to overwrite existing sender"
+                    )),
+                    Entry::Vacant(slot) => {
+                        slot.insert(tx.clone());
+                        None
+                    }
+                }
             }
-            senders_guard.closed
         };
 
-        if mapper_closed {
-            let _ = tx
-                .send(Err(Error::Mapper("mapper closed".to_string())))
-                .await;
-
+        if let Some(reason) = early_error {
+            let _ = tx.send(Err(Error::Mapper(reason))).await;
             return rx;
         }
 
@@ -760,6 +771,113 @@ mod tests {
         assert!(
             !senders.lock().unwrap().map.contains_key("42"),
             "senders map should be cleaned up on read_tx send failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_method_rejects_duplicate_request_id() {
+        // Regression: two concurrent stream() calls for the same request id used to
+        // silently overwrite each other in `senders.map`. The first task's response
+        // sender was dropped and its in-flight gRPC frames were rerouted to the second
+        // task — leading to duplicate downstream child ids and a partial-ack incident
+        // (see misc/investigations/map-stream-loss.md).
+        //
+        // Expected behavior: the in-flight sender is preserved and the duplicate call
+        // returns an error on its own rx without touching the existing entry.
+
+        let (read_tx, mut read_rx) = mpsc::channel::<MapRequest>(10);
+
+        let dummy_handle = tokio::spawn(async {});
+        let abort_handle = Arc::new(AbortOnDropHandle::new(dummy_handle));
+
+        let senders = Arc::new(Mutex::new(StreamSenderMapState::default()));
+        let mapper = UserDefinedStreamMap {
+            read_tx,
+            senders: Arc::clone(&senders),
+            _handle: abort_handle,
+        };
+
+        let make_request = |id: &str| MapRequest {
+            request: Some(numaflow_pb::clients::map::map_request::Request {
+                keys: vec!["k".into()],
+                value: b"v".to_vec(),
+                event_time: None,
+                watermark: None,
+                headers: Default::default(),
+                metadata: None,
+            }),
+            id: id.to_string(),
+            handshake: None,
+            status: None,
+        };
+
+        let cln_token = CancellationToken::new();
+
+        // First stream() call — inserts a sender for "dup-id" and forwards the request
+        // to the server side (here, read_rx). We hold rx_first so the channel stays
+        // alive and the map entry remains.
+        let mut rx_first = mapper
+            .stream(make_request("dup-id"), cln_token.clone())
+            .await;
+        let first_req = read_rx
+            .recv()
+            .await
+            .expect("first request should be forwarded to read_rx");
+        assert_eq!(first_req.id, "dup-id");
+
+        // Snapshot the sender pointer for "dup-id" so we can assert it was NOT replaced.
+        let first_sender_ptr = {
+            let guard = senders.lock().unwrap();
+            let sender = guard
+                .map
+                .get("dup-id")
+                .expect("first sender must be in the map");
+            sender.clone()
+        };
+
+        // Second stream() call with the SAME id — must fast-fail on its own rx without
+        // overwriting the existing entry or forwarding a request to the server.
+        let mut rx_dup = mapper
+            .stream(make_request("dup-id"), cln_token.clone())
+            .await;
+
+        let dup = tokio::time::timeout(Duration::from_millis(500), rx_dup.recv())
+            .await
+            .expect("duplicate rx must yield within 500ms (no hang on collision)")
+            .expect("duplicate rx must yield Some(err)");
+        let err = dup.expect_err("duplicate rx must yield Err variant");
+        assert!(matches!(err, MapError::Mapper(_)));
+        assert!(
+            err.to_string().contains("duplicate in-flight request id"),
+            "unexpected error message: {err}"
+        );
+
+        // The original sender must still be in the map AND must be the same Sender —
+        // not a fresh one inserted by the duplicate call.
+        {
+            let guard = senders.lock().unwrap();
+            let still = guard
+                .map
+                .get("dup-id")
+                .expect("first sender must remain in the map after collision is rejected");
+            assert!(
+                still.same_channel(&first_sender_ptr),
+                "duplicate stream() must not replace the in-flight sender"
+            );
+        }
+
+        // First rx must be untouched — no spurious error pushed onto it by the collision.
+        let no_error = tokio::time::timeout(Duration::from_millis(50), rx_first.recv()).await;
+        assert!(
+            no_error.is_err(),
+            "first rx must not receive anything when a duplicate stream() is rejected"
+        );
+
+        // The duplicate call must NOT have forwarded a request to the server.
+        let no_req = tokio::time::timeout(Duration::from_millis(50), read_rx.recv()).await;
+        assert!(
+            no_req.is_err(),
+            "duplicate stream() must not forward its request to the server"
         );
     }
 }

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
@@ -1,17 +1,18 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use async_nats::jetstream::Context;
 use async_nats::jetstream::consumer::PullConsumer;
 use async_nats::jetstream::context::{PublishAckFuture, PublishErrorKind};
 use async_nats::jetstream::message::PublishMessage;
 use async_nats::jetstream::stream::RetentionPolicy::Limits;
-use async_nats::jetstream::Context;
 use bytes::{Bytes, BytesMut};
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
 
+use crate::Result;
 use crate::config::pipeline::isb::{BufferWriterConfig, CompressionType, Stream};
 use crate::error::Error;
 use crate::message::Message;
@@ -20,7 +21,6 @@ use crate::metrics::{
 };
 use crate::pipeline::isb::compression;
 use crate::pipeline::isb::error::ISBError;
-use crate::Result;
 
 /// Type alias for metric labels
 type MetricLabels = Arc<Vec<(String, String)>>;

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
@@ -72,7 +72,7 @@ impl JetStreamWriter {
         compression_type: Option<CompressionType>,
         cln_token: CancellationToken,
     ) -> Result<Self> {
-        let is_full = Arc::new(AtomicBool::new(true));
+        let is_full = Arc::new(AtomicBool::new(false));
 
         // Build metric labels once during initialization
         let buffer_labels = Arc::new(jetstream_isb_metrics_labels(stream.name));

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
@@ -1,18 +1,17 @@
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
-use async_nats::jetstream::Context;
 use async_nats::jetstream::consumer::PullConsumer;
 use async_nats::jetstream::context::{PublishAckFuture, PublishErrorKind};
 use async_nats::jetstream::message::PublishMessage;
 use async_nats::jetstream::stream::RetentionPolicy::Limits;
+use async_nats::jetstream::Context;
 use bytes::{Bytes, BytesMut};
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
 
-use crate::Result;
 use crate::config::pipeline::isb::{BufferWriterConfig, CompressionType, Stream};
 use crate::error::Error;
 use crate::message::Message;
@@ -21,6 +20,7 @@ use crate::metrics::{
 };
 use crate::pipeline::isb::compression;
 use crate::pipeline::isb::error::ISBError;
+use crate::Result;
 
 /// Type alias for metric labels
 type MetricLabels = Arc<Vec<(String, String)>>;
@@ -72,7 +72,7 @@ impl JetStreamWriter {
         compression_type: Option<CompressionType>,
         cln_token: CancellationToken,
     ) -> Result<Self> {
-        let is_full = Arc::new(AtomicBool::new(false));
+        let is_full = Arc::new(AtomicBool::new(true));
 
         // Build metric labels once during initialization
         let buffer_labels = Arc::new(jetstream_isb_metrics_labels(stream.name));

--- a/rust/numaflow-core/src/pipeline/isb/reader.rs
+++ b/rust/numaflow-core/src/pipeline/isb/reader.rs
@@ -496,6 +496,7 @@ impl<C: NumaflowTypeConfig> ISBReaderOrchestrator<C> {
         for mut message in batch.drain(..) {
             // Skip WMB control messages
             if let MessageType::WMB = message.typ {
+                // TODO: Ack with retry
                 self.reader.ack(&message.offset).await?;
                 continue;
             }


### PR DESCRIPTION
### What this PR does / why we need it
Changes:
* Handle messages that have been redelivered, with same offset, in map-stream
* Return early after sending error on channel, in `stream` method, when mapper is closed/duplicate ID exists in senders map.

### Related issues
Fixes: #3423

### Testing
* Updated the unit tests
* Tested using the validation platform

### Special notes for reviewers
Anything notable for review (risk, rollout, follow-ups).

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
