### PR TITLE
fix: mark JS stream as full until proven otherwise

### DIFF
--- a/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
@@ -65,6 +65,11 @@ pub(crate) struct JetStreamWriter {
 impl JetStreamWriter {
     /// Creates a new JetStreamWriter for a single stream and spawns a background task
     /// to monitor buffer fullness.
+    ///
+    /// The writer starts in a full state (`is_full = true`) and the background task updates
+    /// it after the first stream poll. Callers using `BufferFullStrategy::DiscardLatest`
+    /// should wait for `is_full()` to return `false` before sending messages to avoid
+    /// silent drops during the brief startup window.
     pub(crate) async fn new(
         stream: Stream,
         js_ctx: Context,

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
@@ -72,7 +72,7 @@ impl JetStreamWriter {
         compression_type: Option<CompressionType>,
         cln_token: CancellationToken,
     ) -> Result<Self> {
-        let is_full = Arc::new(AtomicBool::new(false));
+        let is_full = Arc::new(AtomicBool::new(true));
 
         // Build metric labels once during initialization
         let buffer_labels = Arc::new(jetstream_isb_metrics_labels(stream.name));

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
@@ -669,6 +669,9 @@ mod tests {
         .await
         .unwrap();
 
+        // Wait for background task to update is_full to false (initialized to true)
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
         let message = Message {
             typ: Default::default(),
             keys: Arc::from(vec!["key_test".to_string()]),
@@ -740,6 +743,9 @@ mod tests {
         )
         .await
         .unwrap();
+
+        // Wait for background task to update is_full to false (initialized to true)
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
         let message = Message {
             typ: Default::default(),

--- a/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
@@ -669,9 +669,6 @@ mod tests {
         .await
         .unwrap();
 
-        // Wait for background task to update is_full to false (initialized to true)
-        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
         let message = Message {
             typ: Default::default(),
             keys: Arc::from(vec!["key_test".to_string()]),
@@ -688,7 +685,20 @@ mod tests {
             ..Default::default()
         };
 
-        let result = writer.async_write(message).await;
+        // Retry on BufferFull until 2s timeout — is_full is initialized to true and
+        // the background task flips it to false after the first stream poll.
+        let result = tokio::time::timeout(tokio::time::Duration::from_secs(2), async {
+            loop {
+                match writer.async_write(message.clone()).await {
+                    Err(WriteError::BufferFull) => {
+                        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+                    }
+                    other => break other,
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for buffer to become available");
         assert!(
             result.is_ok(),
             "async_write with compression should succeed"
@@ -744,9 +754,6 @@ mod tests {
         .await
         .unwrap();
 
-        // Wait for background task to update is_full to false (initialized to true)
-        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
         let message = Message {
             typ: Default::default(),
             keys: Arc::from(vec!["key_test".to_string()]),
@@ -766,7 +773,20 @@ mod tests {
             ..Default::default()
         };
 
-        let result = writer.write(message).await;
+        // Retry on BufferFull until 2s timeout — is_full is initialized to true and
+        // the background task flips it to false after the first stream poll.
+        let result = tokio::time::timeout(tokio::time::Duration::from_secs(2), async {
+            loop {
+                match writer.write(message.clone()).await {
+                    Err(WriteError::BufferFull) => {
+                        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+                    }
+                    other => break other,
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for buffer to become available");
         assert!(result.is_ok(), "write with compression should succeed");
 
         // Verify the WriteResult has the expected structure

--- a/rust/numaflow-core/src/pipeline/isb/writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/writer.rs
@@ -810,6 +810,17 @@ mod tests {
             .unwrap(),
         );
 
+        // Wait until is_full flips to false — it is initialized to true and the
+        // background task flips it after the first stream poll. Without this,
+        // the orchestrator's retry-on-BufferFull races with cln_token.cancel().
+        tokio::time::timeout(tokio::time::Duration::from_secs(2), async {
+            while writers.get(stream.name).unwrap().is_full() {
+                tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for buffer to become available");
+
         let writer_components: ISBWriterOrchestratorComponents<WithoutRateLimiter> =
             ISBWriterOrchestratorComponents {
                 config: vec![ToVertexConfig {
@@ -834,9 +845,6 @@ mod tests {
             .streaming_write(messages_stream, cln_token.clone())
             .await
             .unwrap();
-
-        // Wait for background task to update is_full to false (initialized to true)
-        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
         let mut ack_rxs = vec![];
         // Send some messages

--- a/rust/numaflow-core/src/pipeline/isb/writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/writer.rs
@@ -835,6 +835,9 @@ mod tests {
             .await
             .unwrap();
 
+        // Wait for background task to update is_full to false (initialized to true)
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
         let mut ack_rxs = vec![];
         // Send some messages
         for i in 0..5 {


### PR DESCRIPTION
### What this PR does / why we need it
Currently when creating a JS writer, we initialize `is_full` atomic flag to `false`, since we're using `Limit` config for stream retention in Jetstream, we should be more conservative on the client side to avoid any possibility of data loss. 

Potential dataloss scenario:
* Buffer at sink vertex is already full (reached 80% of 30k limit)
* There are N number of preceding vertices joining at sink.
* All of the vertices restart (including sink)
* Any lag in getting the first stream/consumer info from ISB at each preceding restarted vertex, will lead to the preceding vertices to start writing to the sink vertex, even though buffer for the sink vertex is full. 

This change is to be more conservative in order to ensure stricter guards to avoid data loss, even though current max messages size in JS is set to 100k currently, and data loss in normal scenarios (non-join vertices) through this route is not possible

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
