### PR TITLE
fix: add monovtx_udf_drop_total metric for MonoVertex map UDF drops

### DIFF
--- a/docs/operations/metrics/metrics.md
+++ b/docs/operations/metrics/metrics.md
@@ -126,6 +126,7 @@ These metrics are emitted by MonoVertex pods. All MonoVertex metrics use the fol
 |--------------------------------|-------------|-----------------------------------------|
 | `monovtx_udf_time`            | Histogram   | Total time taken in UDF, in microseconds |
 | `monovtx_udf_udf_error_total` | Counter     | Total number of UDF errors              |
+| `monovtx_udf_drop_total`      | Counter     | Total number of messages dropped by the user via DROP tag in the map UDF |
 
 ### Sink Metrics
 

--- a/rust/numaflow-core/src/metrics/mod.rs
+++ b/rust/numaflow-core/src/metrics/mod.rs
@@ -99,6 +99,7 @@ const DROPPED_TOTAL: &str = "dropped";
 const PIPELINE_FORWARDER_DROP_TOTAL: &str = "drop";
 const PIPELINE_FORWARDER_DROP_BYTES_TOTAL: &str = "drop_bytes";
 const UDF_DROP_TOTAL: &str = "ud_drop";
+const MONOVTX_UDF_DROP_TOTAL: &str = "drop";
 
 const FALLBACK_SINK_WRITE_TOTAL: &str = "write";
 const PIPELINE_FALLBACK_SINK_WRITE_TOTAL: &str = "fbsink_write";
@@ -351,6 +352,8 @@ pub(crate) struct UDFMetrics {
     /// Mapper latency
     pub(crate) time: Family<Vec<(String, String)>, Histogram>,
     pub(crate) errors_total: Family<Vec<(String, String)>, Counter>,
+    /// Total messages dropped by the user via DROP tag in the map UDF
+    pub(crate) dropped_total: Family<Vec<(String, String)>, Counter>,
 }
 
 /// Family of metrics for the Reduce vertex
@@ -638,6 +641,7 @@ impl MonoVtxMetrics {
                     Histogram::new(exponential_buckets_range(100.0, 60000000.0 * 15.0, 10))
                 }),
                 errors_total: Family::<Vec<(String, String)>, Counter>::default(),
+                dropped_total: Family::<Vec<(String, String)>, Counter>::default(),
             },
 
             sink: SinkMetrics {
@@ -746,6 +750,11 @@ impl MonoVtxMetrics {
             UDF_ERROR_TOTAL,
             "Total number of UDF Errors",
             metrics.udf.errors_total.clone(),
+        );
+        udf_registry.register(
+            MONOVTX_UDF_DROP_TOTAL,
+            "Total messages dropped by the user via DROP tag in the map UDF",
+            metrics.udf.dropped_total.clone(),
         );
 
         // Sink metrics
@@ -1967,6 +1976,12 @@ mod tests {
             .get_or_create(&common_labels)
             .inc_by(2);
 
+        metrics
+            .udf
+            .dropped_total
+            .get_or_create(&common_labels)
+            .inc_by(3);
+
         metrics.sink.write_total.get_or_create(&common_labels).inc();
         metrics
             .sink
@@ -2070,6 +2085,7 @@ mod tests {
             r#"monovtx_transformer_time_count{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 1"#,
             r#"monovtx_transformer_time_bucket{le="100.0",mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 1"#,
             r#"monovtx_transformer_dropped_total{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 2"#,
+            r#"monovtx_udf_drop_total{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 3"#,
             r#"monovtx_sink_write_total{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 1"#,
             r#"monovtx_sink_time_sum{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 4.0"#,
             r#"monovtx_sink_time_count{mvtx_name="test-monovertex-metric-names",mvtx_replica="3"} 1"#,

--- a/rust/numaflow-core/src/sinker/sink.rs
+++ b/rust/numaflow-core/src/sinker/sink.rs
@@ -653,12 +653,14 @@ impl SinkWriter {
     }
 }
 
-/// Sends count of messages marked for explicit drop by the user
+/// Sends count of messages marked for explicit drop by the user.
+/// For MonoVertex these drops originate in the map UDF (or its bypass router),
+/// so they are accounted under the UDF drop counter.
 /// Currently pub(crate) to allow usage by the bypass_router.
 pub(crate) fn send_drop_metrics(is_mono_vertex: bool, dropped_messages_count: usize) {
     if is_mono_vertex {
         monovertex_metrics()
-            .sink
+            .udf
             .dropped_total
             .get_or_create(mvtx_forward_metric_labels())
             .inc_by(dropped_messages_count as u64);
@@ -1327,7 +1329,7 @@ mod tests {
     #[serial_test::serial]
     fn test_send_drop_metrics_mono_vertex() {
         let before = monovertex_metrics()
-            .sink
+            .udf
             .dropped_total
             .get_or_create(mvtx_forward_metric_labels())
             .get();
@@ -1335,7 +1337,7 @@ mod tests {
         send_drop_metrics(true, 5);
 
         let after = monovertex_metrics()
-            .sink
+            .udf
             .dropped_total
             .get_or_create(mvtx_forward_metric_labels())
             .get();
@@ -1343,7 +1345,7 @@ mod tests {
         assert_eq!(
             after,
             before + 5,
-            "monovertex sink dropped_total should be incremented by 5"
+            "monovertex udf dropped_total should be incremented by 5"
         );
     }
 


### PR DESCRIPTION
### What this PR does / why we need it
Previously, messages dropped by a user via the DROP tag in a MonoVertex map UDF were counted under `monovtx_sink_dropped_total`, conflating them with genuine sink-level drops (OnFailureStrategy::Drop after retries
  exhausted). 
  
Added a dedicated counter and redirect `send_drop_metrics` for MonoVertex to it. Mirrors the existing `monovtx_transformer_dropped_total` transformer drop metric and pipeline's `forwarder_ud_drop_total` convention.
