### PR TITLE
fix: return with rx early when stream mapper is closed

### DIFF
--- a/rust/numaflow-core/src/mapper/map/stream.rs
+++ b/rust/numaflow-core/src/mapper/map/stream.rs
@@ -349,6 +349,7 @@ impl UserDefinedStreamMap {
             let _ = tx
                 .send(Err(Error::Mapper("mapper closed".to_string())))
                 .await;
+            return rx;
         }
 
         // only insert if we are able to send the message to the server


### PR DESCRIPTION
### What this PR does / why we need it
We don't need to send any message to udf server when the senders_map is closed for tracking senders since that means the receiver task already exit.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
