### PR TITLE
chore: update to go 1.25.10 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/numaproj/numaflow
 
-go 1.25.0
+go 1.25.10
 
 require (
 	github.com/IBM/sarama v1.46.3


### PR DESCRIPTION
Pending vulnerabilities in current latest image:
<img width="2556" height="1194" alt="Screenshot 2026-05-13 at 3 57 09 PM" src="https://github.com/user-attachments/assets/0a7f889f-d542-4d3e-ad5b-902cb8769b20" />

from `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image quay.io/numaproj/numaflow:latest`
