### PR TITLE
fix: option to skip main image rebuilds during `make Test%`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,10 +153,15 @@ cleanup-e2e:
 	kubectl -n numaflow-system delete po -lnumaflow-e2e=true --ignore-not-found=true
 
 # To run just one of the e2e tests by name (i.e. 'make TestCreateSimplePipeline'):
+# Set SKIP_IMAGE_BUILD=true to skip rebuilding the main image and restarting the
+# controller-manager pod (useful for iterative test runs when only test code changed).
 Test%:
 	$(MAKE) cleanup-e2e
-	$(MAKE) image e2eapi-image
+ifndef SKIP_IMAGE_BUILD
+	$(MAKE) image
 	kubectl -n numaflow-system delete po -lapp.kubernetes.io/component=controller-manager,app.kubernetes.io/part-of=numaflow
+endif
+	$(MAKE) e2eapi-image
 	kubectl -n numaflow-system delete po e2e-api-pod  --ignore-not-found=true
 	go generate $(shell find $(shell grep -rl $(*) ./test/*-e2e/*.go))
 	cat test/manifests/e2e-api-pod.yaml |  sed 's@quay.io/numaproj/@$(IMAGE_NAMESPACE)/@' | sed 's/:latest/:$(VERSION)/' | kubectl -n numaflow-system apply -f -


### PR DESCRIPTION
### What this PR does / why we need it

Support the `SKIP_IMAGE_BUILD` option to skip rebuilding the main image and restarting the controller-manager pod during `make Test%` rule
Uses similar pattern used in the `test-%` rule.

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
