### PR TITLE
Feat/mcp server phase1

### DIFF
--- a/cmd/commands/mcp_server.go
+++ b/cmd/commands/mcp_server.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/numaproj/numaflow/pkg/mcp"
+	sharedutil "github.com/numaproj/numaflow/pkg/shared/util"
+)
+
+func NewMCPServerCommand() *cobra.Command {
+	var (
+		kubeconfig string
+		namespace  string
+	)
+
+	command := &cobra.Command{
+		Use:   "mcp-server",
+		Short: "Start the Numaflow MCP server (read-only) over stdio",
+		Long: `Start a read-only Model Context Protocol (MCP) server for Numaflow over stdio.
+
+It exposes read-only tools (list/get Pipelines, MonoVertices and
+InterStepBufferServices) backed by the Kubernetes API, using the ambient
+kubeconfig (KUBECONFIG or ~/.kube/config) or the in-cluster config. It performs
+no create, update, delete or patch operations.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if kubeconfig != "" {
+				if err := os.Setenv("KUBECONFIG", kubeconfig); err != nil {
+					return err
+				}
+			}
+			numaflowClient, err := mcp.NewNumaflowClient()
+			if err != nil {
+				return err
+			}
+			return mcp.ServeStdio(mcp.NewRegistry(numaflowClient, namespace))
+		},
+	}
+	command.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to the kubeconfig file (defaults to $KUBECONFIG or ~/.kube/config; falls back to in-cluster config).")
+	command.Flags().StringVarP(&namespace, "namespace", "n", sharedutil.LookupEnvStringOr("NAMESPACE", ""), "Default namespace used when a tool call omits one. Empty means all namespaces for list operations.")
+	return command
+}

--- a/cmd/commands/mcp_server.go
+++ b/cmd/commands/mcp_server.go
@@ -27,33 +27,81 @@ import (
 
 func NewMCPServerCommand() *cobra.Command {
 	var (
-		kubeconfig string
-		namespace  string
+		kubeconfig     string
+		namespace      string
+		httpMode       bool
+		port           int
+		insecure       bool
+		certFile       string
+		keyFile        string
+		daemonProtocol string
 	)
 
 	command := &cobra.Command{
 		Use:   "mcp-server",
-		Short: "Start the Numaflow MCP server (read-only) over stdio",
-		Long: `Start a read-only Model Context Protocol (MCP) server for Numaflow over stdio.
+		Short: "Start the Numaflow MCP server (read-only)",
+		Long: `Start a read-only Model Context Protocol (MCP) server for Numaflow.
 
-It exposes read-only tools (list/get Pipelines, MonoVertices and
-InterStepBufferServices) backed by the Kubernetes API, using the ambient
-kubeconfig (KUBECONFIG or ~/.kube/config) or the in-cluster config. It performs
-no create, update, delete or patch operations.`,
+Exposes read-only tools (list/get Pipelines, MonoVertices, ISB Services, daemon
+runtime diagnostics, pod info, logs, and events) backed by the Kubernetes API.
+
+By default the server runs over stdio, suitable for local use with Cursor,
+Claude Code, or any MCP client that supports the stdio transport.
+
+Use --http to run as a streamable-HTTP server for in-cluster deployment.
+
+The server performs no create, update, delete or patch operations.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if kubeconfig != "" {
 				if err := os.Setenv("KUBECONFIG", kubeconfig); err != nil {
 					return err
 				}
 			}
-			numaflowClient, err := mcp.NewNumaflowClient()
+			kubeClient, numaflowClient, err := mcp.NewClients()
 			if err != nil {
 				return err
 			}
-			return mcp.ServeStdio(mcp.NewRegistry(numaflowClient, namespace))
+			reg := mcp.NewRegistry(kubeClient, numaflowClient, namespace, daemonProtocol)
+
+			if httpMode {
+				if port == 0 {
+					if insecure {
+						port = 8080
+					} else {
+						port = 8443
+					}
+				}
+				return mcp.ServeHTTP(reg, mcp.HTTPOptions{
+					Port:     port,
+					Insecure: insecure,
+					CertFile: certFile,
+					KeyFile:  keyFile,
+				})
+			}
+			return mcp.ServeStdio(reg)
 		},
 	}
-	command.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to the kubeconfig file (defaults to $KUBECONFIG or ~/.kube/config; falls back to in-cluster config).")
-	command.Flags().StringVarP(&namespace, "namespace", "n", sharedutil.LookupEnvStringOr("NAMESPACE", ""), "Default namespace used when a tool call omits one. Empty means all namespaces for list operations.")
+
+	command.Flags().StringVar(&kubeconfig, "kubeconfig", "",
+		"Path to the kubeconfig file (defaults to $KUBECONFIG or ~/.kube/config; falls back to in-cluster config).")
+	command.Flags().StringVarP(&namespace, "namespace", "n",
+		sharedutil.LookupEnvStringOr("NAMESPACE", ""),
+		"Default namespace used when a tool call omits one. Empty means all namespaces for list operations.")
+	command.Flags().BoolVar(&httpMode, "http",
+		sharedutil.LookupEnvStringOr("NUMAFLOW_MCP_HTTP", "") == "true",
+		"Run as a streamable-HTTP server instead of stdio. Suitable for in-cluster deployment.")
+	command.Flags().IntVar(&port, "port", 0,
+		"Port for the HTTP server (default 8443, or 8080 when --insecure). Only used with --http.")
+	command.Flags().BoolVar(&insecure, "insecure",
+		sharedutil.LookupEnvStringOr("NUMAFLOW_MCP_INSECURE", "") == "true",
+		"Disable TLS for the HTTP server. For development only. Only used with --http.")
+	command.Flags().StringVar(&certFile, "tls-cert", "",
+		"Path to TLS certificate file. When omitted a self-signed cert is generated. Only used with --http.")
+	command.Flags().StringVar(&keyFile, "tls-key", "",
+		"Path to TLS key file. When omitted a self-signed cert is generated. Only used with --http.")
+	command.Flags().StringVar(&daemonProtocol, "daemon-client-protocol",
+		sharedutil.LookupEnvStringOr("NUMAFLOW_DAEMON_CLIENT_PROTOCOL", "grpc"),
+		"Protocol for daemon client connections: 'grpc' (default) or 'http'.")
+
 	return command
 }

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -46,4 +46,5 @@ func init() {
 	rootCmd.AddCommand(NewWebhookCommand())
 	rootCmd.AddCommand(NewDexServerInitCommand())
 	rootCmd.AddCommand(NewMonoVtxDaemonServerCommand())
+	rootCmd.AddCommand(NewMCPServerCommand())
 }

--- a/docs/development/mcp-server.md
+++ b/docs/development/mcp-server.md
@@ -1,0 +1,203 @@
+# Numaflow MCP Server
+
+The Numaflow MCP (Model Context Protocol) server exposes **read-only** tools so AI assistants (Cursor, Claude Code, etc.) can inspect Pipelines, MonoVertices, pods, logs, metrics, watermarks, and runtime errors without scraping logs manually.
+
+The server never creates, updates, deletes, or patches Kubernetes resources.
+
+## Prerequisites
+
+Before setting up MCP locally you need:
+
+1. **Go 1.24+** — see [Development](development.md)
+2. **kubectl** configured for a cluster that runs Numaflow
+3. **Numaflow installed** on the cluster (controller + CRDs)
+4. At least one **Pipeline** or **MonoVertex** to inspect (optional but useful for testing)
+
+### Quick local cluster (kind)
+
+```shell
+kind create cluster --name numaflow-dev
+kind export kubeconfig --name numaflow-dev
+
+# Install Numaflow (from repo root)
+make start
+```
+
+Verify the cluster is reachable:
+
+```shell
+kubectl get pods -A
+kubectl get pipelines -A
+kubectl get monovertices -A
+```
+
+## Build the MCP binary
+
+From the repository root:
+
+```shell
+make build
+# Binary: ./dist/numaflow
+
+# Or build directly:
+go build -o ./dist/numaflow ./cmd/main.go
+```
+
+Confirm the subcommand exists:
+
+```shell
+./dist/numaflow mcp-server --help
+```
+
+## Run locally (stdio)
+
+The default mode uses **stdio** transport — Cursor and most local MCP clients spawn the process and talk over stdin/stdout:
+
+```shell
+export KUBECONFIG=~/.kube/config
+./dist/numaflow mcp-server --namespace default
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--kubeconfig` | `$KUBECONFIG` or `~/.kube/config` | Path to kubeconfig |
+| `-n`, `--namespace` | (empty) | Default namespace when a tool omits one. Empty = all namespaces for list ops |
+| `--daemon-client-protocol` | `grpc` | Daemon transport: `grpc` or `http` |
+| `--http` | false | Run as streamable-HTTP server (for in-cluster deployment) |
+| `--port` | 8443 (8080 with `--insecure`) | HTTP listen port |
+| `--insecure` | false | Disable TLS on HTTP server (dev only) |
+
+Environment variable equivalents: `KUBECONFIG`, `NAMESPACE`, `NUMAFLOW_DAEMON_CLIENT_PROTOCOL`, `NUMAFLOW_MCP_HTTP`, `NUMAFLOW_MCP_INSECURE`.
+
+## Cursor setup
+
+Create or edit `.cursor/mcp.json` in your project (or global Cursor MCP settings):
+
+```json
+{
+  "mcpServers": {
+    "numaflow-mcp": {
+      "command": "/absolute/path/to/dist/numaflow",
+      "args": ["mcp-server", "--namespace", "default"],
+      "env": {
+        "KUBECONFIG": "/absolute/path/to/.kube/config"
+      }
+    }
+  }
+}
+```
+
+Replace paths with your actual binary and kubeconfig locations.
+
+**Restart MCP after changes:** Cursor Settings → MCP → restart the server, or reload the window. If you rebuild the binary, restart MCP so it picks up the new build.
+
+### Tips for Cursor
+
+- Use an **absolute path** for `command` — relative paths often fail when Cursor starts the server from a different cwd.
+- Set `--namespace` to the namespace you work in most often; you can still pass `namespace` per tool call.
+- Leave `--namespace` empty if you want list tools to search all namespaces.
+
+## How daemon connectivity works
+
+Some tools (metrics, errors, watermarks, buffer info, pipeline status) call the **Pipeline/MonoVertex daemon** over gRPC.
+
+| Where MCP runs | Behavior |
+|----------------|----------|
+| **Inside the cluster** (HTTP mode) | Connects directly to in-cluster DNS, e.g. `simple-pipeline-daemon-svc.default.svc:4327` |
+| **Outside the cluster** (stdio + local kubeconfig) | Automatically opens a **Kubernetes port-forward** to the daemon pod and dials `127.0.0.1:<port>` |
+
+If daemon tools fail with `name resolver error: produced zero addresses`, the MCP server is likely running an old binary without port-forward support, or MCP was not restarted after a rebuild.
+
+## Available tools (20 read-only)
+
+### CRD discovery
+
+| Tool | Description |
+|------|-------------|
+| `list_pipelines` | List Pipelines with phase and vertex count |
+| `get_pipeline` | Full Pipeline spec and status |
+| `list_monovertices` | List MonoVertices with replica counts |
+| `get_monovertex` | Full MonoVertex spec and status |
+| `list_isbservices` | List InterStepBufferServices |
+
+### Daemon-backed diagnostics
+
+| Tool | Description |
+|------|-------------|
+| `get_pipeline_status` | Pipeline health from daemon |
+| `get_pipeline_watermarks` | Per-edge watermarks |
+| `list_buffers` | Buffer list for a pipeline |
+| `get_buffer_info` | Single buffer details |
+| `get_vertex_metrics` | Throughput and pending counts per vertex |
+| `get_vertex_errors` | Structured runtime errors per vertex |
+| `get_monovertex_status` | MonoVertex health from daemon |
+| `get_monovertex_metrics` | MonoVertex throughput and pending |
+| `get_monovertex_errors` | MonoVertex runtime errors |
+
+### Kubernetes-backed
+
+| Tool | Description |
+|------|-------------|
+| `list_namespaces` | Namespaces with Numaflow resources |
+| `get_cluster_summary` | Cluster-wide summary |
+| `list_pods` | Pods for a pipeline vertex or MonoVertex |
+| `get_pod_info` | Pod status, containers, restarts, resources |
+| `tail_pod_logs` | Last N lines of pod logs |
+| `list_namespace_events` | Recent namespace events |
+
+## Example assistant prompts
+
+Once MCP is connected, you can ask your assistant things like:
+
+- *"List pipelines in the default namespace"*
+- *"Get metrics for all vertices in simple-pipeline"*
+- *"Show pod info and logs for map-mono-vertex in numaflow-demo"*
+- *"Are there any errors on the cat vertex of simple-pipeline?"*
+- *"Compare map-mono-vertex and minimal-mono-vertex metrics"*
+
+## HTTP mode (in-cluster)
+
+For running MCP inside Kubernetes (not typical for local dev):
+
+```shell
+./dist/numaflow mcp-server --http --port 8443 --namespace numaflow-system
+```
+
+Use `--insecure` only on trusted networks. TLS cert/key can be supplied with `--tls-cert` and `--tls-key`; otherwise a self-signed cert is generated.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `failed to get kubernetes rest config` | Bad or missing kubeconfig | Set `KUBECONFIG` or `--kubeconfig` |
+| `pipelines.numaflow.io "X" not found` | Wrong name/namespace | Use `list_pipelines` to find exact names |
+| `name resolver error: produced zero addresses` | Old MCP binary or no restart | Rebuild, restart MCP server |
+| `GetVertexMetrics failed` / daemon errors | Daemon pod not running | `kubectl get pods -l app.kubernetes.io/component=daemon` |
+| Empty metrics-server fields in pod info | metrics-server not installed | Install metrics-server (see [Development](development.md)) |
+| MCP tools not visible in Cursor | Config not loaded | Check `.cursor/mcp.json`, restart MCP |
+
+### Manual daemon check (optional)
+
+Port-forward a pipeline daemon and verify gRPC works:
+
+```shell
+# Find daemon pod
+kubectl get pods -n default -l numaflow.numaproj.io/pipeline-name=simple-pipeline
+
+# Port-forward (replace pod name)
+kubectl port-forward -n default pod/simple-pipeline-daemon-xxxxx 4327:4327
+```
+
+## Development & tests
+
+```shell
+# Unit tests
+go test ./pkg/mcp/...
+
+# Integration test (requires live cluster + kubeconfig)
+go test -tags=integration ./pkg/mcp/ -run TestDaemonConnectorPortForward -v
+```
+
+Implementation lives under `pkg/mcp/`. The out-of-cluster port-forward logic is in `pkg/mcp/daemon_connect.go`.

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/imdario/mergo v0.3.16
+	github.com/mark3labs/mcp-go v0.54.1
 	github.com/nats-io/nats-server/v2 v2.11.15
 	github.com/nats-io/nats.go v1.49.0
 	github.com/prometheus/client_golang v1.23.0
@@ -118,6 +119,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
@@ -168,11 +170,12 @@ require (
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sanity-io/litter v1.5.5 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
-	github.com/spf13/cast v1.6.0 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
@@ -190,6 +193,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yudai/gojsondiff v1.0.0 // indirect
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	go.mongodb.org/mongo-driver v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/eapache/go-resiliency v1.7.0 h1:n3NRTnBn5N0Cbi/IeOHuQn9s2UwVUH7Ga0ZWcP+9JTA=
 github.com/eapache/go-resiliency v1.7.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=
@@ -306,6 +308,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -427,6 +431,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mark3labs/mcp-go v0.54.1 h1:Ap/ptEB9FtWzFKM8NDsTA7QDxerQOC06eZigrTldVj0=
+github.com/mark3labs/mcp-go v0.54.1/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
@@ -535,6 +541,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sanity-io/litter v1.5.5 h1:iE+sBxPBzoK6uaEP5Lt3fHNgpKcHXc/A2HGETy0uJQo=
 github.com/sanity-io/litter v1.5.5/go.mod h1:9gzJgR2i4ZpjZHsKvUXIRQVk7P+yM3e+jAF7bU2UI5U=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
@@ -550,8 +558,8 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
-github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
+github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -620,6 +628,8 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0 h1:6fRhSjgLCkTD3JnJxvaJ4Sj+TYblw757bqYgZaOq5ZY=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCOA=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 h1:BHyfKlQyqbsFN5p3IfnEUduWvb9is428/nNb5L3U01M=

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -15,33 +15,38 @@ limitations under the License.
 */
 
 // Package mcp implements a read-only Model Context Protocol (MCP) server for
-// Numaflow. It exposes a small set of read-only tools (list/get Pipelines,
-// MonoVertices and InterStepBufferServices) backed by the Kubernetes API so
-// that MCP clients (e.g. Cursor, Claude) can inspect Numaflow resources.
+// Numaflow. It exposes read-only tools (CRD list/get, daemon-backed runtime
+// diagnostics, and Kubernetes pod/log/event tools) so that MCP clients
+// (e.g. Cursor, Claude Code) can inspect Numaflow resources without log scraping.
 //
-// The server performs no create, update, delete or patch operations: it is
-// read-only by construction.
+// The server performs no create, update, delete or patch operations.
 package mcp
 
 import (
 	"fmt"
+
+	"k8s.io/client-go/kubernetes"
 
 	dfv1versiond "github.com/numaproj/numaflow/pkg/client/clientset/versioned"
 	dfv1clients "github.com/numaproj/numaflow/pkg/client/clientset/versioned/typed/numaflow/v1alpha1"
 	"github.com/numaproj/numaflow/pkg/shared/util"
 )
 
-// NewNumaflowClient builds a Numaflow typed client from the ambient kubeconfig
-// (KUBECONFIG or ~/.kube/config) or, when running inside a cluster, the
-// in-cluster config.
-func NewNumaflowClient() (dfv1clients.NumaflowV1alpha1Interface, error) {
+// NewClients builds a Kubernetes core client and a Numaflow typed client from
+// the ambient kubeconfig (KUBECONFIG or ~/.kube/config) or, when running
+// inside a cluster, the in-cluster config.
+func NewClients() (kubernetes.Interface, dfv1clients.NumaflowV1alpha1Interface, error) {
 	restConfig, err := util.K8sRestConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get kubernetes rest config: %w", err)
+		return nil, nil, fmt.Errorf("failed to get kubernetes rest config: %w", err)
+	}
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 	clientset, err := dfv1versiond.NewForConfig(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create numaflow client: %w", err)
+		return nil, nil, fmt.Errorf("failed to create numaflow client: %w", err)
 	}
-	return clientset.NumaflowV1alpha1(), nil
+	return kubeClient, clientset.NumaflowV1alpha1(), nil
 }

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mcp implements a read-only Model Context Protocol (MCP) server for
+// Numaflow. It exposes a small set of read-only tools (list/get Pipelines,
+// MonoVertices and InterStepBufferServices) backed by the Kubernetes API so
+// that MCP clients (e.g. Cursor, Claude) can inspect Numaflow resources.
+//
+// The server performs no create, update, delete or patch operations: it is
+// read-only by construction.
+package mcp
+
+import (
+	"fmt"
+
+	dfv1versiond "github.com/numaproj/numaflow/pkg/client/clientset/versioned"
+	dfv1clients "github.com/numaproj/numaflow/pkg/client/clientset/versioned/typed/numaflow/v1alpha1"
+	"github.com/numaproj/numaflow/pkg/shared/util"
+)
+
+// NewNumaflowClient builds a Numaflow typed client from the ambient kubeconfig
+// (KUBECONFIG or ~/.kube/config) or, when running inside a cluster, the
+// in-cluster config.
+func NewNumaflowClient() (dfv1clients.NumaflowV1alpha1Interface, error) {
+	restConfig, err := util.K8sRestConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubernetes rest config: %w", err)
+	}
+	clientset, err := dfv1versiond.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create numaflow client: %w", err)
+	}
+	return clientset.NumaflowV1alpha1(), nil
+}

--- a/pkg/mcp/daemon_connect.go
+++ b/pkg/mcp/daemon_connect.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// daemonConnector resolves in-cluster daemon service addresses to a dialable
+// endpoint. When the MCP server runs outside the cluster (e.g. stdio mode with
+// a local kubeconfig), cluster DNS names like "pipeline-daemon-svc.ns.svc:4327"
+// do not resolve; in that case a cached Kubernetes port-forward to the daemon
+// pod is established instead.
+type daemonConnector struct {
+	restConfig *rest.Config
+	kubeClient kubernetes.Interface
+
+	mu       sync.Mutex
+	forwards map[string]*daemonPortForward
+}
+
+type daemonPortForward struct {
+	localAddr string
+	stopCh    chan struct{}
+}
+
+func newDaemonConnector(restConfig *rest.Config, kubeClient kubernetes.Interface) *daemonConnector {
+	return &daemonConnector{
+		restConfig: restConfig,
+		kubeClient: kubeClient,
+		forwards:   make(map[string]*daemonPortForward),
+	}
+}
+
+func isInCluster() bool {
+	_, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	return err == nil
+}
+
+// resolve returns a dialable address for the daemon service. In-cluster callers
+// receive the original cluster DNS address unchanged. Out-of-cluster callers
+// receive a localhost port-forward address when one can be established; if
+// port-forward setup fails the original address is returned as a fallback.
+func (c *daemonConnector) resolve(ctx context.Context, clusterAddr string) (string, error) {
+	if c == nil || isInCluster() {
+		return clusterAddr, nil
+	}
+	addr, err := c.portForward(ctx, clusterAddr)
+	if err != nil {
+		return clusterAddr, nil
+	}
+	return addr, nil
+}
+
+func (c *daemonConnector) portForward(ctx context.Context, clusterAddr string) (string, error) {
+	c.mu.Lock()
+	if pf, ok := c.forwards[clusterAddr]; ok {
+		c.mu.Unlock()
+		return pf.localAddr, nil
+	}
+	c.mu.Unlock()
+
+	svcName, ns, remotePort, err := parseClusterSvcAddr(clusterAddr)
+	if err != nil {
+		return clusterAddr, err
+	}
+
+	podName, err := c.findDaemonPod(ctx, ns, svcName)
+	if err != nil {
+		return "", fmt.Errorf("find daemon pod for %s/%s: %w", ns, svcName, err)
+	}
+
+	localPort, err := freeLocalPort()
+	if err != nil {
+		return "", fmt.Errorf("allocate local port: %w", err)
+	}
+
+	stopCh := make(chan struct{}, 1)
+	readyCh := make(chan struct{})
+	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", ns, podName)
+	transport, upgrader, err := spdy.RoundTripperFor(c.restConfig)
+	if err != nil {
+		return "", fmt.Errorf("create port-forward transport: %w", err)
+	}
+	scheme, host := restConfigHost(c.restConfig)
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost,
+		&url.URL{Scheme: scheme, Path: path, Host: host})
+	fw, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", localPort, remotePort)}, stopCh, readyCh, io.Discard, io.Discard)
+	if err != nil {
+		return "", fmt.Errorf("create port-forward: %w", err)
+	}
+
+	go func() {
+		_ = fw.ForwardPorts()
+	}()
+
+	select {
+	case <-readyCh:
+	case <-ctx.Done():
+		close(stopCh)
+		return "", ctx.Err()
+	}
+
+	localAddr := fmt.Sprintf("127.0.0.1:%d", localPort)
+	pf := &daemonPortForward{localAddr: localAddr, stopCh: stopCh}
+
+	c.mu.Lock()
+	c.forwards[clusterAddr] = pf
+	c.mu.Unlock()
+
+	return localAddr, nil
+}
+
+func (c *daemonConnector) findDaemonPod(ctx context.Context, ns, svcName string) (string, error) {
+	svc, err := c.kubeClient.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if len(svc.Spec.Selector) == 0 {
+		return "", fmt.Errorf("service %q has no selector", svcName)
+	}
+	pods, err := c.kubeClient.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.Set(svc.Spec.Selector).String(),
+	})
+	if err != nil {
+		return "", err
+	}
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			return pod.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no running daemon pod found for service %q", svcName)
+}
+
+// parseClusterSvcAddr parses addresses of the form "name.ns.svc:port".
+func parseClusterSvcAddr(addr string) (svcName, ns string, port int, err error) {
+	host, portStr, splitErr := net.SplitHostPort(addr)
+	if splitErr != nil {
+		return "", "", 0, fmt.Errorf("invalid cluster service address %q: %w", addr, splitErr)
+	}
+	port, err = strconv.Atoi(portStr)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid port in address %q: %w", addr, err)
+	}
+	parts := strings.SplitN(host, ".", 3)
+	if len(parts) != 3 || parts[2] != "svc" {
+		return "", "", 0, fmt.Errorf("invalid cluster service address %q", addr)
+	}
+	return parts[0], parts[1], port, nil
+}
+
+func restConfigHost(config *rest.Config) (scheme, host string) {
+	if strings.HasPrefix(config.Host, "https://") {
+		return "https", strings.TrimPrefix(config.Host, "https://")
+	}
+	return "http", strings.TrimPrefix(config.Host, "http://")
+}
+
+func freeLocalPort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port, nil
+}

--- a/pkg/mcp/daemon_connect_integration_test.go
+++ b/pkg/mcp/daemon_connect_integration_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the License specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mvtdaemonclient "github.com/numaproj/numaflow/pkg/mvtxdaemon/client"
+	"github.com/numaproj/numaflow/pkg/shared/util"
+)
+
+func TestDaemonConnectorPortForwardMapMonoVertex(t *testing.T) {
+	if isInCluster() {
+		t.Skip("integration test targets out-of-cluster port-forward path")
+	}
+	restConfig, err := util.K8sRestConfig()
+	require.NoError(t, err)
+	kube, _, err := NewClients()
+	require.NoError(t, err)
+
+	connector := newDaemonConnector(restConfig, kube)
+	addr, err := connector.resolve(context.Background(), "map-mono-vertex-mv-daemon-svc.numaflow-demo.svc:4327")
+	require.NoError(t, err)
+	require.Contains(t, addr, "127.0.0.1:")
+
+	client, err := mvtdaemonclient.NewGRPCClient(addr)
+	require.NoError(t, err)
+	defer client.Close()
+
+	metrics, err := client.GetMonoVertexMetrics(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, metrics)
+	require.Equal(t, "map-mono-vertex", metrics.MonoVertex)
+
+	errs, err := client.GetMonoVertexErrors(context.Background(), "map-mono-vertex")
+	require.NoError(t, err)
+	t.Logf("map-mono-vertex metrics: %+v", metrics)
+	t.Logf("map-mono-vertex errors: %+v", errs)
+}
+
+func TestDaemonConnectorPortForwardMinimalMonoVertex(t *testing.T) {
+	if isInCluster() {
+		t.Skip("integration test targets out-of-cluster port-forward path")
+	}
+	restConfig, err := util.K8sRestConfig()
+	require.NoError(t, err)
+	kube, _, err := NewClients()
+	require.NoError(t, err)
+
+	connector := newDaemonConnector(restConfig, kube)
+	addr, err := connector.resolve(context.Background(), "minimal-mono-vertex-mv-daemon-svc.numaflow-demo.svc:4327")
+	require.NoError(t, err)
+	require.Contains(t, addr, "127.0.0.1:")
+
+	client, err := mvtdaemonclient.NewGRPCClient(addr)
+	require.NoError(t, err)
+	defer client.Close()
+
+	metrics, err := client.GetMonoVertexMetrics(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, metrics)
+	require.Equal(t, "minimal-mono-vertex", metrics.MonoVertex)
+
+	errs, err := client.GetMonoVertexErrors(context.Background(), "minimal-mono-vertex")
+	require.NoError(t, err)
+	t.Logf("minimal-mono-vertex metrics: %+v", metrics)
+	t.Logf("minimal-mono-vertex errors: %+v", errs)
+}

--- a/pkg/mcp/daemon_connect_test.go
+++ b/pkg/mcp/daemon_connect_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseClusterSvcAddr(t *testing.T) {
+	svc, ns, port, err := parseClusterSvcAddr("simple-pipeline-daemon-svc.default.svc:4327")
+	require.NoError(t, err)
+	assert.Equal(t, "simple-pipeline-daemon-svc", svc)
+	assert.Equal(t, "default", ns)
+	assert.Equal(t, 4327, port)
+
+	svc, ns, port, err = parseClusterSvcAddr("map-mono-vertex-mv-daemon-svc.numaflow-demo.svc:4327")
+	require.NoError(t, err)
+	assert.Equal(t, "map-mono-vertex-mv-daemon-svc", svc)
+	assert.Equal(t, "numaflow-demo", ns)
+	assert.Equal(t, 4327, port)
+
+	_, _, _, err = parseClusterSvcAddr("invalid")
+	assert.Error(t, err)
+}
+
+func TestDaemonConnectorResolveInCluster(t *testing.T) {
+	// nil connector returns address unchanged.
+	var c *daemonConnector
+	addr, err := c.resolve(t.Context(), "simple-pipeline-daemon-svc.default.svc:4327")
+	require.NoError(t, err)
+	assert.Equal(t, "simple-pipeline-daemon-svc.default.svc:4327", addr)
+}

--- a/pkg/mcp/daemon_tools.go
+++ b/pkg/mcp/daemon_tools.go
@@ -1,0 +1,365 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	daemonclient "github.com/numaproj/numaflow/pkg/daemon/client"
+	mvtdaemonclient "github.com/numaproj/numaflow/pkg/mvtxdaemon/client"
+)
+
+// daemonClientFactory and mvtDaemonClientFactory are package-level vars so tests
+// can swap them for fakes without touching the registry constructor.
+var (
+	daemonClientFactory = func(addr, protocol string) (daemonclient.DaemonClient, error) {
+		if strings.EqualFold(protocol, "http") {
+			return daemonclient.NewRESTfulDaemonServiceClient(addr)
+		}
+		return daemonclient.NewGRPCDaemonServiceClient(addr)
+	}
+	mvtDaemonClientFactory = func(addr, protocol string) (mvtdaemonclient.MonoVertexDaemonClient, error) {
+		if strings.EqualFold(protocol, "http") {
+			return mvtdaemonclient.NewRESTfulClient(addr)
+		}
+		return mvtdaemonclient.NewGRPCClient(addr)
+	}
+)
+
+// pipelineDaemonSvcAddress returns the in-cluster DNS address of the daemon
+// service for a Pipeline.  The format must stay in sync with
+// GetDaemonServiceURL in pkg/apis/numaflow/v1alpha1/pipeline_types.go.
+func pipelineDaemonSvcAddress(ns, pipeline string) string {
+	return fmt.Sprintf("%s-daemon-svc.%s.svc:%d", pipeline, ns, dfv1.DaemonServicePort)
+}
+
+// monoVertexDaemonSvcAddress returns the in-cluster DNS address of the daemon
+// service for a MonoVertex.  Must stay in sync with GetDaemonServiceURL in
+// pkg/apis/numaflow/v1alpha1/mono_vertex_types.go.
+func monoVertexDaemonSvcAddress(ns, monoVertex string) string {
+	return fmt.Sprintf("%s-mv-daemon-svc.%s.svc:%d", monoVertex, ns, dfv1.MonoVertexDaemonServicePort)
+}
+
+// daemonRegistry extends registry with LRU-cached daemon clients and the
+// Kubernetes client needed for K8s-backed tools. It is created by
+// NewRegistry when the full set of clients is provided.
+type daemonRegistry struct {
+	registry
+	daemonClientsCache    *lru.Cache[string, daemonclient.DaemonClient]
+	mvtDaemonClientsCache *lru.Cache[string, mvtdaemonclient.MonoVertexDaemonClient]
+	daemonProtocol        string
+}
+
+// getPipelineDaemonClient returns a cached or freshly-dialled daemon client
+// for the named pipeline.
+func (r *daemonRegistry) getPipelineDaemonClient(ns, pipeline string) (daemonclient.DaemonClient, error) {
+	addr := pipelineDaemonSvcAddress(ns, pipeline)
+	if c, ok := r.daemonClientsCache.Get(addr); ok {
+		return c, nil
+	}
+	c, err := daemonClientFactory(addr, r.daemonProtocol)
+	if err != nil {
+		return nil, err
+	}
+	r.daemonClientsCache.Add(addr, c)
+	return c, nil
+}
+
+// getMonoVertexDaemonClient returns a cached or freshly-dialled daemon client
+// for the named MonoVertex.
+func (r *daemonRegistry) getMonoVertexDaemonClient(ns, monoVertex string) (mvtdaemonclient.MonoVertexDaemonClient, error) {
+	addr := monoVertexDaemonSvcAddress(ns, monoVertex)
+	if c, ok := r.mvtDaemonClientsCache.Get(addr); ok {
+		return c, nil
+	}
+	c, err := mvtDaemonClientFactory(addr, r.daemonProtocol)
+	if err != nil {
+		return nil, err
+	}
+	r.mvtDaemonClientsCache.Add(addr, c)
+	return c, nil
+}
+
+// daemonToolDefinitions returns the tool definitions for all daemon-backed
+// read-only runtime diagnostic tools.
+func (r *daemonRegistry) daemonToolDefinitions() []ToolDefinition {
+	return []ToolDefinition{
+		{
+			Tool: readOnlyTool("get_pipeline_status",
+				mcp.WithDescription("Get the overall health and data-criticality status of a Numaflow Pipeline as reported by its daemon. Returns {status, message, code}."),
+				mcp.WithString("namespace", mcp.Description("Namespace of the Pipeline. If omitted, the server's default namespace is used.")),
+				mcp.WithString("pipeline", mcp.Required(), mcp.Description("Name of the Pipeline.")),
+			),
+			Handler: r.getPipelineStatus,
+		},
+		{
+			Tool: readOnlyTool("get_pipeline_watermarks",
+				mcp.WithDescription("Get per-edge watermarks for a Numaflow Pipeline. Returns an array of {pipeline, edge, watermarks, isWatermarkEnabled, from, to}."),
+				mcp.WithString("namespace", mcp.Description("Namespace of the Pipeline.")),
+				mcp.WithString("pipeline", mcp.Required(), mcp.Description("Name of the Pipeline.")),
+			),
+			Handler: r.getPipelineWatermarks,
+		},
+		{
+			Tool: readOnlyTool("list_buffers",
+				mcp.WithDescription("List all inter-step buffers for a Numaflow Pipeline. Each entry includes pending, ack-pending, total messages, usage ratio and whether the buffer is full."),
+				mcp.WithString("namespace", mcp.Description("Namespace of the Pipeline.")),
+				mcp.WithString("pipeline", mcp.Required(), mcp.Description("Name of the Pipeline.")),
+			),
+			Handler: r.listBuffers,
+		},
+		{
+			Tool: readOnlyTool("get_buffer_info",
+				mcp.WithDescription("Get detailed buffer metrics (pending, ack-pending, total, usage, isFull) for a single inter-step buffer of a Numaflow Pipeline."),
+				mcp.WithString("namespace", mcp.Description("Namespace of the Pipeline.")),
+				mcp.WithString("pipeline", mcp.Required(), mcp.Description("Name of the Pipeline.")),
+				mcp.WithString("buffer", mcp.Required(), mcp.Description("Name of the inter-step buffer (e.g. 'simple-pipeline-cat-0').")),
+			),
+			Handler: r.getBufferInfo,
+		},
+		{
+			Tool: readOnlyTool("get_vertex_metrics",
+				mcp.WithDescription("Get throughput and pending-count metrics for a vertex (or all vertices) of a Numaflow Pipeline. Returns processing rates keyed by rate window (e.g. '1m', '5m', '15m') and pending counts per replica."),
+				mcp.WithString("namespace", mcp.Description("Namespace of the Pipeline.")),
+				mcp.WithString("pipeline", mcp.Required(), mcp.Description("Name of the Pipeline.")),
+				mcp.WithString("vertex", mcp.Required(), mcp.Description("Name of the vertex.")),
+			),
+			Handler: r.getVertexMetrics,
+		},
+		{
+			Tool: readOnlyTool("get_vertex_errors",
+				mcp.WithDescription("Get structured runtime errors persisted by the monitor sidecar for a vertex of a Numaflow Pipeline. Returns an array of {replica, containerErrors:[{containerName, error, count, lastSeen}]}."),
+				mcp.WithString("namespace", mcp.Description("Namespace of the Pipeline.")),
+				mcp.WithString("pipeline", mcp.Required(), mcp.Description("Name of the Pipeline.")),
+				mcp.WithString("vertex", mcp.Required(), mcp.Description("Name of the vertex.")),
+			),
+			Handler: r.getVertexErrors,
+		},
+		{
+			Tool: readOnlyTool("get_monovertex_status",
+				mcp.WithDescription("Get the health status of a Numaflow MonoVertex as reported by its daemon. Returns {status, message, code}."),
+				mcp.WithString("namespace", mcp.Description("Namespace of the MonoVertex.")),
+				mcp.WithString("mono_vertex", mcp.Required(), mcp.Description("Name of the MonoVertex.")),
+			),
+			Handler: r.getMonoVertexStatus,
+		},
+		{
+			Tool: readOnlyTool("get_monovertex_metrics",
+				mcp.WithDescription("Get throughput and pending-count metrics for a Numaflow MonoVertex. Returns processing rates keyed by rate window and pending counts per replica."),
+				mcp.WithString("namespace", mcp.Description("Namespace of the MonoVertex.")),
+				mcp.WithString("mono_vertex", mcp.Required(), mcp.Description("Name of the MonoVertex.")),
+			),
+			Handler: r.getMonoVertexMetrics,
+		},
+		{
+			Tool: readOnlyTool("get_monovertex_errors",
+				mcp.WithDescription("Get structured runtime errors persisted by the monitor sidecar for a Numaflow MonoVertex. Returns an array of {replica, containerErrors}."),
+				mcp.WithString("namespace", mcp.Description("Namespace of the MonoVertex.")),
+				mcp.WithString("mono_vertex", mcp.Required(), mcp.Description("Name of the MonoVertex.")),
+			),
+			Handler: r.getMonoVertexErrors,
+		},
+	}
+}
+
+func (r *daemonRegistry) getPipelineStatus(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns, pl, err := r.requirePipeline(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	c, err := r.getPipelineDaemonClient(ns, pl)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get daemon client for pipeline %q: %v", pl, err)), nil
+	}
+	status, err := c.GetPipelineStatus(ctx, pl)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("GetPipelineStatus failed for %q: %v", pl, err)), nil
+	}
+	return jsonResult(status)
+}
+
+func (r *daemonRegistry) getPipelineWatermarks(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns, pl, err := r.requirePipeline(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	c, err := r.getPipelineDaemonClient(ns, pl)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get daemon client for pipeline %q: %v", pl, err)), nil
+	}
+	wms, err := c.GetPipelineWatermarks(ctx, pl)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("GetPipelineWatermarks failed for %q: %v", pl, err)), nil
+	}
+	return jsonResult(wms)
+}
+
+func (r *daemonRegistry) listBuffers(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns, pl, err := r.requirePipeline(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	c, err := r.getPipelineDaemonClient(ns, pl)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get daemon client for pipeline %q: %v", pl, err)), nil
+	}
+	buffers, err := c.ListPipelineBuffers(ctx, pl)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("ListPipelineBuffers failed for %q: %v", pl, err)), nil
+	}
+	return jsonResult(buffers)
+}
+
+func (r *daemonRegistry) getBufferInfo(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns, pl, err := r.requirePipeline(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	bufferName, err := req.RequireString("buffer")
+	if err != nil {
+		return mcp.NewToolResultError("buffer is required"), nil
+	}
+	c, err := r.getPipelineDaemonClient(ns, pl)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get daemon client for pipeline %q: %v", pl, err)), nil
+	}
+	info, err := c.GetPipelineBuffer(ctx, pl, bufferName)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("GetPipelineBuffer failed for %q/%q: %v", pl, bufferName, err)), nil
+	}
+	return jsonResult(info)
+}
+
+func (r *daemonRegistry) getVertexMetrics(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns, pl, err := r.requirePipeline(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	vertex, err := req.RequireString("vertex")
+	if err != nil {
+		return mcp.NewToolResultError("vertex is required"), nil
+	}
+	c, err := r.getPipelineDaemonClient(ns, pl)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get daemon client for pipeline %q: %v", pl, err)), nil
+	}
+	metrics, err := c.GetVertexMetrics(ctx, pl, vertex)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("GetVertexMetrics failed for %q/%q: %v", pl, vertex, err)), nil
+	}
+	return jsonResult(metrics)
+}
+
+func (r *daemonRegistry) getVertexErrors(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns, pl, err := r.requirePipeline(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	vertex, err := req.RequireString("vertex")
+	if err != nil {
+		return mcp.NewToolResultError("vertex is required"), nil
+	}
+	c, err := r.getPipelineDaemonClient(ns, pl)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get daemon client for pipeline %q: %v", pl, err)), nil
+	}
+	errs, err := c.GetVertexErrors(ctx, pl, vertex)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("GetVertexErrors failed for %q/%q: %v", pl, vertex, err)), nil
+	}
+	return jsonResult(errs)
+}
+
+func (r *daemonRegistry) getMonoVertexStatus(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns, mv, err := r.requireMonoVertex(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	c, err := r.getMonoVertexDaemonClient(ns, mv)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get daemon client for mono vertex %q: %v", mv, err)), nil
+	}
+	status, err := c.GetMonoVertexStatus(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("GetMonoVertexStatus failed for %q: %v", mv, err)), nil
+	}
+	return jsonResult(status)
+}
+
+func (r *daemonRegistry) getMonoVertexMetrics(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns, mv, err := r.requireMonoVertex(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	c, err := r.getMonoVertexDaemonClient(ns, mv)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get daemon client for mono vertex %q: %v", mv, err)), nil
+	}
+	metrics, err := c.GetMonoVertexMetrics(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("GetMonoVertexMetrics failed for %q: %v", mv, err)), nil
+	}
+	return jsonResult(metrics)
+}
+
+func (r *daemonRegistry) getMonoVertexErrors(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns, mv, err := r.requireMonoVertex(req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	c, err := r.getMonoVertexDaemonClient(ns, mv)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get daemon client for mono vertex %q: %v", mv, err)), nil
+	}
+	errs, err := c.GetMonoVertexErrors(ctx, mv)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("GetMonoVertexErrors failed for %q: %v", mv, err)), nil
+	}
+	return jsonResult(errs)
+}
+
+// requirePipeline extracts and validates the namespace + pipeline arguments.
+func (r *daemonRegistry) requirePipeline(req mcp.CallToolRequest) (ns, pipeline string, err error) {
+	pipeline, err = req.RequireString("pipeline")
+	if err != nil {
+		return "", "", fmt.Errorf("pipeline is required")
+	}
+	ns = r.namespace(req)
+	if ns == "" {
+		return "", "", fmt.Errorf("namespace is required (no default namespace configured)")
+	}
+	return ns, pipeline, nil
+}
+
+// requireMonoVertex extracts and validates the namespace + mono_vertex arguments.
+func (r *daemonRegistry) requireMonoVertex(req mcp.CallToolRequest) (ns, monoVertex string, err error) {
+	monoVertex, err = req.RequireString("mono_vertex")
+	if err != nil {
+		return "", "", fmt.Errorf("mono_vertex is required")
+	}
+	ns = r.namespace(req)
+	if ns == "" {
+		return "", "", fmt.Errorf("namespace is required (no default namespace configured)")
+	}
+	return ns, monoVertex, nil
+}

--- a/pkg/mcp/daemon_tools.go
+++ b/pkg/mcp/daemon_tools.go
@@ -67,6 +67,7 @@ type daemonRegistry struct {
 	registry
 	daemonClientsCache    *lru.Cache[string, daemonclient.DaemonClient]
 	mvtDaemonClientsCache *lru.Cache[string, mvtdaemonclient.MonoVertexDaemonClient]
+	daemonConnector       *daemonConnector
 	daemonProtocol        string
 }
 
@@ -77,7 +78,11 @@ func (r *daemonRegistry) getPipelineDaemonClient(ns, pipeline string) (daemoncli
 	if c, ok := r.daemonClientsCache.Get(addr); ok {
 		return c, nil
 	}
-	c, err := daemonClientFactory(addr, r.daemonProtocol)
+	dialAddr, err := r.daemonConnector.resolve(context.Background(), addr)
+	if err != nil {
+		return nil, err
+	}
+	c, err := daemonClientFactory(dialAddr, r.daemonProtocol)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +97,11 @@ func (r *daemonRegistry) getMonoVertexDaemonClient(ns, monoVertex string) (mvtda
 	if c, ok := r.mvtDaemonClientsCache.Get(addr); ok {
 		return c, nil
 	}
-	c, err := mvtDaemonClientFactory(addr, r.daemonProtocol)
+	dialAddr, err := r.daemonConnector.resolve(context.Background(), addr)
+	if err != nil {
+		return nil, err
+	}
+	c, err := mvtDaemonClientFactory(dialAddr, r.daemonProtocol)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcp/daemon_tools_test.go
+++ b/pkg/mcp/daemon_tools_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/numaproj/numaflow/pkg/apis/proto/daemon"
+	"github.com/numaproj/numaflow/pkg/apis/proto/mvtxdaemon"
+	daemonclient "github.com/numaproj/numaflow/pkg/daemon/client"
+	dffake "github.com/numaproj/numaflow/pkg/client/clientset/versioned/fake"
+	mvtdaemonclient "github.com/numaproj/numaflow/pkg/mvtxdaemon/client"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// fakeDaemonClient implements DaemonClient for testing.
+type fakeDaemonClient struct {
+	status     *daemon.PipelineStatus
+	watermarks []*daemon.EdgeWatermark
+	buffers    []*daemon.BufferInfo
+	buffer     *daemon.BufferInfo
+	metrics    []*daemon.VertexMetrics
+	errors     []*daemon.ReplicaErrors
+}
+
+func (f *fakeDaemonClient) Close() error                    { return nil }
+func (f *fakeDaemonClient) IsDrained(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+func (f *fakeDaemonClient) ListPipelineBuffers(_ context.Context, _ string) ([]*daemon.BufferInfo, error) {
+	return f.buffers, nil
+}
+func (f *fakeDaemonClient) GetPipelineBuffer(_ context.Context, _, _ string) (*daemon.BufferInfo, error) {
+	return f.buffer, nil
+}
+func (f *fakeDaemonClient) GetVertexMetrics(_ context.Context, _, _ string) ([]*daemon.VertexMetrics, error) {
+	return f.metrics, nil
+}
+func (f *fakeDaemonClient) GetPipelineWatermarks(_ context.Context, _ string) ([]*daemon.EdgeWatermark, error) {
+	return f.watermarks, nil
+}
+func (f *fakeDaemonClient) GetPipelineStatus(_ context.Context, _ string) (*daemon.PipelineStatus, error) {
+	return f.status, nil
+}
+func (f *fakeDaemonClient) GetVertexErrors(_ context.Context, _, _ string) ([]*daemon.ReplicaErrors, error) {
+	return f.errors, nil
+}
+
+var _ daemonclient.DaemonClient = (*fakeDaemonClient)(nil)
+
+// fakeMVTDaemonClient implements MonoVertexDaemonClient for testing.
+type fakeMVTDaemonClient struct {
+	status  *mvtxdaemon.MonoVertexStatus
+	metrics *mvtxdaemon.MonoVertexMetrics
+	errors  []*mvtxdaemon.ReplicaErrors
+}
+
+func (f *fakeMVTDaemonClient) Close() error { return nil }
+func (f *fakeMVTDaemonClient) GetMonoVertexMetrics(_ context.Context) (*mvtxdaemon.MonoVertexMetrics, error) {
+	return f.metrics, nil
+}
+func (f *fakeMVTDaemonClient) GetMonoVertexStatus(_ context.Context) (*mvtxdaemon.MonoVertexStatus, error) {
+	return f.status, nil
+}
+func (f *fakeMVTDaemonClient) GetMonoVertexErrors(_ context.Context, _ string) ([]*mvtxdaemon.ReplicaErrors, error) {
+	return f.errors, nil
+}
+
+var _ mvtdaemonclient.MonoVertexDaemonClient = (*fakeMVTDaemonClient)(nil)
+
+// newDaemonTestRegistry injects fake daemon clients into the registry and
+// returns the populated ToolRegistry together with the fake clients for
+// assertion.
+func newDaemonTestRegistry(t *testing.T) (ToolRegistry, *fakeDaemonClient, *fakeMVTDaemonClient) {
+	t.Helper()
+
+	fdc := &fakeDaemonClient{
+		status:     &daemon.PipelineStatus{Status: "healthy", Message: "all good", Code: "200"},
+		watermarks: []*daemon.EdgeWatermark{{Pipeline: "p1", Edge: "in-out", IsWatermarkEnabled: wrapperspb.Bool(true)}},
+		buffers:    []*daemon.BufferInfo{{Pipeline: "p1", BufferName: "p1-in-out-0", PendingCount: wrapperspb.Int64(42)}},
+		buffer:     &daemon.BufferInfo{Pipeline: "p1", BufferName: "p1-in-out-0", PendingCount: wrapperspb.Int64(42)},
+		metrics:    []*daemon.VertexMetrics{{Pipeline: "p1", Vertex: "in"}},
+		errors:     []*daemon.ReplicaErrors{},
+	}
+	fmdc := &fakeMVTDaemonClient{
+		status:  &mvtxdaemon.MonoVertexStatus{Status: "healthy"},
+		metrics: &mvtxdaemon.MonoVertexMetrics{MonoVertex: "mv1"},
+		errors:  []*mvtxdaemon.ReplicaErrors{},
+	}
+
+	// Swap global factories for the duration of the test.
+	origPl := daemonClientFactory
+	origMv := mvtDaemonClientFactory
+	t.Cleanup(func() {
+		daemonClientFactory = origPl
+		mvtDaemonClientFactory = origMv
+	})
+	daemonClientFactory = func(_, _ string) (daemonclient.DaemonClient, error) { return fdc, nil }
+	mvtDaemonClientFactory = func(_, _ string) (mvtdaemonclient.MonoVertexDaemonClient, error) { return fmdc, nil }
+
+	nf := dffake.NewSimpleClientset().NumaflowV1alpha1()
+	kube := k8sfake.NewSimpleClientset()
+	reg := NewRegistry(kube, nf, testNS, "grpc")
+	return reg, fdc, fmdc
+}
+
+func TestGetPipelineStatus(t *testing.T) {
+	reg, _, _ := newDaemonTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_pipeline_status"), map[string]any{"namespace": testNS, "pipeline": "p1"})
+	assert.False(t, res.IsError)
+	var out daemon.PipelineStatus
+	require.NoError(t, json.Unmarshal([]byte(textOf(t, res)), &out))
+	assert.Equal(t, "healthy", out.Status)
+}
+
+func TestGetPipelineWatermarks(t *testing.T) {
+	reg, _, _ := newDaemonTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_pipeline_watermarks"), map[string]any{"namespace": testNS, "pipeline": "p1"})
+	assert.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "in-out")
+}
+
+func TestListBuffers(t *testing.T) {
+	reg, _, _ := newDaemonTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "list_buffers"), map[string]any{"namespace": testNS, "pipeline": "p1"})
+	assert.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "p1-in-out-0")
+}
+
+func TestGetBufferInfo(t *testing.T) {
+	reg, _, _ := newDaemonTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_buffer_info"), map[string]any{
+		"namespace": testNS, "pipeline": "p1", "buffer": "p1-in-out-0",
+	})
+	assert.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "p1-in-out-0")
+}
+
+func TestGetBufferInfo_MissingBuffer(t *testing.T) {
+	reg, _, _ := newDaemonTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_buffer_info"), map[string]any{"namespace": testNS, "pipeline": "p1"})
+	assert.True(t, res.IsError)
+}
+
+func TestGetVertexMetrics(t *testing.T) {
+	reg, _, _ := newDaemonTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_vertex_metrics"), map[string]any{
+		"namespace": testNS, "pipeline": "p1", "vertex": "in",
+	})
+	assert.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), `"in"`)
+}
+
+func TestGetVertexErrors(t *testing.T) {
+	reg, _, _ := newDaemonTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_vertex_errors"), map[string]any{
+		"namespace": testNS, "pipeline": "p1", "vertex": "in",
+	})
+	assert.False(t, res.IsError)
+	// empty error list marshals as []
+	assert.Contains(t, textOf(t, res), "[]")
+}
+
+func TestGetMonoVertexStatus(t *testing.T) {
+	reg, _, _ := newDaemonTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_monovertex_status"), map[string]any{"namespace": testNS, "mono_vertex": "mv1"})
+	assert.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "healthy")
+}
+
+func TestGetMonoVertexMetrics(t *testing.T) {
+	reg, _, _ := newDaemonTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_monovertex_metrics"), map[string]any{"namespace": testNS, "mono_vertex": "mv1"})
+	assert.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "mv1")
+}
+
+func TestGetMonoVertexErrors(t *testing.T) {
+	reg, _, _ := newDaemonTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_monovertex_errors"), map[string]any{"namespace": testNS, "mono_vertex": "mv1"})
+	assert.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "[]")
+}
+
+func TestDaemonTools_MissingPipeline(t *testing.T) {
+	reg, _, _ := newDaemonTestRegistry(t)
+	for _, tool := range []string{"get_pipeline_status", "get_pipeline_watermarks", "list_buffers", "get_vertex_metrics", "get_vertex_errors"} {
+		res := call(t, handlerFor(t, reg, tool), map[string]any{"namespace": testNS})
+		assert.True(t, res.IsError, "tool %q should error when pipeline arg is missing", tool)
+	}
+}
+
+func TestDaemonTools_MissingMonoVertex(t *testing.T) {
+	reg, _, _ := newDaemonTestRegistry(t)
+	for _, tool := range []string{"get_monovertex_status", "get_monovertex_metrics", "get_monovertex_errors"} {
+		res := call(t, handlerFor(t, reg, tool), map[string]any{"namespace": testNS})
+		assert.True(t, res.IsError, "tool %q should error when mono_vertex arg is missing", tool)
+	}
+}

--- a/pkg/mcp/k8s_tools.go
+++ b/pkg/mcp/k8s_tools.go
@@ -1,0 +1,549 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	dfv1clients "github.com/numaproj/numaflow/pkg/client/clientset/versioned/typed/numaflow/v1alpha1"
+	apiv1 "github.com/numaproj/numaflow/server/apis/v1"
+)
+
+const (
+	maxTailLines    = int64(10000)
+	defaultEvtLimit = int64(200)
+
+	isbSvcStatusHealthy  = "healthy"
+	isbSvcStatusCritical = "critical"
+	isbSvcStatusWarning  = "warning"
+	isbSvcStatusInactive = "inactive"
+)
+
+// k8sRegistry adds a kubernetes.Interface to the base registry so Kubernetes-
+// backed tools (namespaces, pods, logs, events, cluster summary) can be served.
+type k8sRegistry struct {
+	daemonRegistry
+	kubeClient     kubernetes.Interface
+	numaflowClient dfv1clients.NumaflowV1alpha1Interface
+}
+
+// k8sToolDefinitions returns read-only tool definitions for all Kubernetes-backed tools.
+func (r *k8sRegistry) k8sToolDefinitions() []ToolDefinition {
+	return []ToolDefinition{
+		{
+			Tool: readOnlyTool("list_namespaces",
+				mcp.WithDescription("List all Kubernetes namespaces visible to the server, excluding kube-system, kube-public, and kube-node-lease."),
+			),
+			Handler: r.listNamespaces,
+		},
+		{
+			Tool: readOnlyTool("get_cluster_summary",
+				mcp.WithDescription("Get a per-namespace summary of all Numaflow Pipelines, MonoVertices, and ISB Services in the cluster, with counts bucketed by health status (healthy/warning/critical/inactive)."),
+			),
+			Handler: r.getClusterSummary,
+		},
+		{
+			Tool: readOnlyTool("list_pods",
+				mcp.WithDescription("List pods backing a Numaflow Pipeline vertex or MonoVertex. Set kind to 'pipeline' or 'monovertex'."),
+				mcp.WithString("namespace", mcp.Required(), mcp.Description("Kubernetes namespace.")),
+				mcp.WithString("kind", mcp.Required(), mcp.Description("Resource kind: 'pipeline' or 'monovertex'.")),
+				mcp.WithString("name", mcp.Required(), mcp.Description("Name of the Pipeline or MonoVertex.")),
+				mcp.WithString("vertex", mcp.Description("Vertex name (only used when kind=pipeline).")),
+			),
+			Handler: r.listPods,
+		},
+		{
+			Tool: readOnlyTool("get_pod_info",
+				mcp.WithDescription("Get detailed status and container info for pods backing a Numaflow Pipeline vertex or MonoVertex. Includes restart counts, waiting/termination reasons, and resource requests/limits."),
+				mcp.WithString("namespace", mcp.Required(), mcp.Description("Kubernetes namespace.")),
+				mcp.WithString("kind", mcp.Required(), mcp.Description("Resource kind: 'pipeline' or 'monovertex'.")),
+				mcp.WithString("name", mcp.Required(), mcp.Description("Name of the Pipeline or MonoVertex.")),
+				mcp.WithString("vertex", mcp.Description("Vertex name (only used when kind=pipeline).")),
+			),
+			Handler: r.getPodInfo,
+		},
+		{
+			Tool: readOnlyTool("tail_pod_logs",
+				mcp.WithDescription("Fetch the last N lines of logs from a pod container. Maximum 10000 lines per call. Returns plain text with timestamps prepended by the Kubernetes log API."),
+				mcp.WithString("namespace", mcp.Required(), mcp.Description("Kubernetes namespace.")),
+				mcp.WithString("pod", mcp.Required(), mcp.Description("Pod name.")),
+				mcp.WithString("container", mcp.Description("Container name (defaults to first container if omitted).")),
+				mcp.WithNumber("lines", mcp.Description(fmt.Sprintf("Number of lines to return from the end of the log (max %d, default 100).", maxTailLines))),
+				mcp.WithString("since", mcp.Description("Only return logs newer than this duration, e.g. '5m', '1h'.")),
+				mcp.WithBoolean("previous", mcp.Description("Return logs from the previous (terminated) container instance.")),
+			),
+			Handler: r.tailPodLogs,
+		},
+		{
+			Tool: readOnlyTool("list_namespace_events",
+				mcp.WithDescription("List recent Kubernetes events for a namespace, sorted newest first. Optionally filter by object kind and name."),
+				mcp.WithString("namespace", mcp.Required(), mcp.Description("Kubernetes namespace.")),
+				mcp.WithString("object_type", mcp.Description("Filter by involved object kind, e.g. 'Pipeline', 'Pod'.")),
+				mcp.WithString("object_name", mcp.Description("Filter by involved object name (requires object_type to also be set).")),
+				mcp.WithNumber("limit", mcp.Description(fmt.Sprintf("Maximum events to return (default %d).", defaultEvtLimit))),
+			),
+			Handler: r.listNamespaceEvents,
+		},
+	}
+}
+
+func (r *k8sRegistry) listNamespaces(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	all, err := r.kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to list namespaces: %v", err)), nil
+	}
+	var names []string
+	for _, ns := range all.Items {
+		name := ns.Name
+		if name == metav1.NamespaceSystem || name == metav1.NamespacePublic || name == "kube-node-lease" {
+			continue
+		}
+		names = append(names, name)
+	}
+	return jsonResult(names)
+}
+
+func (r *k8sRegistry) getClusterSummary(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	type nsSummary struct {
+		pl  apiv1.PipelineSummary
+		isb apiv1.IsbServiceSummary
+		mv  apiv1.MonoVertexSummary
+	}
+	summaryMap := make(map[string]*nsSummary)
+
+	ensureNS := func(ns string) *nsSummary {
+		if s, ok := summaryMap[ns]; ok {
+			return s
+		}
+		s := &nsSummary{}
+		summaryMap[ns] = s
+		return s
+	}
+
+	// Pipelines
+	plList, err := r.numaflowClient.Pipelines("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to list pipelines: %v", err)), nil
+	}
+	for i := range plList.Items {
+		pl := &plList.Items[i]
+		status := pipelineHealthStatus(pl)
+		s := ensureNS(pl.Namespace)
+		if status == dfv1.PipelineStatusInactive || status == dfv1.PipelineStatusUnknown || status == dfv1.PipelineStatusDeleting {
+			s.pl.Inactive++
+		} else {
+			incrementActive(&s.pl.Active, status)
+		}
+	}
+
+	// ISB Services
+	isbList, err := r.numaflowClient.InterStepBufferServices("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to list isb services: %v", err)), nil
+	}
+	for i := range isbList.Items {
+		isb := &isbList.Items[i]
+		status := isbServiceHealthStatus(isb)
+		s := ensureNS(isb.Namespace)
+		if status == isbSvcStatusInactive {
+			s.isb.Inactive++
+		} else {
+			incrementActive(&s.isb.Active, status)
+		}
+	}
+
+	// MonoVertices
+	mvList, err := r.numaflowClient.MonoVertices("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to list mono vertices: %v", err)), nil
+	}
+	for i := range mvList.Items {
+		mv := &mvList.Items[i]
+		status := monoVertexHealthStatus(mv)
+		s := ensureNS(mv.Namespace)
+		if status == dfv1.MonoVertexStatusInactive || status == dfv1.MonoVertexStatusUnknown {
+			s.mv.Inactive++
+		} else {
+			incrementActive(&s.mv.Active, status)
+		}
+	}
+
+	// Collect and sort
+	var resp apiv1.ClusterSummaryResponse
+	for ns, s := range summaryMap {
+		resp = append(resp, apiv1.NewNamespaceSummary(ns, s.pl, s.isb, s.mv))
+	}
+	sort.Slice(resp, func(i, j int) bool { return resp[i].Namespace < resp[j].Namespace })
+	return jsonResult(resp)
+}
+
+func (r *k8sRegistry) listPods(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns, _ := req.RequireString("namespace")
+	pods, err := r.fetchPods(ctx, req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	_ = ns
+	names := make([]string, 0, len(pods))
+	for _, p := range pods {
+		names = append(names, p.Name)
+	}
+	type podSummary struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+		Phase     string `json:"phase"`
+		NodeName  string `json:"nodeName,omitempty"`
+	}
+	summaries := make([]podSummary, 0, len(pods))
+	for _, p := range pods {
+		summaries = append(summaries, podSummary{
+			Name:      p.Name,
+			Namespace: p.Namespace,
+			Phase:     string(p.Status.Phase),
+			NodeName:  p.Spec.NodeName,
+		})
+	}
+	return jsonResult(summaries)
+}
+
+func (r *k8sRegistry) getPodInfo(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	pods, err := r.fetchPods(ctx, req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	details := make([]apiv1.PodDetails, 0, len(pods))
+	for _, p := range pods {
+		details = append(details, podDetails(p))
+	}
+	return jsonResult(details)
+}
+
+func (r *k8sRegistry) tailPodLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns, err := req.RequireString("namespace")
+	if err != nil {
+		return mcp.NewToolResultError("namespace is required"), nil
+	}
+	pod, err := req.RequireString("pod")
+	if err != nil {
+		return mcp.NewToolResultError("pod is required"), nil
+	}
+
+	lines := int64(100)
+	if n := req.GetFloat("lines", 0); n > 0 {
+		lines = int64(n)
+	}
+	if lines > maxTailLines {
+		lines = maxTailLines
+	}
+
+	opts := &corev1.PodLogOptions{
+		Container:  req.GetString("container", ""),
+		TailLines:  &lines,
+		Timestamps: true,
+		Previous:   req.GetBool("previous", false),
+	}
+
+	if sinceStr := req.GetString("since", ""); sinceStr != "" {
+		d, parseErr := time.ParseDuration(sinceStr)
+		if parseErr == nil {
+			sinceSeconds := int64(d.Seconds())
+			opts.SinceSeconds = &sinceSeconds
+		}
+	}
+
+	stream, err := r.kubeClient.CoreV1().Pods(ns).GetLogs(pod, opts).Stream(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get logs for pod %q: %v", pod, err)), nil
+	}
+	defer stream.Close()
+
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to read logs for pod %q: %v", pod, err)), nil
+	}
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (r *k8sRegistry) listNamespaceEvents(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns, err := req.RequireString("namespace")
+	if err != nil {
+		return mcp.NewToolResultError("namespace is required"), nil
+	}
+
+	limit := defaultEvtLimit
+	if n := req.GetFloat("limit", 0); n > 0 {
+		limit = int64(n)
+	}
+
+	objType := req.GetString("object_type", "")
+	objName := req.GetString("object_name", "")
+
+	eventList, err := r.kubeClient.CoreV1().Events(ns).List(ctx, metav1.ListOptions{Limit: limit})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to list events in namespace %q: %v", ns, err)), nil
+	}
+
+	var events []apiv1.K8sEventsResponse
+	for _, evt := range eventList.Items {
+		if evt.LastTimestamp.IsZero() {
+			continue
+		}
+		if objType != "" && !strings.EqualFold(evt.InvolvedObject.Kind, objType) {
+			continue
+		}
+		if objName != "" && !strings.EqualFold(evt.InvolvedObject.Name, objName) {
+			continue
+		}
+		events = append(events, apiv1.NewK8sEventsResponse(
+			evt.LastTimestamp.UnixMilli(),
+			evt.Type,
+			evt.InvolvedObject.Kind,
+			evt.InvolvedObject.Name,
+			evt.Reason,
+			evt.Message,
+		))
+	}
+
+	sort.Slice(events, func(i, j int) bool { return events[i].TimeStamp > events[j].TimeStamp })
+	return jsonResult(events)
+}
+
+// fetchPods is shared by listPods and getPodInfo: derives the label selector
+// from kind/name/vertex, does the List, and returns the pod slice.
+func (r *k8sRegistry) fetchPods(ctx context.Context, req mcp.CallToolRequest) ([]corev1.Pod, error) {
+	ns, err := req.RequireString("namespace")
+	if err != nil {
+		return nil, fmt.Errorf("namespace is required")
+	}
+	kind, err := req.RequireString("kind")
+	if err != nil {
+		return nil, fmt.Errorf("kind is required (pipeline or monovertex)")
+	}
+	name, err := req.RequireString("name")
+	if err != nil {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	var selector string
+	switch strings.ToLower(kind) {
+	case "pipeline":
+		vertex := req.GetString("vertex", "")
+		if vertex != "" {
+			selector = fmt.Sprintf("%s=%s,%s=%s", dfv1.KeyPipelineName, name, dfv1.KeyVertexName, vertex)
+		} else {
+			selector = fmt.Sprintf("%s=%s", dfv1.KeyPipelineName, name)
+		}
+	case "monovertex":
+		selector = fmt.Sprintf("%s=%s", dfv1.KeyMonoVertexName, name)
+	default:
+		return nil, fmt.Errorf("kind must be 'pipeline' or 'monovertex', got %q", kind)
+	}
+
+	pods, err := r.kubeClient.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods: %v", err)
+	}
+	return pods.Items, nil
+}
+
+// podDetails builds a PodDetails from a pod without calling the metrics server
+// (avoids an extra dependency; CPU/memory fields will be empty).
+func podDetails(pod corev1.Pod) apiv1.PodDetails {
+	d := apiv1.PodDetails{
+		Name:    pod.Name,
+		Status:  string(pod.Status.Phase),
+		Message: pod.Status.Message,
+		Reason:  pod.Status.Reason,
+	}
+	d.ContainerDetailsMap = containerDetails(pod)
+	return d
+}
+
+func containerDetails(pod corev1.Pod) map[string]apiv1.ContainerDetails {
+	m := make(map[string]apiv1.ContainerDetails)
+
+	processStatus := func(status corev1.ContainerStatus, isInit bool) {
+		if isInit && !isSidecar(status.Name, pod) {
+			return
+		}
+		cd := apiv1.ContainerDetails{
+			Name:         status.Name,
+			ID:           status.ContainerID,
+			State:        containerState(status.State),
+			RestartCount: status.RestartCount,
+		}
+		if status.State.Waiting != nil {
+			cd.WaitingReason = status.State.Waiting.Reason
+			cd.WaitingMessage = status.State.Waiting.Message
+		}
+		if status.LastTerminationState.Terminated != nil {
+			cd.LastTerminationReason = status.LastTerminationState.Terminated.Reason
+			cd.LastTerminationMessage = status.LastTerminationState.Terminated.Message
+			cd.LastTerminationExitCode = &status.LastTerminationState.Terminated.ExitCode
+		}
+		if status.State.Running != nil {
+			cd.LastStartedAt = status.State.Running.StartedAt.Format(time.RFC3339)
+		}
+		m[status.Name] = cd
+	}
+
+	for _, s := range pod.Status.InitContainerStatuses {
+		processStatus(s, true)
+	}
+	for _, s := range pod.Status.ContainerStatuses {
+		processStatus(s, false)
+	}
+
+	processResources := func(c corev1.Container, isInit bool) {
+		if isInit && !isSidecar(c.Name, pod) {
+			return
+		}
+		cd, ok := m[c.Name]
+		if !ok {
+			cd = apiv1.ContainerDetails{Name: c.Name}
+		}
+		if v := c.Resources.Requests.Cpu().MilliValue(); v != 0 {
+			cd.RequestedCPU = strconv.FormatInt(v, 10) + "m"
+		}
+		if v := c.Resources.Requests.Memory().Value() / (1024 * 1024); v != 0 {
+			cd.RequestedMemory = strconv.FormatInt(v, 10) + "Mi"
+		}
+		if v := c.Resources.Limits.Cpu().MilliValue(); v != 0 {
+			cd.LimitCPU = strconv.FormatInt(v, 10) + "m"
+		}
+		if v := c.Resources.Limits.Memory().Value() / (1024 * 1024); v != 0 {
+			cd.LimitMemory = strconv.FormatInt(v, 10) + "Mi"
+		}
+		m[c.Name] = cd
+	}
+
+	for _, c := range pod.Spec.InitContainers {
+		processResources(c, true)
+	}
+	for _, c := range pod.Spec.Containers {
+		processResources(c, false)
+	}
+	return m
+}
+
+func isSidecar(name string, pod corev1.Pod) bool {
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name == name {
+			return c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways
+		}
+	}
+	return false
+}
+
+func containerState(state corev1.ContainerState) string {
+	switch {
+	case state.Running != nil:
+		return "Running"
+	case state.Waiting != nil:
+		return "Waiting"
+	case state.Terminated != nil:
+		return "Terminated"
+	default:
+		return "Unknown"
+	}
+}
+
+// pipelineHealthStatus mirrors getPipelineStatus in server/apis/v1/handler.go.
+func pipelineHealthStatus(pl *dfv1.Pipeline) string {
+	switch pl.Status.Phase {
+	case dfv1.PipelinePhaseFailed:
+		return dfv1.PipelineStatusCritical
+	case dfv1.PipelinePhasePaused, dfv1.PipelinePhasePausing:
+		return dfv1.PipelineStatusInactive
+	case dfv1.PipelinePhaseDeleting:
+		return dfv1.PipelineStatusDeleting
+	case dfv1.PipelinePhaseRunning:
+		if pl.GetDesiredPhase() == dfv1.PipelinePhasePaused {
+			return dfv1.PipelineStatusInactive
+		}
+		if !pl.Status.IsHealthy() {
+			return dfv1.PipelineStatusWarning
+		}
+		return dfv1.PipelineStatusHealthy
+	default:
+		return dfv1.PipelineStatusUnknown
+	}
+}
+
+// isbServiceHealthStatus mirrors getIsbServiceStatus in server/apis/v1/handler.go.
+func isbServiceHealthStatus(isb *dfv1.InterStepBufferService) string {
+	switch isb.Status.Phase {
+	case dfv1.ISBSvcPhaseFailed:
+		return isbSvcStatusCritical
+	case dfv1.ISBSvcPhaseUnknown:
+		return isbSvcStatusInactive
+	case dfv1.ISBSvcPhasePending, dfv1.ISBSvcPhaseRunning:
+		if !isb.Status.IsHealthy() {
+			return isbSvcStatusWarning
+		}
+		return isbSvcStatusHealthy
+	default:
+		return isbSvcStatusHealthy
+	}
+}
+
+// monoVertexHealthStatus mirrors getMonoVertexStatus in server/apis/v1/handler.go.
+func monoVertexHealthStatus(mv *dfv1.MonoVertex) string {
+	switch mv.Status.Phase {
+	case dfv1.MonoVertexPhaseFailed:
+		return dfv1.MonoVertexStatusCritical
+	case dfv1.MonoVertexPhasePaused:
+		return dfv1.MonoVertexStatusInactive
+	case dfv1.MonoVertexPhaseRunning:
+		if mv.Spec.Lifecycle.GetDesiredPhase() == dfv1.MonoVertexPhasePaused {
+			return dfv1.MonoVertexStatusInactive
+		}
+		if !mv.Status.IsHealthy() {
+			return dfv1.MonoVertexStatusWarning
+		}
+		return dfv1.MonoVertexStatusHealthy
+	default:
+		return dfv1.MonoVertexStatusUnknown
+	}
+}
+
+// incrementActive increments the correct bucket (healthy/warning/critical) on
+// an ActiveStatus by the status string returned from the *HealthStatus helpers.
+// All three resource types use the same string values ("healthy", "warning",
+// "critical"), so a single switch on the string value suffices.
+func incrementActive(a *apiv1.ActiveStatus, status string) {
+	switch status {
+	case "healthy":
+		a.Healthy++
+	case "warning":
+		a.Warning++
+	default:
+		a.Critical++
+	}
+}

--- a/pkg/mcp/k8s_tools_test.go
+++ b/pkg/mcp/k8s_tools_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	dffake "github.com/numaproj/numaflow/pkg/client/clientset/versioned/fake"
+	daemonclient "github.com/numaproj/numaflow/pkg/daemon/client"
+	mvtdaemonclient "github.com/numaproj/numaflow/pkg/mvtxdaemon/client"
+	apiv1 "github.com/numaproj/numaflow/server/apis/v1"
+)
+
+func newK8sTestRegistry(t *testing.T) ToolRegistry {
+	t.Helper()
+
+	// Swap daemon factories so the registry can be constructed without a real cluster.
+	origPl, origMv := daemonClientFactory, mvtDaemonClientFactory
+	t.Cleanup(func() { daemonClientFactory = origPl; mvtDaemonClientFactory = origMv })
+	daemonClientFactory = func(_, _ string) (daemonclient.DaemonClient, error) { return &fakeDaemonClient{}, nil }
+	mvtDaemonClientFactory = func(_, _ string) (mvtdaemonclient.MonoVertexDaemonClient, error) {
+		return &fakeMVTDaemonClient{}, nil
+	}
+
+	kube := k8sfake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNS}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-1",
+				Namespace: testNS,
+				Labels: map[string]string{
+					dfv1.KeyPipelineName: "p1",
+					dfv1.KeyVertexName:   "in",
+				},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		&corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "evt-1", Namespace: testNS},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pipeline",
+				Name: "p1",
+			},
+			Type:          "Normal",
+			Reason:        "Created",
+			Message:       "pipeline created",
+			LastTimestamp: metav1.NewTime(time.Now()),
+		},
+	)
+
+	pl := &dfv1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: testNS},
+		Spec:       dfv1.PipelineSpec{Vertices: []dfv1.AbstractVertex{{Name: "in"}, {Name: "out"}}},
+		Status:     dfv1.PipelineStatus{Phase: dfv1.PipelinePhaseRunning},
+	}
+	isb := &dfv1.InterStepBufferService{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: testNS},
+		Spec:       dfv1.InterStepBufferServiceSpec{JetStream: &dfv1.JetStreamBufferService{}},
+		Status:     dfv1.InterStepBufferServiceStatus{Phase: dfv1.ISBSvcPhaseRunning},
+	}
+	client := dffake.NewSimpleClientset()
+	nf := client.NumaflowV1alpha1()
+	ctx := context.Background()
+	_, err := nf.Pipelines(testNS).Create(ctx, pl, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = nf.InterStepBufferServices(testNS).Create(ctx, isb, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	return NewRegistry(kube, nf, testNS, "grpc")
+}
+
+func TestListNamespaces(t *testing.T) {
+	reg := newK8sTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "list_namespaces"), map[string]any{})
+	assert.False(t, res.IsError)
+	var names []string
+	require.NoError(t, json.Unmarshal([]byte(textOf(t, res)), &names))
+	assert.Contains(t, names, testNS)
+	assert.NotContains(t, names, "kube-system", "system namespaces must be filtered")
+}
+
+func TestGetClusterSummary(t *testing.T) {
+	reg := newK8sTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_cluster_summary"), map[string]any{})
+	assert.False(t, res.IsError)
+	var summary apiv1.ClusterSummaryResponse
+	require.NoError(t, json.Unmarshal([]byte(textOf(t, res)), &summary))
+	require.NotEmpty(t, summary)
+	var found bool
+	for _, ns := range summary {
+		if ns.Namespace == testNS {
+			found = true
+			total := ns.PipelineSummary.Active.Healthy + ns.PipelineSummary.Active.Warning + ns.PipelineSummary.Active.Critical
+			assert.Equal(t, 1, total, "expected exactly one active pipeline in namespace %s", testNS)
+		}
+	}
+	assert.True(t, found, "cluster summary must include %s", testNS)
+}
+
+func TestListPods(t *testing.T) {
+	reg := newK8sTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "list_pods"), map[string]any{
+		"namespace": testNS, "kind": "pipeline", "name": "p1", "vertex": "in",
+	})
+	assert.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), "pod-1")
+}
+
+func TestListPods_InvalidKind(t *testing.T) {
+	reg := newK8sTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "list_pods"), map[string]any{
+		"namespace": testNS, "kind": "banana", "name": "p1",
+	})
+	assert.True(t, res.IsError)
+}
+
+func TestGetPodInfo(t *testing.T) {
+	reg := newK8sTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_pod_info"), map[string]any{
+		"namespace": testNS, "kind": "pipeline", "name": "p1", "vertex": "in",
+	})
+	assert.False(t, res.IsError)
+	var details []apiv1.PodDetails
+	require.NoError(t, json.Unmarshal([]byte(textOf(t, res)), &details))
+	require.Len(t, details, 1)
+	assert.Equal(t, "pod-1", details[0].Name)
+}
+
+func TestListNamespaceEvents(t *testing.T) {
+	reg := newK8sTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "list_namespace_events"), map[string]any{"namespace": testNS})
+	assert.False(t, res.IsError)
+	var events []apiv1.K8sEventsResponse
+	require.NoError(t, json.Unmarshal([]byte(textOf(t, res)), &events))
+	require.NotEmpty(t, events)
+	assert.Equal(t, "Pipeline/p1", events[0].Object)
+}
+
+func TestListNamespaceEvents_FilterByType(t *testing.T) {
+	reg := newK8sTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "list_namespace_events"), map[string]any{
+		"namespace":   testNS,
+		"object_type": "Pipeline",
+		"object_name": "p1",
+	})
+	assert.False(t, res.IsError)
+	var events []apiv1.K8sEventsResponse
+	require.NoError(t, json.Unmarshal([]byte(textOf(t, res)), &events))
+	for _, e := range events {
+		assert.Equal(t, "Pipeline/p1", e.Object)
+	}
+}
+
+func TestTailPodLogs_MissingPod(t *testing.T) {
+	reg := newK8sTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "tail_pod_logs"), map[string]any{"namespace": testNS})
+	assert.True(t, res.IsError)
+}

--- a/pkg/mcp/registry.go
+++ b/pkg/mcp/registry.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	dfv1clients "github.com/numaproj/numaflow/pkg/client/clientset/versioned/typed/numaflow/v1alpha1"
+)
+
+// ToolDefinition pairs an MCP tool with the handler that serves it.
+type ToolDefinition struct {
+	Tool    mcp.Tool
+	Handler server.ToolHandlerFunc
+}
+
+// ToolRegistry exposes the set of MCP tools that the server registers. Keeping
+// this transport-agnostic means the same tools can later be served over a
+// different transport (e.g. HTTP/SSE) without changes.
+type ToolRegistry interface {
+	Tools() []ToolDefinition
+}
+
+// registry is the read-only Numaflow tool registry, backed by the Numaflow
+// typed clientset. It is read-only by construction: only list and get
+// operations are registered, never create/update/delete/patch.
+type registry struct {
+	numaflowClient dfv1clients.NumaflowV1alpha1Interface
+	// defaultNamespace is used when a tool call omits the "namespace" argument.
+	// An empty value means "all namespaces" for list operations.
+	defaultNamespace string
+}
+
+// NewRegistry creates a read-only Numaflow tool registry.
+func NewRegistry(numaflowClient dfv1clients.NumaflowV1alpha1Interface, defaultNamespace string) ToolRegistry {
+	return &registry{
+		numaflowClient:   numaflowClient,
+		defaultNamespace: defaultNamespace,
+	}
+}
+
+var _ ToolRegistry = (*registry)(nil)
+
+// readOnlyTool builds an MCP tool that is annotated as read-only and
+// non-destructive, so clients render and gate it appropriately. Every tool in
+// this registry is read-only, so all of them are constructed via this helper.
+func readOnlyTool(name string, opts ...mcp.ToolOption) mcp.Tool {
+	base := []mcp.ToolOption{
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+	}
+	return mcp.NewTool(name, append(base, opts...)...)
+}
+
+// Tools returns the read-only tool set, sorted implicitly by registration order.
+func (r *registry) Tools() []ToolDefinition {
+	return []ToolDefinition{
+		{
+			Tool: readOnlyTool("list_pipelines",
+				mcp.WithDescription("List all Numaflow Pipelines in a namespace. Each entry includes the pipeline's phase (e.g. Running, Paused, Failed), an optional status message and its vertex count."),
+				mcp.WithString("namespace", mcp.Description("Kubernetes namespace to list Pipelines in. If omitted, the server's default namespace is used (empty default means all namespaces).")),
+			),
+			Handler: r.listPipelines,
+		},
+		{
+			Tool: readOnlyTool("get_pipeline",
+				mcp.WithDescription("Get the full spec and status of a single Numaflow Pipeline."),
+				mcp.WithString("namespace", mcp.Description("Namespace of the Pipeline. If omitted, the server's default namespace is used.")),
+				mcp.WithString("pipeline", mcp.Required(), mcp.Description("Name of the Pipeline.")),
+			),
+			Handler: r.getPipeline,
+		},
+		{
+			Tool: readOnlyTool("list_monovertices",
+				mcp.WithDescription("List all Numaflow MonoVertices in a namespace. Each entry includes the MonoVertex's phase and its current/ready replica counts."),
+				mcp.WithString("namespace", mcp.Description("Kubernetes namespace to list MonoVertices in. If omitted, the server's default namespace is used (empty default means all namespaces).")),
+			),
+			Handler: r.listMonoVertices,
+		},
+		{
+			Tool: readOnlyTool("get_monovertex",
+				mcp.WithDescription("Get the full spec and status of a single Numaflow MonoVertex."),
+				mcp.WithString("namespace", mcp.Description("Namespace of the MonoVertex. If omitted, the server's default namespace is used.")),
+				mcp.WithString("mono_vertex", mcp.Required(), mcp.Description("Name of the MonoVertex.")),
+			),
+			Handler: r.getMonoVertex,
+		},
+		{
+			Tool: readOnlyTool("list_isbservices",
+				mcp.WithDescription("List all Numaflow InterStepBufferServices (ISB services) in a namespace. Each entry includes the service's phase and type (e.g. jetstream)."),
+				mcp.WithString("namespace", mcp.Description("Kubernetes namespace to list InterStepBufferServices in. If omitted, the server's default namespace is used (empty default means all namespaces).")),
+			),
+			Handler: r.listISBServices,
+		},
+	}
+}

--- a/pkg/mcp/registry.go
+++ b/pkg/mcp/registry.go
@@ -17,10 +17,14 @@ limitations under the License.
 package mcp
 
 import (
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"k8s.io/client-go/kubernetes"
 
 	dfv1clients "github.com/numaproj/numaflow/pkg/client/clientset/versioned/typed/numaflow/v1alpha1"
+	daemonclient "github.com/numaproj/numaflow/pkg/daemon/client"
+	mvtdaemonclient "github.com/numaproj/numaflow/pkg/mvtxdaemon/client"
 )
 
 // ToolDefinition pairs an MCP tool with the handler that serves it.
@@ -36,9 +40,9 @@ type ToolRegistry interface {
 	Tools() []ToolDefinition
 }
 
-// registry is the read-only Numaflow tool registry, backed by the Numaflow
-// typed clientset. It is read-only by construction: only list and get
-// operations are registered, never create/update/delete/patch.
+// registry is the base read-only registry backed by the Numaflow typed
+// clientset. It is read-only by construction: only list and get operations are
+// registered.
 type registry struct {
 	numaflowClient dfv1clients.NumaflowV1alpha1Interface
 	// defaultNamespace is used when a tool call omits the "namespace" argument.
@@ -46,19 +50,47 @@ type registry struct {
 	defaultNamespace string
 }
 
-// NewRegistry creates a read-only Numaflow tool registry.
-func NewRegistry(numaflowClient dfv1clients.NumaflowV1alpha1Interface, defaultNamespace string) ToolRegistry {
-	return &registry{
+// NewRegistry creates a full read-only Numaflow tool registry including CRD,
+// daemon-backed runtime diagnostic, and Kubernetes-backed tools.
+//
+// kubeClient and numaflowClient are both constructed by NewClients() from the
+// ambient kubeconfig. daemonProtocol selects "grpc" (default) or "http" for
+// daemon transport.
+func NewRegistry(
+	kubeClient kubernetes.Interface,
+	numaflowClient dfv1clients.NumaflowV1alpha1Interface,
+	defaultNamespace string,
+	daemonProtocol string,
+) ToolRegistry {
+	if daemonProtocol == "" {
+		daemonProtocol = "grpc"
+	}
+
+	daemonCache, _ := lru.NewWithEvict[string, daemonclient.DaemonClient](500,
+		func(_ string, c daemonclient.DaemonClient) { _ = c.Close() })
+	mvtCache, _ := lru.NewWithEvict[string, mvtdaemonclient.MonoVertexDaemonClient](500,
+		func(_ string, c mvtdaemonclient.MonoVertexDaemonClient) { _ = c.Close() })
+
+	base := registry{
 		numaflowClient:   numaflowClient,
 		defaultNamespace: defaultNamespace,
 	}
+	dr := daemonRegistry{
+		registry:              base,
+		daemonClientsCache:    daemonCache,
+		mvtDaemonClientsCache: mvtCache,
+		daemonProtocol:        daemonProtocol,
+	}
+	return &k8sRegistry{
+		daemonRegistry: dr,
+		kubeClient:     kubeClient,
+		numaflowClient: numaflowClient,
+	}
 }
 
-var _ ToolRegistry = (*registry)(nil)
+var _ ToolRegistry = (*k8sRegistry)(nil)
 
-// readOnlyTool builds an MCP tool that is annotated as read-only and
-// non-destructive, so clients render and gate it appropriately. Every tool in
-// this registry is read-only, so all of them are constructed via this helper.
+// readOnlyTool builds an MCP tool annotated as read-only and non-destructive.
 func readOnlyTool(name string, opts ...mcp.ToolOption) mcp.Tool {
 	base := []mcp.ToolOption{
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -69,8 +101,20 @@ func readOnlyTool(name string, opts ...mcp.ToolOption) mcp.Tool {
 	return mcp.NewTool(name, append(base, opts...)...)
 }
 
-// Tools returns the read-only tool set, sorted implicitly by registration order.
-func (r *registry) Tools() []ToolDefinition {
+// Tools returns the complete read-only tool set:
+//   - CRD discovery tools (list/get Pipelines, MonoVertices, ISBServices)
+//   - Daemon-backed runtime diagnostic tools
+//   - Kubernetes-backed pod/log/event tools
+func (r *k8sRegistry) Tools() []ToolDefinition {
+	var tools []ToolDefinition
+	tools = append(tools, r.registry.crdToolDefinitions()...)
+	tools = append(tools, r.daemonRegistry.daemonToolDefinitions()...)
+	tools = append(tools, r.k8sToolDefinitions()...)
+	return tools
+}
+
+// crdToolDefinitions returns the CRD list/get tools that were in the original POC.
+func (r *registry) crdToolDefinitions() []ToolDefinition {
 	return []ToolDefinition{
 		{
 			Tool: readOnlyTool("list_pipelines",
@@ -110,4 +154,12 @@ func (r *registry) Tools() []ToolDefinition {
 			Handler: r.listISBServices,
 		},
 	}
+}
+
+// namespace resolves the effective namespace for a tool call.
+func (r *registry) namespace(req mcp.CallToolRequest) string {
+	if ns := req.GetString("namespace", ""); ns != "" {
+		return ns
+	}
+	return r.defaultNamespace
 }

--- a/pkg/mcp/registry.go
+++ b/pkg/mcp/registry.go
@@ -25,6 +25,7 @@ import (
 	dfv1clients "github.com/numaproj/numaflow/pkg/client/clientset/versioned/typed/numaflow/v1alpha1"
 	daemonclient "github.com/numaproj/numaflow/pkg/daemon/client"
 	mvtdaemonclient "github.com/numaproj/numaflow/pkg/mvtxdaemon/client"
+	"github.com/numaproj/numaflow/pkg/shared/util"
 )
 
 // ToolDefinition pairs an MCP tool with the handler that serves it.
@@ -75,10 +76,15 @@ func NewRegistry(
 		numaflowClient:   numaflowClient,
 		defaultNamespace: defaultNamespace,
 	}
+	var connector *daemonConnector
+	if restConfig, err := util.K8sRestConfig(); err == nil {
+		connector = newDaemonConnector(restConfig, kubeClient)
+	}
 	dr := daemonRegistry{
 		registry:              base,
 		daemonClientsCache:    daemonCache,
 		mvtDaemonClientsCache: mvtCache,
+		daemonConnector:       connector,
 		daemonProtocol:        daemonProtocol,
 	}
 	return &k8sRegistry{

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/numaproj/numaflow"
+)
+
+// NewServer builds an MCP server that exposes the read-only Numaflow tools
+// provided by the given registry.
+func NewServer(reg ToolRegistry) *server.MCPServer {
+	s := server.NewMCPServer(
+		"Numaflow MCP Server",
+		numaflow.GetVersion().Version,
+		server.WithToolCapabilities(false),
+	)
+	for _, td := range reg.Tools() {
+		s.AddTool(td.Tool, td.Handler)
+	}
+	return s
+}
+
+// ServeStdio builds the MCP server from the registry and serves it over stdio
+// until the client disconnects or the process is signalled.
+func ServeStdio(reg ToolRegistry) error {
+	return server.ServeStdio(NewServer(reg))
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -17,18 +17,35 @@ limitations under the License.
 package mcp
 
 import (
-	"github.com/mark3labs/mcp-go/server"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	mcpserver "github.com/mark3labs/mcp-go/server"
 
 	"github.com/numaproj/numaflow"
+	sharedtls "github.com/numaproj/numaflow/pkg/shared/tls"
 )
+
+// HTTPOptions configures the streamable-HTTP transport.
+type HTTPOptions struct {
+	// Port to listen on (e.g. 8443).
+	Port int
+	// Insecure disables TLS. For development only — logs a warning on startup.
+	Insecure bool
+	// CertFile / KeyFile point to PEM-encoded TLS material. When both are empty
+	// and Insecure is false a self-signed certificate is generated automatically.
+	CertFile string
+	KeyFile  string
+}
 
 // NewServer builds an MCP server that exposes the read-only Numaflow tools
 // provided by the given registry.
-func NewServer(reg ToolRegistry) *server.MCPServer {
-	s := server.NewMCPServer(
+func NewServer(reg ToolRegistry) *mcpserver.MCPServer {
+	s := mcpserver.NewMCPServer(
 		"Numaflow MCP Server",
 		numaflow.GetVersion().Version,
-		server.WithToolCapabilities(false),
+		mcpserver.WithToolCapabilities(false),
 	)
 	for _, td := range reg.Tools() {
 		s.AddTool(td.Tool, td.Handler)
@@ -39,5 +56,58 @@ func NewServer(reg ToolRegistry) *server.MCPServer {
 // ServeStdio builds the MCP server from the registry and serves it over stdio
 // until the client disconnects or the process is signalled.
 func ServeStdio(reg ToolRegistry) error {
-	return server.ServeStdio(NewServer(reg))
+	return mcpserver.ServeStdio(NewServer(reg))
+}
+
+// ServeHTTP builds the MCP server and serves it over streamable HTTP at /mcp
+// on the configured port. When opts.Insecure is false a TLS listener is used;
+// if no cert/key files are provided a self-signed certificate is generated.
+func ServeHTTP(reg ToolRegistry, opts HTTPOptions) error {
+	addr := fmt.Sprintf(":%d", opts.Port)
+
+	if opts.Insecure {
+		fmt.Printf("WARNING: Numaflow MCP server starting without TLS on %s — do not expose outside a trusted network\n", addr)
+		s := mcpserver.NewStreamableHTTPServer(
+			NewServer(reg),
+			mcpserver.WithEndpointPath("/mcp"),
+		)
+		return s.Start(addr)
+	}
+
+	tlsCfg, err := buildTLSConfig(opts.CertFile, opts.KeyFile)
+	if err != nil {
+		return fmt.Errorf("failed to build TLS config: %w", err)
+	}
+
+	httpSrv := &http.Server{
+		Addr:      addr,
+		TLSConfig: tlsCfg,
+	}
+	s := mcpserver.NewStreamableHTTPServer(
+		NewServer(reg),
+		mcpserver.WithEndpointPath("/mcp"),
+		mcpserver.WithStreamableHTTPServer(httpSrv),
+	)
+	return s.Start(addr)
+}
+
+func buildTLSConfig(certFile, keyFile string) (*tls.Config, error) {
+	var cert *tls.Certificate
+	if certFile != "" && keyFile != "" {
+		c, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load TLS key pair: %w", err)
+		}
+		cert = &c
+	} else {
+		c, err := sharedtls.GenerateX509KeyPair()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate self-signed certificate: %w", err)
+		}
+		cert = c
+	}
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{*cert},
+	}, nil
 }

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -44,16 +44,6 @@ type objectSummary struct {
 	ReadyReplicas *uint32 `json:"readyReplicas,omitempty"`
 }
 
-// namespace resolves the namespace for a tool call: the explicit "namespace"
-// argument when present, otherwise the server's default namespace. An empty
-// result means "all namespaces" for list operations.
-func (r *registry) namespace(req mcp.CallToolRequest) string {
-	if ns := req.GetString("namespace", ""); ns != "" {
-		return ns
-	}
-	return r.defaultNamespace
-}
-
 func (r *registry) listPipelines(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	ns := r.namespace(req)
 	list, err := r.numaflowClient.Pipelines(ns).List(ctx, metav1.ListOptions{})

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// objectSummary is a compact, read-only view of a Numaflow object. It is kept
+// intentionally small so that list results do not overwhelm the model's
+// context window; use the get_* tools for the full object.
+type objectSummary struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Phase     string `json:"phase,omitempty"`
+	Message   string `json:"message,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+	// Type is populated for InterStepBufferServices (e.g. "jetstream").
+	Type string `json:"type,omitempty"`
+	// VertexCount is populated for Pipelines.
+	VertexCount *uint32 `json:"vertexCount,omitempty"`
+	// Replicas / ReadyReplicas are populated for MonoVertices.
+	Replicas      *uint32 `json:"replicas,omitempty"`
+	ReadyReplicas *uint32 `json:"readyReplicas,omitempty"`
+}
+
+// namespace resolves the namespace for a tool call: the explicit "namespace"
+// argument when present, otherwise the server's default namespace. An empty
+// result means "all namespaces" for list operations.
+func (r *registry) namespace(req mcp.CallToolRequest) string {
+	if ns := req.GetString("namespace", ""); ns != "" {
+		return ns
+	}
+	return r.defaultNamespace
+}
+
+func (r *registry) listPipelines(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns := r.namespace(req)
+	list, err := r.numaflowClient.Pipelines(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to list pipelines: %v", err)), nil
+	}
+	summaries := make([]objectSummary, 0, len(list.Items))
+	for i := range list.Items {
+		pl := &list.Items[i]
+		vertexCount := uint32(len(pl.Spec.Vertices))
+		summaries = append(summaries, objectSummary{
+			Name:        pl.Name,
+			Namespace:   pl.Namespace,
+			Phase:       string(pl.Status.Phase),
+			Message:     pl.Status.Message,
+			CreatedAt:   created(pl.ObjectMeta),
+			VertexCount: &vertexCount,
+		})
+	}
+	return jsonResult(summaries)
+}
+
+func (r *registry) getPipeline(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name, err := req.RequireString("pipeline")
+	if err != nil {
+		return mcp.NewToolResultError("pipeline is required"), nil
+	}
+	ns := r.namespace(req)
+	if ns == "" {
+		return mcp.NewToolResultError("namespace is required (no default namespace configured)"), nil
+	}
+	pl, err := r.numaflowClient.Pipelines(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get pipeline %q in namespace %q: %v", name, ns, err)), nil
+	}
+	pl.ManagedFields = nil
+	return jsonResult(pl)
+}
+
+func (r *registry) listMonoVertices(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns := r.namespace(req)
+	list, err := r.numaflowClient.MonoVertices(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to list monovertices: %v", err)), nil
+	}
+	summaries := make([]objectSummary, 0, len(list.Items))
+	for i := range list.Items {
+		mv := &list.Items[i]
+		replicas := mv.Status.Replicas
+		readyReplicas := mv.Status.ReadyReplicas
+		summaries = append(summaries, objectSummary{
+			Name:          mv.Name,
+			Namespace:     mv.Namespace,
+			Phase:         string(mv.Status.Phase),
+			CreatedAt:     created(mv.ObjectMeta),
+			Replicas:      &replicas,
+			ReadyReplicas: &readyReplicas,
+		})
+	}
+	return jsonResult(summaries)
+}
+
+func (r *registry) getMonoVertex(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name, err := req.RequireString("mono_vertex")
+	if err != nil {
+		return mcp.NewToolResultError("mono_vertex is required"), nil
+	}
+	ns := r.namespace(req)
+	if ns == "" {
+		return mcp.NewToolResultError("namespace is required (no default namespace configured)"), nil
+	}
+	mv, err := r.numaflowClient.MonoVertices(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get monovertex %q in namespace %q: %v", name, ns, err)), nil
+	}
+	mv.ManagedFields = nil
+	return jsonResult(mv)
+}
+
+func (r *registry) listISBServices(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ns := r.namespace(req)
+	list, err := r.numaflowClient.InterStepBufferServices(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to list isb services: %v", err)), nil
+	}
+	summaries := make([]objectSummary, 0, len(list.Items))
+	for i := range list.Items {
+		isb := &list.Items[i]
+		isbType := string(isb.Status.Type)
+		if isbType == "" {
+			isbType = string(isb.GetType())
+		}
+		summaries = append(summaries, objectSummary{
+			Name:      isb.Name,
+			Namespace: isb.Namespace,
+			Phase:     string(isb.Status.Phase),
+			Message:   isb.Status.Message,
+			CreatedAt: created(isb.ObjectMeta),
+			Type:      isbType,
+		})
+	}
+	return jsonResult(summaries)
+}
+
+// created renders an object's creation timestamp as an RFC3339 UTC string.
+func created(meta metav1.ObjectMeta) string {
+	if meta.CreationTimestamp.IsZero() {
+		return ""
+	}
+	return meta.CreationTimestamp.UTC().Format(time.RFC3339)
+}
+
+// jsonResult marshals v to indented JSON and wraps it as a tool text result.
+func jsonResult(v any) (*mcp.CallToolResult, error) {
+	bs, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+	}
+	return mcp.NewToolResultText(string(bs)), nil
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	dffake "github.com/numaproj/numaflow/pkg/client/clientset/versioned/fake"
+)
+
+const testNS = "test-ns"
+
+func newTestRegistry(t *testing.T) ToolRegistry {
+	t.Helper()
+	pl := &dfv1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: testNS},
+		Spec:       dfv1.PipelineSpec{Vertices: []dfv1.AbstractVertex{{Name: "in"}, {Name: "out"}}},
+		Status:     dfv1.PipelineStatus{Phase: dfv1.PipelinePhaseRunning},
+	}
+	mv := &dfv1.MonoVertex{
+		ObjectMeta: metav1.ObjectMeta{Name: "mv1", Namespace: testNS},
+		Status:     dfv1.MonoVertexStatus{Phase: dfv1.MonoVertexPhaseRunning, Replicas: 2, ReadyReplicas: 2},
+	}
+	isb := &dfv1.InterStepBufferService{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: testNS},
+		Spec:       dfv1.InterStepBufferServiceSpec{JetStream: &dfv1.JetStreamBufferService{}},
+		Status:     dfv1.InterStepBufferServiceStatus{Phase: dfv1.ISBSvcPhaseRunning},
+	}
+	// Seed via the typed client's Create rather than NewSimpleClientset(objs...),
+	// because the fake constructor mis-pluralizes irregular kinds (MonoVertex ->
+	// "monovertexs") and the seeded object would not be found by List.
+	client := dffake.NewSimpleClientset()
+	nf := client.NumaflowV1alpha1()
+	ctx := context.Background()
+	_, err := nf.Pipelines(testNS).Create(ctx, pl, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = nf.MonoVertices(testNS).Create(ctx, mv, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = nf.InterStepBufferServices(testNS).Create(ctx, isb, metav1.CreateOptions{})
+	require.NoError(t, err)
+	return NewRegistry(nf, testNS)
+}
+
+func handlerFor(t *testing.T, reg ToolRegistry, name string) server.ToolHandlerFunc {
+	t.Helper()
+	for _, td := range reg.Tools() {
+		if td.Tool.Name == name {
+			return td.Handler
+		}
+	}
+	t.Fatalf("tool %q not registered", name)
+	return nil
+}
+
+func call(t *testing.T, h server.ToolHandlerFunc, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := h(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	return res
+}
+
+func textOf(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	require.Len(t, res.Content, 1)
+	tc, ok := res.Content[0].(mcp.TextContent)
+	require.True(t, ok, "expected text content, got %T", res.Content[0])
+	return tc.Text
+}
+
+func TestRegistry_IsReadOnly(t *testing.T) {
+	reg := newTestRegistry(t)
+	names := map[string]bool{}
+	for _, td := range reg.Tools() {
+		names[td.Tool.Name] = true
+	}
+	assert.Len(t, names, 5)
+	for _, n := range []string{"list_pipelines", "get_pipeline", "list_monovertices", "get_monovertex", "list_isbservices"} {
+		assert.Contains(t, names, n)
+	}
+	for n := range names {
+		for _, verb := range []string{"create", "update", "delete", "patch", "pause", "resume"} {
+			assert.NotContains(t, n, verb, "read-only registry must not expose mutating tools")
+		}
+	}
+}
+
+func TestListPipelines(t *testing.T) {
+	reg := newTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "list_pipelines"), map[string]any{"namespace": testNS})
+	assert.False(t, res.IsError)
+	var got []objectSummary
+	require.NoError(t, json.Unmarshal([]byte(textOf(t, res)), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "p1", got[0].Name)
+	assert.Equal(t, "Running", got[0].Phase)
+	require.NotNil(t, got[0].VertexCount)
+	assert.Equal(t, uint32(2), *got[0].VertexCount)
+}
+
+func TestGetPipeline(t *testing.T) {
+	reg := newTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_pipeline"), map[string]any{"namespace": testNS, "pipeline": "p1"})
+	assert.False(t, res.IsError)
+	assert.Contains(t, textOf(t, res), `"p1"`)
+}
+
+func TestGetPipeline_MissingName(t *testing.T) {
+	reg := newTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_pipeline"), map[string]any{"namespace": testNS})
+	assert.True(t, res.IsError)
+}
+
+func TestGetPipeline_NotFound(t *testing.T) {
+	reg := newTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "get_pipeline"), map[string]any{"namespace": testNS, "pipeline": "missing"})
+	assert.True(t, res.IsError)
+}
+
+func TestListMonoVertices(t *testing.T) {
+	reg := newTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "list_monovertices"), map[string]any{"namespace": testNS})
+	assert.False(t, res.IsError)
+	var got []objectSummary
+	require.NoError(t, json.Unmarshal([]byte(textOf(t, res)), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "mv1", got[0].Name)
+	require.NotNil(t, got[0].Replicas)
+	assert.Equal(t, uint32(2), *got[0].Replicas)
+}
+
+func TestListISBServices(t *testing.T) {
+	reg := newTestRegistry(t)
+	res := call(t, handlerFor(t, reg, "list_isbservices"), map[string]any{"namespace": testNS})
+	assert.False(t, res.IsError)
+	var got []objectSummary
+	require.NoError(t, json.Unmarshal([]byte(textOf(t, res)), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "default", got[0].Name)
+	assert.Equal(t, "jetstream", got[0].Type)
+}
+
+func TestListPipelines_AllNamespaces(t *testing.T) {
+	reg := newTestRegistry(t)
+	// No namespace arg and default is testNS, so it still scopes to testNS here;
+	// this asserts the default-namespace fallback path is exercised without error.
+	res := call(t, handlerFor(t, reg, "list_pipelines"), map[string]any{})
+	assert.False(t, res.IsError)
+	var got []objectSummary
+	require.NoError(t, json.Unmarshal([]byte(textOf(t, res)), &got))
+	require.Len(t, got, 1)
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	dffake "github.com/numaproj/numaflow/pkg/client/clientset/versioned/fake"
@@ -61,7 +62,8 @@ func newTestRegistry(t *testing.T) ToolRegistry {
 	require.NoError(t, err)
 	_, err = nf.InterStepBufferServices(testNS).Create(ctx, isb, metav1.CreateOptions{})
 	require.NoError(t, err)
-	return NewRegistry(nf, testNS)
+	kubeFake := k8sfake.NewSimpleClientset()
+	return NewRegistry(kubeFake, nf, testNS, "grpc")
 }
 
 func handlerFor(t *testing.T, reg ToolRegistry, name string) server.ToolHandlerFunc {
@@ -99,8 +101,16 @@ func TestRegistry_IsReadOnly(t *testing.T) {
 	for _, td := range reg.Tools() {
 		names[td.Tool.Name] = true
 	}
-	assert.Len(t, names, 5)
-	for _, n := range []string{"list_pipelines", "get_pipeline", "list_monovertices", "get_monovertex", "list_isbservices"} {
+	// 5 CRD tools + 9 daemon tools + 6 K8s tools = 20
+	assert.Len(t, names, 20)
+	for _, n := range []string{
+		"list_pipelines", "get_pipeline", "list_monovertices", "get_monovertex", "list_isbservices",
+		"get_pipeline_status", "get_pipeline_watermarks", "list_buffers", "get_buffer_info",
+		"get_vertex_metrics", "get_vertex_errors",
+		"get_monovertex_status", "get_monovertex_metrics", "get_monovertex_errors",
+		"list_namespaces", "get_cluster_summary", "list_pods", "get_pod_info",
+		"tail_pod_logs", "list_namespace_events",
+	} {
 		assert.Contains(t, names, n)
 	}
 	for n := range names {


### PR DESCRIPTION
## What this PR does / why we need it

Adds a `numaflow mcp-server` subcommand that exposes Numaflow's existing runtime APIs as a read-only [Model Context Protocol](https://modelcontextprotocol.io) server. This lets any MCP client (Claude Code, Cursor, in-cluster ops agents) ask "what is happening with this pipeline?" and get structured answers — without log scraping or bespoke adapters.

**20 read-only tools across three categories:**
- **Discovery** — `list_pipelines`, `get_pipeline`, `list_monovertices`, `get_monovertex`, `list_isbservices`
- **Runtime diagnostics** (daemon-backed) — `get_pipeline_status`, `get_pipeline_watermarks`, `list_buffers`, `get_buffer_info`, `get_vertex_metrics`, `get_vertex_errors`, `get_monovertex_status`, `get_monovertex_metrics`, `get_monovertex_errors`
- **Kubernetes** — `list_namespaces`, `get_cluster_summary`, `list_pods`, `get_pod_info`, `tail_pod_logs`, `list_namespace_events`

Two transports: `stdio` (local dev with Cursor/Claude Code) and `streamable_http` (in-cluster deployment). No mutations. Auth is a follow-up.

## Related issues

Fixes #

## Testing

Unit tests with fake clients — no real cluster required:
```bash
go test ./pkg/mcp/... -v
# 29 tests, all pass
```

Manual smoke test against a kind cluster:
```bash
kind create cluster && kubectl apply -f config/install.yaml
kubectl apply -f examples/0-isbsvc-jetstream.yaml -f examples/1-simple-pipeline.yaml
go build -o /tmp/numaflow . && /tmp/numaflow mcp-server --stdio --namespace default
```

HTTP mode:
```bash
/tmp/numaflow mcp-server --http --insecure --port 8080 &
curl -s -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
  http://127.0.0.1:8080/mcp | jq '.result.tools[].name'
```

## Special notes for reviewers

- **Read-only by construction** — no mutating tools are registered; the `readOnlyTool` helper enforces MCP hint annotations on every tool.
- **Daemon clients** use the same LRU-cache + service DNS pattern as the UX server (`server/apis/v1/handler.go`). No new auth surface.
- Pod log calls are bounded server-side at 10 000 lines regardless of caller input.
