### PR TITLE
feat: add MCP friendly diagnostic APIs

### DIFF
--- a/pkg/apis/numaflow/v1alpha1/pipeline_types.go
+++ b/pkg/apis/numaflow/v1alpha1/pipeline_types.go
@@ -101,6 +101,13 @@ type Pipeline struct {
 	Status PipelineStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
+// GetVertexFullName returns the generated Vertex CR name for a logical vertex
+// name, which is "<pipeline>-<vertex>". This is the name used for the Vertex
+// object and as the involvedObject name on its Kubernetes events.
+func (p Pipeline) GetVertexFullName(vertexName string) string {
+	return p.Name + "-" + vertexName
+}
+
 // GetVertex is used to find the AbstractVertex info from vertex name.
 func (p Pipeline) GetVertex(vertexName string) *AbstractVertex {
 	for _, v := range p.Spec.Vertices {

--- a/pkg/apis/numaflow/v1alpha1/pipeline_types.go
+++ b/pkg/apis/numaflow/v1alpha1/pipeline_types.go
@@ -101,13 +101,6 @@ type Pipeline struct {
 	Status PipelineStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
-// GetVertexFullName returns the generated Vertex CR name for a logical vertex
-// name, which is "<pipeline>-<vertex>". This is the name used for the Vertex
-// object and as the involvedObject name on its Kubernetes events.
-func (p Pipeline) GetVertexFullName(vertexName string) string {
-	return p.Name + "-" + vertexName
-}
-
 // GetVertex is used to find the AbstractVertex info from vertex name.
 func (p Pipeline) GetVertex(vertexName string) *AbstractVertex {
 	for _, v := range p.Spec.Vertices {

--- a/server/apis/v1/handler.go
+++ b/server/apis/v1/handler.go
@@ -792,6 +792,265 @@ func (h *handler) respondWithError(c *gin.Context, message string) {
 	c.JSON(http.StatusOK, NewNumaflowAPIResponse(&message, nil))
 }
 
+// respondWithStatusError returns the given HTTP status code with a small typed body,
+// rather than HTTP 200 with an errMsg field as respondWithError does.
+func (h *handler) respondWithStatusError(c *gin.Context, status int, message string) {
+	c.JSON(status, gin.H{"error": message})
+}
+
+// GetVertexMetrics provides the processing rates and pending counts for a single
+// named vertex of a pipeline, broken down per partition.
+func (h *handler) GetVertexMetrics(c *gin.Context) {
+	ns, pipeline, vertex := c.Param("namespace"), c.Param("pipeline"), c.Param("vertex")
+
+	client, err := h.getPipelineDaemonClient(ns, pipeline)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for pipeline %q: %v", pipeline, err))
+		return
+	}
+
+	metrics, err := client.GetVertexMetrics(c, pipeline, vertex)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get the metrics for pipeline %q vertex %q: %v", pipeline, vertex, err))
+		return
+	}
+	c.JSON(http.StatusOK, newVertexMetricsDTO(pipeline, vertex, metrics))
+}
+
+// GetVertexPending provides the pending (backlog) message counts for a single
+// named vertex of a pipeline, keyed by lookback window.
+func (h *handler) GetVertexPending(c *gin.Context) {
+	ns, pipeline, vertex := c.Param("namespace"), c.Param("pipeline"), c.Param("vertex")
+
+	client, err := h.getPipelineDaemonClient(ns, pipeline)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for pipeline %q: %v", pipeline, err))
+		return
+	}
+
+	metrics, err := client.GetVertexMetrics(c, pipeline, vertex)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get the pending counts for pipeline %q vertex %q: %v", pipeline, vertex, err))
+		return
+	}
+	c.JSON(http.StatusOK, newVertexPendingDTO(pipeline, vertex, metrics))
+}
+
+// GetMonoVertexPending provides the pending (backlog) message counts for a mono
+// vertex, keyed by lookback window.
+func (h *handler) GetMonoVertexPending(c *gin.Context) {
+	ns, monoVertex := c.Param("namespace"), c.Param("mono-vertex")
+
+	client, err := h.getMonoVertexDaemonClient(ns, monoVertex)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for mono vertex %q: %v", monoVertex, err))
+		return
+	}
+
+	metrics, err := client.GetMonoVertexMetrics(c)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get the pending counts for mono vertex %q: %v", monoVertex, err))
+		return
+	}
+	c.JSON(http.StatusOK, newMonoVertexPendingDTO(monoVertex, metrics))
+}
+
+// GetPipelineBufferInfo provides the metrics for a single inter-step buffer
+// (pending, ack-pending, total messages, usage, isFull).
+func (h *handler) GetPipelineBufferInfo(c *gin.Context) {
+	ns, pipeline, buffer := c.Param("namespace"), c.Param("pipeline"), c.Param("buffer")
+
+	client, err := h.getPipelineDaemonClient(ns, pipeline)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for pipeline %q: %v", pipeline, err))
+		return
+	}
+
+	info, err := client.GetPipelineBuffer(c, pipeline, buffer)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get the buffer %q for pipeline %q: %v", buffer, pipeline, err))
+		return
+	}
+	if info == nil {
+		h.respondWithStatusError(c, http.StatusNotFound, fmt.Sprintf("buffer %q not found for pipeline %q", buffer, pipeline))
+		return
+	}
+	c.JSON(http.StatusOK, newBufferDTO(info))
+}
+
+// GetPipelineBufferPending provides the pending (backlog) message counts for a
+// single inter-step buffer of a pipeline.
+func (h *handler) GetPipelineBufferPending(c *gin.Context) {
+	ns, pipeline, buffer := c.Param("namespace"), c.Param("pipeline"), c.Param("buffer")
+
+	client, err := h.getPipelineDaemonClient(ns, pipeline)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for pipeline %q: %v", pipeline, err))
+		return
+	}
+
+	info, err := client.GetPipelineBuffer(c, pipeline, buffer)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get the buffer %q for pipeline %q: %v", buffer, pipeline, err))
+		return
+	}
+	if info == nil {
+		h.respondWithStatusError(c, http.StatusNotFound, fmt.Sprintf("buffer %q not found for pipeline %q", buffer, pipeline))
+		return
+	}
+	c.JSON(http.StatusOK, newBufferPendingDTO(info))
+}
+
+// GetPipelineDataHealth provides only the data-plane (criticality) health of a
+// pipeline from the daemon, without the resource-health computation.
+func (h *handler) GetPipelineDataHealth(c *gin.Context) {
+	ns, pipeline := c.Param("namespace"), c.Param("pipeline")
+
+	client, err := h.getPipelineDaemonClient(ns, pipeline)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for pipeline %q: %v", pipeline, err))
+		return
+	}
+
+	status, err := client.GetPipelineStatus(c, pipeline)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get the data health for pipeline %q: %v", pipeline, err))
+		return
+	}
+	c.JSON(http.StatusOK, DataHealthDTO{
+		Status:  status.GetStatus(),
+		Message: status.GetMessage(),
+		Code:    status.GetCode(),
+	})
+}
+
+// GetMonoVertexDataHealth provides only the data-plane (criticality) health of a
+// mono vertex from its daemon, without the resource-health computation.
+func (h *handler) GetMonoVertexDataHealth(c *gin.Context) {
+	ns, monoVertex := c.Param("namespace"), c.Param("mono-vertex")
+
+	client, err := h.getMonoVertexDaemonClient(ns, monoVertex)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for mono vertex %q: %v", monoVertex, err))
+		return
+	}
+
+	status, err := client.GetMonoVertexStatus(c)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get the data health for mono vertex %q: %v", monoVertex, err))
+		return
+	}
+	c.JSON(http.StatusOK, DataHealthDTO{
+		Status:  status.GetStatus(),
+		Message: status.GetMessage(),
+		Code:    status.GetCode(),
+	})
+}
+
+// GetPipelineWatermarkLag provides the end-to-end watermark lag of a pipeline
+// (max source watermark minus min sink watermark, in milliseconds), without
+// fetching the full pipeline spec as GetPipeline does.
+func (h *handler) GetPipelineWatermarkLag(c *gin.Context) {
+	ns, pipeline := c.Param("namespace"), c.Param("pipeline")
+
+	pl, err := h.numaflowClient.Pipelines(ns).Get(c, pipeline, metav1.GetOptions{})
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusNotFound, fmt.Sprintf("failed to fetch pipeline %q namespace %q: %v", pipeline, ns, err))
+		return
+	}
+
+	client, err := h.getPipelineDaemonClient(ns, pipeline)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for pipeline %q: %v", pipeline, err))
+		return
+	}
+
+	watermarks, err := client.GetPipelineWatermarks(c, pipeline)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to calculate watermark lag for pipeline %q: %v", pipeline, err))
+		return
+	}
+	c.JSON(http.StatusOK, computePipelineWatermarkLag(pl, watermarks))
+}
+
+// GetPipelineStatusInfo provides only the status subresource of a pipeline
+// (phase, conditions, counts, drainedOnPause) without the spec.
+func (h *handler) GetPipelineStatusInfo(c *gin.Context) {
+	ns, pipeline := c.Param("namespace"), c.Param("pipeline")
+
+	pl, err := h.numaflowClient.Pipelines(ns).Get(c, pipeline, metav1.GetOptions{})
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusNotFound, fmt.Sprintf("failed to fetch pipeline %q namespace %q: %v", pipeline, ns, err))
+		return
+	}
+	c.JSON(http.StatusOK, newPipelineStatusDTO(pl))
+}
+
+// GetVertexStatus provides only the status subresource of a single vertex
+// (phase, replica counts, rolling-update hashes) without the spec.
+func (h *handler) GetVertexStatus(c *gin.Context) {
+	ns, pipeline, vertex := c.Param("namespace"), c.Param("pipeline"), c.Param("vertex")
+
+	vertexName := fmt.Sprintf("%s-%s", pipeline, vertex)
+	v, err := h.numaflowClient.Vertices(ns).Get(c, vertexName, metav1.GetOptions{})
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusNotFound, fmt.Sprintf("failed to fetch vertex %q of pipeline %q namespace %q: %v", vertex, pipeline, ns, err))
+		return
+	}
+	c.JSON(http.StatusOK, newVertexStatusDTO(v))
+}
+
+// GetMonoVertexStatusInfo provides only the status subresource of a mono vertex
+// (phase, replica counts) without the spec.
+func (h *handler) GetMonoVertexStatusInfo(c *gin.Context) {
+	ns, monoVertex := c.Param("namespace"), c.Param("mono-vertex")
+
+	mv, err := h.numaflowClient.MonoVertices(ns).Get(c, monoVertex, metav1.GetOptions{})
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusNotFound, fmt.Sprintf("failed to fetch mono vertex %q namespace %q: %v", monoVertex, ns, err))
+		return
+	}
+	c.JSON(http.StatusOK, newMonoVertexStatusDTO(mv))
+}
+
+// GetVertexRuntimeErrors provides the runtime errors observed on each replica of
+// a pipeline vertex.
+func (h *handler) GetVertexRuntimeErrors(c *gin.Context) {
+	ns, pipeline, vertex := c.Param("namespace"), c.Param("pipeline"), c.Param("vertex")
+
+	client, err := h.getPipelineDaemonClient(ns, pipeline)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for pipeline %q: %v", pipeline, err))
+		return
+	}
+
+	errs, err := client.GetVertexErrors(c, pipeline, vertex)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get the errors for pipeline %q vertex %q: %v", pipeline, vertex, err))
+		return
+	}
+	c.JSON(http.StatusOK, newReplicaErrorDTOs(errs))
+}
+
+// GetMonoVertexRuntimeErrors provides the runtime errors observed on each replica
+// of a mono vertex.
+func (h *handler) GetMonoVertexRuntimeErrors(c *gin.Context) {
+	ns, monoVertex := c.Param("namespace"), c.Param("mono-vertex")
+
+	client, err := h.getMonoVertexDaemonClient(ns, monoVertex)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for mono vertex %q: %v", monoVertex, err))
+		return
+	}
+
+	errs, err := client.GetMonoVertexErrors(c, monoVertex)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get the errors for mono vertex %q: %v", monoVertex, err))
+		return
+	}
+	c.JSON(http.StatusOK, newMonoVertexReplicaErrorDTOs(errs))
+}
+
 // UpdateVertex is used to update the vertex spec
 func (h *handler) UpdateVertex(c *gin.Context) {
 	if h.opts.readonly {
@@ -948,6 +1207,133 @@ func (h *handler) PodLogs(c *gin.Context) {
 	h.streamLogs(c, stream)
 }
 
+// defaultVertexLogTailLines bounds the number of log lines returned per replica
+// by the vertex/mono vertex logs endpoints when the caller does not specify
+// tailLines, so a single call cannot return an unbounded volume.
+const defaultVertexLogTailLines int64 = 200
+
+// GetVertexLogs streams the logs of a pipeline vertex addressed by vertex and
+// container name, fanning out across all of the vertex's replicas. Each line is
+// prefixed with "[<pod>/<container>] ". This avoids the caller having to first
+// list pods and track pod names.
+func (h *handler) GetVertexLogs(c *gin.Context) {
+	ns, pipeline, vertex := c.Param("namespace"), c.Param("pipeline"), c.Param("vertex")
+	selector := fmt.Sprintf("%s=%s,%s=%s", dfv1.KeyPipelineName, pipeline, dfv1.KeyVertexName, vertex)
+	h.streamVertexLogs(c, ns, fmt.Sprintf("pipeline %q vertex %q", pipeline, vertex), selector)
+}
+
+// GetMonoVertexLogs streams the logs of a mono vertex addressed by mono vertex
+// and container name, fanning out across all of its replicas.
+func (h *handler) GetMonoVertexLogs(c *gin.Context) {
+	ns, monoVertex := c.Param("namespace"), c.Param("mono-vertex")
+	selector := fmt.Sprintf("%s=%s", dfv1.KeyMonoVertexName, monoVertex)
+	h.streamVertexLogs(c, ns, fmt.Sprintf("mono vertex %q", monoVertex), selector)
+}
+
+// streamVertexLogs lists the pods matching selector and streams their logs,
+// optionally narrowed to a single replica via the "replica" query param. It is
+// shared by GetVertexLogs and GetMonoVertexLogs.
+func (h *handler) streamVertexLogs(c *gin.Context, ns, subject, selector string) {
+	pods, err := h.kubeClient.CoreV1().Pods(ns).List(c, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to list pods for %s in namespace %q: %v", subject, ns, err))
+		return
+	}
+	if pods == nil || len(pods.Items) == 0 {
+		h.respondWithStatusError(c, http.StatusNotFound, fmt.Sprintf("no pods found for %s in namespace %q", subject, ns))
+		return
+	}
+
+	// Optionally narrow to a single replica.
+	if replica := c.Query("replica"); replica != "" {
+		idx := slices.IndexFunc(pods.Items, func(p corev1.Pod) bool { return p.Name == replica })
+		if idx < 0 {
+			h.respondWithStatusError(c, http.StatusNotFound, fmt.Sprintf("replica %q not found for %s in namespace %q", replica, subject, ns))
+			return
+		}
+		pods.Items = pods.Items[idx : idx+1]
+	}
+
+	// follow streams a single pod indefinitely, so it cannot be merged across
+	// replicas sequentially. Require the caller to pick one replica.
+	follow := c.Query("follow") == "true"
+	if follow && len(pods.Items) > 1 {
+		h.respondWithStatusError(c, http.StatusBadRequest, fmt.Sprintf("follow=true requires a single replica for %s; specify the replica query param (one of %d pods)", subject, len(pods.Items)))
+		return
+	}
+
+	// Validate the requested container against the pods' actual containers.
+	container := c.Query("container")
+	if container != "" {
+		valid := podContainerNames(&pods.Items[0])
+		if !slices.Contains(valid, container) {
+			h.respondWithStatusError(c, http.StatusBadRequest, fmt.Sprintf("container %q not found for %s; valid containers: %s", container, subject, strings.Join(valid, ", ")))
+			return
+		}
+	}
+
+	tailLines := h.parseTailLines(c.Query("tailLines"))
+	if tailLines == nil {
+		tailLines = ptr.To(defaultVertexLogTailLines)
+	}
+	var sinceSeconds *int64
+	if s := c.Query("sinceSeconds"); s != "" {
+		if v, perr := strconv.ParseInt(s, 10, 64); perr == nil && v > 0 {
+			sinceSeconds = ptr.To(v)
+		}
+	}
+	logOptions := &corev1.PodLogOptions{
+		Container:    container,
+		Follow:       follow,
+		TailLines:    tailLines,
+		SinceSeconds: sinceSeconds,
+		Timestamps:   true,
+		Previous:     c.Query("previous") == "true",
+	}
+
+	for i := range pods.Items {
+		pod := pods.Items[i]
+		stream, serr := h.kubeClient.CoreV1().Pods(ns).GetLogs(pod.Name, logOptions).Stream(c)
+		if serr != nil {
+			// Surface the failure inline rather than aborting the whole response;
+			// other replicas may still have useful logs.
+			_, _ = fmt.Fprintf(c.Writer, "[%s/%s] failed to get logs: %v\n", pod.Name, container, serr)
+			c.Writer.Flush()
+			continue
+		}
+		h.streamPrefixedLogs(c, stream, pod.Name, container)
+		_ = stream.Close()
+	}
+}
+
+// streamPrefixedLogs streams the logs from a single pod, prefixing each line with
+// "[<pod>/<container>] " so merged multi-replica output is attributable.
+func (h *handler) streamPrefixedLogs(c *gin.Context, stream io.ReadCloser, pod, container string) {
+	prefix := fmt.Sprintf("[%s/%s] ", pod, container)
+	scanner := bufio.NewScanner(stream)
+	for scanner.Scan() {
+		_, _ = c.Writer.WriteString(prefix)
+		_, _ = c.Writer.Write(scanner.Bytes())
+		_, _ = c.Writer.WriteString("\n")
+		c.Writer.Flush()
+	}
+}
+
+// podContainerNames returns the names of a pod's regular and sidecar (init with
+// Always restart policy) containers.
+func podContainerNames(pod *corev1.Pod) []string {
+	names := make([]string, 0, len(pod.Spec.Containers)+len(pod.Spec.InitContainers))
+	for _, ic := range pod.Spec.InitContainers {
+		if ic.RestartPolicy != nil && *ic.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			names = append(names, ic.Name)
+		}
+	}
+	for _, ct := range pod.Spec.Containers {
+		names = append(names, ct.Name)
+	}
+	return names
+}
+
 func (h *handler) GetMonoVertexPodsInfo(c *gin.Context) {
 	var response = make([]PodDetails, 0)
 	ns, monoVertex := c.Param("namespace"), c.Param("mono-vertex")
@@ -1027,9 +1413,9 @@ func (h *handler) streamLogs(c *gin.Context, stream io.ReadCloser) {
 // Events are sorted by timestamp in descending order.
 func (h *handler) GetNamespaceEvents(c *gin.Context) {
 	ns := c.Param("namespace")
-	objType := c.DefaultQuery("objectType", "")
-	objName := c.DefaultQuery("objectName", "")
-	if (objType == "" && objName != "") || (objType != "" && objName == "") {
+	objectKind := c.DefaultQuery("objectType", "")
+	objectName := c.DefaultQuery("objectName", "")
+	if (objectKind == "" && objectName != "") || (objectKind != "" && objectName == "") {
 		h.respondWithError(c, fmt.Sprintf("Failed to get a list of events: namespace %q: "+
 			"please either specify both objectType and objectName or not specify.", ns))
 		return
@@ -1052,9 +1438,9 @@ func (h *handler) GetNamespaceEvents(c *gin.Context) {
 		if event.LastTimestamp.Time.Equal(defaultTimeObject) {
 			continue
 		}
-		if (objType == "" && objName == "") ||
-			(strings.EqualFold(event.InvolvedObject.Kind, objType) && strings.EqualFold(event.InvolvedObject.Name, objName)) {
-			newEvent := NewK8sEventsResponse(event.LastTimestamp.UnixMilli(), event.Type, event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message)
+		if (objectKind == "" && objectName == "") ||
+			(strings.EqualFold(event.InvolvedObject.Kind, objectKind) && strings.EqualFold(event.InvolvedObject.Name, objectName)) {
+			newEvent := NewK8sEventsResponse(event.LastTimestamp.UnixMilli(), event.Type, event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message, event.Count)
 			response = append(response, newEvent)
 		}
 	}
@@ -1699,6 +2085,10 @@ func (h *handler) getPodDetails(pod corev1.Pod) (PodDetails, error) {
 		Status:  string(pod.Status.Phase),
 		Message: pod.Status.Message,
 		Reason:  pod.Status.Reason,
+		Node:    pod.Spec.NodeName,
+	}
+	if !pod.CreationTimestamp.IsZero() {
+		podDetails.CreatedAt = pod.CreationTimestamp.UTC().Format(time.RFC3339)
 	}
 
 	metricsClient := h.metricsClient
@@ -1758,6 +2148,8 @@ func (h *handler) getContainerDetails(pod corev1.Pod) map[string]ContainerDetail
 			ID:           status.ContainerID,
 			State:        h.getContainerStatus(status.State),
 			RestartCount: status.RestartCount,
+			Image:        status.Image,
+			Ready:        status.Ready,
 		}
 		// Reason the container is not yet running
 		// Message regarding why the container is not yet running

--- a/server/apis/v1/handler_debug.go
+++ b/server/apis/v1/handler_debug.go
@@ -143,6 +143,10 @@ func setEventListHeaders(c *gin.Context, meta eventListMetadata) {
 	}
 }
 
+func vertexCRName(pipeline, vertex string) string {
+	return fmt.Sprintf("%s-%s", pipeline, vertex)
+}
+
 // listScopedEvents lists namespace events narrowed by the given filter. The
 // filter is pushed into the Kubernetes API call via a field selector (so noisy
 // namespaces don't load every event), with an in-memory pass as a backstop
@@ -247,8 +251,7 @@ func (h *handler) GetPipelineEvents(c *gin.Context) {
 func (h *handler) GetVertexEvents(c *gin.Context) {
 	ns, pipeline, vertex := c.Param("namespace"), c.Param("pipeline"), c.Param("vertex")
 	limit, _ := strconv.ParseInt(c.Query("limit"), 10, 64)
-	vertexFullName := dfv1.Pipeline{ObjectMeta: metav1.ObjectMeta{Name: pipeline}}.GetVertexFullName(vertex)
-	events, meta, err := h.listScopedEvents(c, ns, eventFilter{objectKind: dfv1.VertexGroupVersionKind.Kind, objectName: vertexFullName, limit: limit})
+	events, meta, err := h.listScopedEvents(c, ns, eventFilter{objectKind: dfv1.VertexGroupVersionKind.Kind, objectName: vertexCRName(pipeline, vertex), limit: limit})
 	if err != nil {
 		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get events for pipeline %q vertex %q: %v", pipeline, vertex, err))
 		return
@@ -293,6 +296,25 @@ func newSnapshotDaemonError(err error) *SnapshotSectionError {
 		return &SnapshotSectionError{Code: SnapshotErrCodeTimeout, Message: err.Error()}
 	}
 	return &SnapshotSectionError{Code: SnapshotErrCodeDaemonUnavailable, Message: err.Error()}
+}
+
+func capReplicaErrors(replicas []ReplicaErrorDTO, remainingErrors *int) []ReplicaErrorDTO {
+	kept := make([]ReplicaErrorDTO, 0, len(replicas))
+	for i := range replicas {
+		if *remainingErrors <= 0 {
+			break
+		}
+		limit := snapshotMaxErrorsPerVtx
+		if limit > *remainingErrors {
+			limit = *remainingErrors
+		}
+		if len(replicas[i].Errors) > limit {
+			replicas[i].Errors = replicas[i].Errors[:limit]
+		}
+		*remainingErrors -= len(replicas[i].Errors)
+		kept = append(kept, replicas[i])
+	}
+	return kept
 }
 
 // GetPipelineDebugSnapshot returns a bounded, read-only correlation of a
@@ -448,6 +470,99 @@ func (h *handler) GetPipelineDebugSnapshot(c *gin.Context) {
 	warnFilter := eventFilter{
 		objectKind: dfv1.PipelineGroupVersionKind.Kind,
 		objectName: pipeline,
+		eventType:  "Warning",
+		limit:      snapshotMaxWarningEvents,
+	}
+	if events, meta, e := h.listScopedEvents(snapshotCtx, ns, warnFilter); e != nil {
+		snap.WarningEvents.Error = &SnapshotSectionError{Code: SnapshotErrCodeInternal, Message: e.Error()}
+	} else {
+		if meta.limited {
+			snap.Notes = append(snap.Notes, fmt.Sprintf("warning events truncated at %d", snapshotMaxWarningEvents))
+		}
+		if meta.scanCeilingReached {
+			snap.Notes = append(snap.Notes, fmt.Sprintf("warning event scan reached %d event ceiling; most recent warning events may be incomplete", eventScanCeiling))
+		}
+		snap.WarningEvents.Data = events
+	}
+
+	c.JSON(http.StatusOK, snap)
+}
+
+// GetMonoVertexDebugSnapshot returns a bounded, read-only correlation of a mono
+// vertex's current state. Each section is fetched independently; a failed
+// section carries a structured error instead of failing the whole response.
+func (h *handler) GetMonoVertexDebugSnapshot(c *gin.Context) {
+	ns, monoVertex := c.Param("namespace"), c.Param("mono-vertex")
+
+	if _, err := h.numaflowClient.MonoVertices(ns).Get(c, monoVertex, metav1.GetOptions{}); err != nil {
+		h.respondWithStatusError(c, http.StatusNotFound, fmt.Sprintf("failed to fetch mono vertex %q namespace %q: %v", monoVertex, ns, err))
+		return
+	}
+
+	now := func() string { return time.Now().UTC().Format(time.RFC3339) }
+	snap := MonoVertexDebugSnapshotDTO{MonoVertex: monoVertex, Namespace: ns, ObservedAt: now()}
+	snapshotCtx, cancelSnapshot := context.WithTimeout(c.Request.Context(), snapshotOverallTimeout)
+	defer cancelSnapshot()
+
+	snap.ResourceHealth.ObservedAt = now()
+	if rh, rerr := h.healthChecker.getMonoVtxResourceHealth(h, ns, monoVertex); rerr != nil {
+		snap.ResourceHealth.Error = &SnapshotSectionError{Code: SnapshotErrCodeInternal, Message: rerr.Error()}
+	} else {
+		snap.ResourceHealth.Data = &ResourceHealthData{Status: rh.Status, Message: rh.Message, Code: rh.Code}
+	}
+
+	client, derr := h.getMonoVertexDaemonClient(ns, monoVertex)
+	if derr != nil || client == nil {
+		se := &SnapshotSectionError{Code: SnapshotErrCodeDaemonUnavailable, Message: fmt.Sprintf("daemon unavailable: %v", derr)}
+		snap.DataHealth.Error, snap.Metrics.Error, snap.RuntimeErrors.Error = se, se, se
+		snap.DataHealth.ObservedAt, snap.Metrics.ObservedAt, snap.RuntimeErrors.ObservedAt = now(), now(), now()
+	} else {
+		snap.DataHealth.ObservedAt = now()
+		func() {
+			dctx, cancel := snapshotSubCallContext(snapshotCtx)
+			defer cancel()
+			if st, e := client.GetMonoVertexStatus(dctx); e != nil {
+				snap.DataHealth.Error = newSnapshotDaemonError(e)
+			} else if st == nil {
+				snap.DataHealth.Error = &SnapshotSectionError{Code: SnapshotErrCodeInternal, Message: "mono vertex daemon returned nil status"}
+			} else {
+				snap.DataHealth.Data = &DataHealthDTO{Status: st.GetStatus(), Message: st.GetMessage(), Code: st.GetCode()}
+			}
+		}()
+
+		snap.Metrics.ObservedAt = now()
+		func() {
+			dctx, cancel := snapshotSubCallContext(snapshotCtx)
+			defer cancel()
+			if metrics, e := client.GetMonoVertexMetrics(dctx); e != nil {
+				snap.Metrics.Error = newSnapshotDaemonError(e)
+			} else {
+				dto := newMonoVertexMetricsDTO(monoVertex, metrics)
+				snap.Metrics.Data = &dto
+			}
+		}()
+
+		snap.RuntimeErrors.ObservedAt = now()
+		func() {
+			dctx, cancel := snapshotSubCallContext(snapshotCtx)
+			defer cancel()
+			errs, e := client.GetMonoVertexErrors(dctx, monoVertex)
+			if e != nil {
+				snap.RuntimeErrors.Error = newSnapshotDaemonError(e)
+				return
+			}
+			remainingErrors := snapshotMaxTotalErrors
+			snap.RuntimeErrors.Data = capReplicaErrors(newMonoVertexReplicaErrorDTOs(errs), &remainingErrors)
+			if remainingErrors <= 0 {
+				snap.Notes = append(snap.Notes, fmt.Sprintf("runtime errors truncated at %d total", snapshotMaxTotalErrors))
+			}
+		}()
+	}
+
+	snap.WarningEvents.ObservedAt = now()
+	warnFilter := eventFilter{
+		objectKind: dfv1.MonoVertexGroupVersionKind.Kind,
+		objectName: monoVertex,
 		eventType:  "Warning",
 		limit:      snapshotMaxWarningEvents,
 	}

--- a/server/apis/v1/handler_debug.go
+++ b/server/apis/v1/handler_debug.go
@@ -1,0 +1,467 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+
+	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+)
+
+// GetPipelineTopology returns the pipeline's graph (vertices with roles,
+// partitions, scale bounds, expected containers, and edges), derived from spec.
+func (h *handler) GetPipelineTopology(c *gin.Context) {
+	ns, pipeline := c.Param("namespace"), c.Param("pipeline")
+
+	pl, err := h.numaflowClient.Pipelines(ns).Get(c, pipeline, metav1.GetOptions{})
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusNotFound, fmt.Sprintf("failed to fetch pipeline %q namespace %q: %v", pipeline, ns, err))
+		return
+	}
+	c.JSON(http.StatusOK, newPipelineTopologyDTO(pl))
+}
+
+// GetPipelineBuffers returns all inter-step buffers of a pipeline as typed DTOs.
+func (h *handler) GetPipelineBuffers(c *gin.Context) {
+	ns, pipeline := c.Param("namespace"), c.Param("pipeline")
+
+	client, err := h.getPipelineDaemonClient(ns, pipeline)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for pipeline %q: %v", pipeline, err))
+		return
+	}
+	buffers, err := client.ListPipelineBuffers(c, pipeline)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to list buffers for pipeline %q: %v", pipeline, err))
+		return
+	}
+	out := make([]BufferDTO, 0, len(buffers))
+	for _, b := range buffers {
+		if b != nil {
+			out = append(out, newBufferDTO(b))
+		}
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// GetPipelineEdgeWatermarks returns the per-edge watermarks of a pipeline as typed DTOs.
+func (h *handler) GetPipelineEdgeWatermarks(c *gin.Context) {
+	ns, pipeline := c.Param("namespace"), c.Param("pipeline")
+
+	client, err := h.getPipelineDaemonClient(ns, pipeline)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for pipeline %q: %v", pipeline, err))
+		return
+	}
+	watermarks, err := client.GetPipelineWatermarks(c, pipeline)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get watermarks for pipeline %q: %v", pipeline, err))
+		return
+	}
+	c.JSON(http.StatusOK, newEdgeWatermarkDTOs(watermarks))
+}
+
+// GetMonoVertexThroughputMetrics returns the processing rates and pending counts
+// of a mono vertex as a typed DTO.
+func (h *handler) GetMonoVertexThroughputMetrics(c *gin.Context) {
+	ns, monoVertex := c.Param("namespace"), c.Param("mono-vertex")
+
+	client, err := h.getMonoVertexDaemonClient(ns, monoVertex)
+	if err != nil || client == nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get daemon service client for mono vertex %q: %v", monoVertex, err))
+		return
+	}
+	metrics, err := client.GetMonoVertexMetrics(c)
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get the metrics for mono vertex %q: %v", monoVertex, err))
+		return
+	}
+	c.JSON(http.StatusOK, newMonoVertexMetricsDTO(monoVertex, metrics))
+}
+
+// defaultScopedEventLimit is the number of most-recent events returned by the
+// scoped/snapshot event endpoints when the caller does not specify a limit.
+const defaultScopedEventLimit int64 = 100
+
+// eventListPageSize is the per-page size used while paging the field-selected
+// event list; eventScanCeiling bounds the total events scanned so a pathological
+// namespace cannot cause an unbounded fetch.
+const (
+	eventListPageSize int64 = 500
+	eventScanCeiling  int   = 5000
+)
+
+// eventFilter narrows an event list query.
+type eventFilter struct {
+	objectKind string // involvedObject.kind
+	objectName string // involvedObject.name
+	eventType  string // "Warning" | "Normal" | ""
+	limit      int64  // 0 => defaultScopedEventLimit
+}
+
+type eventListMetadata struct {
+	limited            bool
+	scanCeilingReached bool
+}
+
+func (m eventListMetadata) truncated() bool {
+	return m.limited || m.scanCeilingReached
+}
+
+func setEventListHeaders(c *gin.Context, meta eventListMetadata) {
+	if !meta.truncated() {
+		return
+	}
+	c.Header("X-Numaflow-Events-Truncated", "true")
+	if meta.scanCeilingReached {
+		c.Header("X-Numaflow-Events-Scan-Ceiling-Reached", "true")
+	}
+}
+
+// listScopedEvents lists namespace events narrowed by the given filter. The
+// filter is pushed into the Kubernetes API call via a field selector (so noisy
+// namespaces don't load every event), with an in-memory pass as a backstop
+// (field selectors are best-effort and the fake client in tests ignores them).
+// It is the shared core used by GetNamespaceEvents and the scoped-event routes.
+func (h *handler) listScopedEvents(ctx context.Context, ns string, f eventFilter) ([]K8sEventsResponse, eventListMetadata, error) {
+	selectors := fields.Set{}
+	if f.objectKind != "" {
+		selectors["involvedObject.kind"] = f.objectKind
+	}
+	if f.objectName != "" {
+		selectors["involvedObject.name"] = f.objectName
+	}
+	if f.eventType != "" {
+		selectors["type"] = f.eventType
+	}
+	limit := f.limit
+	if limit <= 0 {
+		limit = defaultScopedEventLimit
+	}
+
+	// The field selector narrows the result set server-side, but Kubernetes list
+	// pagination is not ordered by timestamp, so we cannot use ListOptions.Limit
+	// to mean "most recent N". Instead we page through the filtered events
+	// (bounded by a hard ceiling), sort by timestamp in memory, then cap to limit.
+	fieldSelector := ""
+	if len(selectors) > 0 {
+		fieldSelector = selectors.AsSelector().String()
+	}
+
+	var (
+		response          []K8sEventsResponse
+		defaultTimeObject time.Time
+		continueToken     string
+		meta              eventListMetadata
+		scanned           int
+	)
+	for {
+		events, err := h.kubeClient.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
+			FieldSelector: fieldSelector,
+			Limit:         eventListPageSize,
+			Continue:      continueToken,
+		})
+		if err != nil {
+			return nil, eventListMetadata{}, err
+		}
+		scanned += len(events.Items)
+		for _, event := range events.Items {
+			if event.LastTimestamp.Time.Equal(defaultTimeObject) {
+				continue
+			}
+			// Backstop the field selector in memory (no-op when the server already filtered).
+			if f.objectKind != "" && !strings.EqualFold(event.InvolvedObject.Kind, f.objectKind) {
+				continue
+			}
+			if f.objectName != "" && !strings.EqualFold(event.InvolvedObject.Name, f.objectName) {
+				continue
+			}
+			if f.eventType != "" && !strings.EqualFold(event.Type, f.eventType) {
+				continue
+			}
+			response = append(response, NewK8sEventsResponse(event.LastTimestamp.UnixMilli(), event.Type,
+				event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message, event.Count))
+		}
+		continueToken = events.Continue
+		// Stop when there are no more pages or we've scanned the safety ceiling.
+		if continueToken == "" {
+			break
+		}
+		if scanned >= eventScanCeiling {
+			meta.scanCeilingReached = true
+			break
+		}
+	}
+
+	// Most-recent-first, then cap to the requested limit.
+	sort.Slice(response, func(i int, j int) bool {
+		return response[i].TimeStamp >= response[j].TimeStamp
+	})
+	if int64(len(response)) > limit {
+		meta.limited = true
+		response = response[:limit]
+	}
+	return response, meta, nil
+}
+
+// GetPipelineEvents returns Kubernetes events for a pipeline object.
+func (h *handler) GetPipelineEvents(c *gin.Context) {
+	ns, pipeline := c.Param("namespace"), c.Param("pipeline")
+	limit, _ := strconv.ParseInt(c.Query("limit"), 10, 64)
+	events, meta, err := h.listScopedEvents(c, ns, eventFilter{objectKind: dfv1.PipelineGroupVersionKind.Kind, objectName: pipeline, limit: limit})
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get events for pipeline %q: %v", pipeline, err))
+		return
+	}
+	setEventListHeaders(c, meta)
+	c.JSON(http.StatusOK, events)
+}
+
+// GetVertexEvents returns Kubernetes events for a vertex. K8s events reference
+// the generated Vertex CR name (<pipeline>-<vertex>), so we resolve that here.
+func (h *handler) GetVertexEvents(c *gin.Context) {
+	ns, pipeline, vertex := c.Param("namespace"), c.Param("pipeline"), c.Param("vertex")
+	limit, _ := strconv.ParseInt(c.Query("limit"), 10, 64)
+	vertexFullName := dfv1.Pipeline{ObjectMeta: metav1.ObjectMeta{Name: pipeline}}.GetVertexFullName(vertex)
+	events, meta, err := h.listScopedEvents(c, ns, eventFilter{objectKind: dfv1.VertexGroupVersionKind.Kind, objectName: vertexFullName, limit: limit})
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get events for pipeline %q vertex %q: %v", pipeline, vertex, err))
+		return
+	}
+	setEventListHeaders(c, meta)
+	c.JSON(http.StatusOK, events)
+}
+
+// GetMonoVertexEvents returns Kubernetes events for a mono vertex object.
+func (h *handler) GetMonoVertexEvents(c *gin.Context) {
+	ns, monoVertex := c.Param("namespace"), c.Param("mono-vertex")
+	limit, _ := strconv.ParseInt(c.Query("limit"), 10, 64)
+	events, meta, err := h.listScopedEvents(c, ns, eventFilter{objectKind: dfv1.MonoVertexGroupVersionKind.Kind, objectName: monoVertex, limit: limit})
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusBadGateway, fmt.Sprintf("failed to get events for mono vertex %q: %v", monoVertex, err))
+		return
+	}
+	setEventListHeaders(c, meta)
+	c.JSON(http.StatusOK, events)
+}
+
+// Caps that bound the debug-snapshot fan-out so it can never become the heaviest API.
+const (
+	snapshotMaxVertices      = 50
+	snapshotMaxErrorsPerVtx  = 20
+	snapshotMaxTotalErrors   = 200
+	snapshotMaxWarningEvents = 50
+	snapshotOverallTimeout   = 30 * time.Second
+	snapshotSubCallTimeout   = 3 * time.Second
+)
+
+// snapshotSubCallContext derives a fresh per-sub-call timeout context from the request,
+// so one slow daemon call cannot starve later sections of the snapshot.
+func snapshotSubCallContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, snapshotSubCallTimeout)
+}
+
+// newSnapshotDaemonError classifies a failed daemon sub-call: a deadline gets the
+// stable timeout code, everything else daemon_unavailable.
+func newSnapshotDaemonError(err error) *SnapshotSectionError {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return &SnapshotSectionError{Code: SnapshotErrCodeTimeout, Message: err.Error()}
+	}
+	return &SnapshotSectionError{Code: SnapshotErrCodeDaemonUnavailable, Message: err.Error()}
+}
+
+// GetPipelineDebugSnapshot returns a bounded, read-only correlation of a
+// pipeline's current state. Each section is fetched independently; a failed
+// section carries a structured error instead of failing the whole response.
+func (h *handler) GetPipelineDebugSnapshot(c *gin.Context) {
+	ns, pipeline := c.Param("namespace"), c.Param("pipeline")
+
+	pl, err := h.numaflowClient.Pipelines(ns).Get(c, pipeline, metav1.GetOptions{})
+	if err != nil {
+		h.respondWithStatusError(c, http.StatusNotFound, fmt.Sprintf("failed to fetch pipeline %q namespace %q: %v", pipeline, ns, err))
+		return
+	}
+
+	now := func() string { return time.Now().UTC().Format(time.RFC3339) }
+	snap := DebugSnapshotDTO{Pipeline: pipeline, Namespace: ns, ObservedAt: now()}
+	snapshotCtx, cancelSnapshot := context.WithTimeout(c.Request.Context(), snapshotOverallTimeout)
+	defer cancelSnapshot()
+
+	// Resource health (K8s-side, cached).
+	snap.ResourceHealth.ObservedAt = now()
+	if rh, rerr := h.healthChecker.getPipelineResourceHealth(h, ns, pipeline); rerr != nil {
+		snap.ResourceHealth.Error = &SnapshotSectionError{Code: SnapshotErrCodeInternal, Message: rerr.Error()}
+	} else {
+		snap.ResourceHealth.Data = &ResourceHealthData{Status: rh.Status, Message: rh.Message, Code: rh.Code}
+	}
+
+	// All remaining sections need the daemon client.
+	client, derr := h.getPipelineDaemonClient(ns, pipeline)
+	if derr != nil || client == nil {
+		se := &SnapshotSectionError{Code: SnapshotErrCodeDaemonUnavailable, Message: fmt.Sprintf("daemon unavailable: %v", derr)}
+		snap.DataHealth.Error, snap.WatermarkLag.Error = se, se
+		snap.Vertices.Error, snap.Buffers.Error, snap.RuntimeErrors.Error = se, se, se
+		snap.DataHealth.ObservedAt, snap.WatermarkLag.ObservedAt = now(), now()
+		snap.Vertices.ObservedAt, snap.Buffers.ObservedAt, snap.RuntimeErrors.ObservedAt = now(), now(), now()
+	} else {
+		// Data health (own timeout).
+		snap.DataHealth.ObservedAt = now()
+		func() {
+			dctx, cancel := snapshotSubCallContext(snapshotCtx)
+			defer cancel()
+			if st, e := client.GetPipelineStatus(dctx, pipeline); e != nil {
+				snap.DataHealth.Error = newSnapshotDaemonError(e)
+			} else {
+				snap.DataHealth.Data = &DataHealthDTO{Status: st.GetStatus(), Message: st.GetMessage(), Code: st.GetCode()}
+			}
+		}()
+
+		// Watermark lag (own timeout).
+		snap.WatermarkLag.ObservedAt = now()
+		func() {
+			dctx, cancel := snapshotSubCallContext(snapshotCtx)
+			defer cancel()
+			if wms, e := client.GetPipelineWatermarks(dctx, pipeline); e != nil {
+				snap.WatermarkLag.Error = newSnapshotDaemonError(e)
+			} else {
+				lag := computePipelineWatermarkLag(pl, wms)
+				snap.WatermarkLag.Data = &lag
+			}
+		}()
+
+		// Buffers (own timeout).
+		snap.Buffers.ObservedAt = now()
+		func() {
+			dctx, cancel := snapshotSubCallContext(snapshotCtx)
+			defer cancel()
+			if buffers, e := client.ListPipelineBuffers(dctx, pipeline); e != nil {
+				snap.Buffers.Error = newSnapshotDaemonError(e)
+			} else {
+				for _, b := range buffers {
+					if b != nil {
+						snap.Buffers.Data = append(snap.Buffers.Data, newBufferDTO(b))
+					}
+				}
+			}
+		}()
+
+		// Per-vertex metrics and runtime errors (bounded).
+		snap.Vertices.ObservedAt = now()
+		snap.RuntimeErrors.ObservedAt = now()
+		vertices := pl.Spec.Vertices
+		if len(vertices) > snapshotMaxVertices {
+			vertices = vertices[:snapshotMaxVertices]
+			snap.Notes = append(snap.Notes, fmt.Sprintf("vertices truncated to %d", snapshotMaxVertices))
+		}
+		remainingErrors := snapshotMaxTotalErrors
+		for _, v := range vertices {
+			if errors.Is(snapshotCtx.Err(), context.DeadlineExceeded) {
+				timeoutErr := newSnapshotDaemonError(snapshotCtx.Err())
+				if snap.Vertices.Error == nil {
+					snap.Vertices.Error = timeoutErr
+				}
+				if snap.RuntimeErrors.Error == nil {
+					snap.RuntimeErrors.Error = timeoutErr
+				}
+				snap.Notes = append(snap.Notes, fmt.Sprintf("debug snapshot exceeded %s overall timeout", snapshotOverallTimeout))
+				break
+			}
+			func() {
+				dctx, cancel := snapshotSubCallContext(snapshotCtx)
+				defer cancel()
+				if vm, e := client.GetVertexMetrics(dctx, pipeline, v.Name); e == nil {
+					snap.Vertices.Data = append(snap.Vertices.Data, SnapshotVertexMetrics{
+						Vertex:     v.Name,
+						Partitions: newVertexMetricsDTO(pipeline, v.Name, vm).Partitions,
+					})
+				} else if snap.Vertices.Error == nil {
+					snap.Vertices.Error = newSnapshotDaemonError(e)
+				}
+			}()
+
+			if remainingErrors <= 0 {
+				snap.Notes = append(snap.Notes, fmt.Sprintf("runtime errors truncated at %d total", snapshotMaxTotalErrors))
+				break
+			}
+			func() {
+				dctx, cancel := snapshotSubCallContext(snapshotCtx)
+				defer cancel()
+				errs, e := client.GetVertexErrors(dctx, pipeline, v.Name)
+				if e != nil {
+					if snap.RuntimeErrors.Error == nil {
+						snap.RuntimeErrors.Error = newSnapshotDaemonError(e)
+					}
+					return
+				}
+				replicas := newReplicaErrorDTOs(errs)
+				var kept []ReplicaErrorDTO
+				for i := range replicas {
+					if remainingErrors <= 0 {
+						break
+					}
+					// Bound each replica by both the per-replica cap and the
+					// remaining total budget.
+					limit := snapshotMaxErrorsPerVtx
+					if limit > remainingErrors {
+						limit = remainingErrors
+					}
+					if len(replicas[i].Errors) > limit {
+						replicas[i].Errors = replicas[i].Errors[:limit]
+					}
+					remainingErrors -= len(replicas[i].Errors)
+					kept = append(kept, replicas[i])
+				}
+				if len(kept) > 0 {
+					snap.RuntimeErrors.Data = append(snap.RuntimeErrors.Data, SnapshotVertexErrors{Vertex: v.Name, Errors: kept})
+				}
+			}()
+		}
+	}
+
+	// Recent Warning events for the pipeline (bounded server-side by type+limit).
+	snap.WarningEvents.ObservedAt = now()
+	warnFilter := eventFilter{
+		objectKind: dfv1.PipelineGroupVersionKind.Kind,
+		objectName: pipeline,
+		eventType:  "Warning",
+		limit:      snapshotMaxWarningEvents,
+	}
+	if events, meta, e := h.listScopedEvents(snapshotCtx, ns, warnFilter); e != nil {
+		snap.WarningEvents.Error = &SnapshotSectionError{Code: SnapshotErrCodeInternal, Message: e.Error()}
+	} else {
+		if meta.limited {
+			snap.Notes = append(snap.Notes, fmt.Sprintf("warning events truncated at %d", snapshotMaxWarningEvents))
+		}
+		if meta.scanCeilingReached {
+			snap.Notes = append(snap.Notes, fmt.Sprintf("warning event scan reached %d event ceiling; most recent warning events may be incomplete", eventScanCeiling))
+		}
+		snap.WarningEvents.Data = events
+	}
+
+	c.JSON(http.StatusOK, snap)
+}

--- a/server/apis/v1/handler_debug_test.go
+++ b/server/apis/v1/handler_debug_test.go
@@ -1,0 +1,421 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeKube "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaflow/pkg/apis/proto/daemon"
+	"github.com/numaproj/numaflow/pkg/apis/proto/mvtxdaemon"
+	numaflowfake "github.com/numaproj/numaflow/pkg/client/clientset/versioned/fake"
+	dfv1clients "github.com/numaproj/numaflow/pkg/client/clientset/versioned/typed/numaflow/v1alpha1"
+	daemonclient "github.com/numaproj/numaflow/pkg/daemon/client"
+	mvtdaemonclient "github.com/numaproj/numaflow/pkg/mvtxdaemon/client"
+)
+
+// --- test doubles for the daemon clients ---
+
+type fakeDaemonClient struct {
+	buffers    []*daemon.BufferInfo
+	watermarks []*daemon.EdgeWatermark
+	status     *daemon.PipelineStatus
+	metrics    []*daemon.VertexMetrics
+	errors     []*daemon.ReplicaErrors
+	failAll    bool
+	// timeoutAll makes every sub-call return context.DeadlineExceeded.
+	timeoutAll bool
+}
+
+func (f *fakeDaemonClient) Close() error                                    { return nil }
+func (f *fakeDaemonClient) IsDrained(context.Context, string) (bool, error) { return false, nil }
+func (f *fakeDaemonClient) ListPipelineBuffers(context.Context, string) ([]*daemon.BufferInfo, error) {
+	if f.failAll {
+		return nil, fmt.Errorf("boom")
+	}
+	return f.buffers, nil
+}
+func (f *fakeDaemonClient) GetPipelineBuffer(context.Context, string, string) (*daemon.BufferInfo, error) {
+	return nil, nil
+}
+func (f *fakeDaemonClient) GetVertexMetrics(context.Context, string, string) ([]*daemon.VertexMetrics, error) {
+	if f.failAll {
+		return nil, fmt.Errorf("boom")
+	}
+	return f.metrics, nil
+}
+func (f *fakeDaemonClient) GetPipelineWatermarks(context.Context, string) ([]*daemon.EdgeWatermark, error) {
+	if f.failAll {
+		return nil, fmt.Errorf("boom")
+	}
+	return f.watermarks, nil
+}
+func (f *fakeDaemonClient) GetPipelineStatus(context.Context, string) (*daemon.PipelineStatus, error) {
+	if f.timeoutAll {
+		return nil, context.DeadlineExceeded
+	}
+	if f.failAll {
+		return nil, fmt.Errorf("boom")
+	}
+	return f.status, nil
+}
+func (f *fakeDaemonClient) GetVertexErrors(context.Context, string, string) ([]*daemon.ReplicaErrors, error) {
+	if f.timeoutAll {
+		return nil, context.DeadlineExceeded
+	}
+	if f.failAll {
+		return nil, fmt.Errorf("boom")
+	}
+	return f.errors, nil
+}
+
+var _ daemonclient.DaemonClient = (*fakeDaemonClient)(nil)
+
+type fakeMvtClient struct {
+	metrics *mvtxdaemon.MonoVertexMetrics
+}
+
+func (f *fakeMvtClient) Close() error { return nil }
+func (f *fakeMvtClient) GetMonoVertexMetrics(context.Context) (*mvtxdaemon.MonoVertexMetrics, error) {
+	return f.metrics, nil
+}
+func (f *fakeMvtClient) GetMonoVertexStatus(context.Context) (*mvtxdaemon.MonoVertexStatus, error) {
+	return &mvtxdaemon.MonoVertexStatus{}, nil
+}
+func (f *fakeMvtClient) GetMonoVertexErrors(context.Context, string) ([]*mvtxdaemon.ReplicaErrors, error) {
+	return nil, nil
+}
+
+var _ mvtdaemonclient.MonoVertexDaemonClient = (*fakeMvtClient)(nil)
+
+func debugTestContext(params gin.Params) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Params = params
+	return c, w
+}
+
+func seedClient(t *testing.T, objs ...runtime.Object) dfv1clients.NumaflowV1alpha1Interface {
+	t.Helper()
+	client := numaflowfake.NewSimpleClientset().NumaflowV1alpha1()
+	ctx := context.Background()
+	for _, obj := range objs {
+		var err error
+		switch o := obj.(type) {
+		case *dfv1.Pipeline:
+			_, err = client.Pipelines(o.Namespace).Create(ctx, o, metav1.CreateOptions{})
+		case *dfv1.MonoVertex:
+			_, err = client.MonoVertices(o.Namespace).Create(ctx, o, metav1.CreateOptions{})
+		default:
+			t.Fatalf("unsupported object %T", obj)
+		}
+		assert.NoError(t, err)
+	}
+	return client
+}
+
+func twoVertexPipeline() *dfv1.Pipeline {
+	return &dfv1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "p1"},
+		Spec: dfv1.PipelineSpec{
+			Vertices: []dfv1.AbstractVertex{
+				{Name: "in", Source: &dfv1.Source{}},
+				{Name: "out", Sink: &dfv1.Sink{AbstractSink: dfv1.AbstractSink{UDSink: &dfv1.UDSink{}}}},
+			},
+			Edges: []dfv1.Edge{{From: "in", To: "out"}},
+		},
+	}
+}
+
+func TestHandler_GetPipelineTopology(t *testing.T) {
+	h := &handler{numaflowClient: seedClient(t, twoVertexPipeline()), opts: &handlerOptions{}}
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "pipeline", Value: "p1"}})
+
+	h.GetPipelineTopology(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got PipelineTopologyDTO
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Len(t, got.Vertices, 2)
+	assert.Len(t, got.Edges, 1)
+	assert.Equal(t, "in", got.Edges[0].From)
+	// roles + expected containers
+	byName := map[string]TopologyVertexDTO{}
+	for _, v := range got.Vertices {
+		byName[v.Name] = v
+	}
+	assert.Equal(t, "source", byName["in"].Type)
+	assert.Equal(t, "sink", byName["out"].Type)
+	assert.Contains(t, byName["out"].ExpectedContainers, dfv1.CtrUdsink)
+	assert.Contains(t, byName["in"].ExpectedContainers, dfv1.CtrMain)
+}
+
+func pipelineDaemonHandler(t *testing.T, dc daemonclient.DaemonClient, objs ...runtime.Object) *handler {
+	t.Helper()
+	cache, _ := lru.New[string, daemonclient.DaemonClient](10)
+	cache.Add(pipelineDaemonSvcAddress("ns1", "p1"), dc)
+	return &handler{
+		numaflowClient:     seedClient(t, objs...),
+		kubeClient:         fakeKube.NewSimpleClientset(),
+		daemonClientsCache: cache,
+		opts:               &handlerOptions{},
+		healthChecker:      NewHealthChecker(context.Background()),
+	}
+}
+
+func TestHandler_GetPipelineBuffers(t *testing.T) {
+	dc := &fakeDaemonClient{buffers: []*daemon.BufferInfo{
+		{BufferName: "p1-out-0", PendingCount: wrapperspb.Int64(5), TotalMessages: wrapperspb.Int64(9)},
+	}}
+	h := pipelineDaemonHandler(t, dc, twoVertexPipeline())
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "pipeline", Value: "p1"}})
+
+	h.GetPipelineBuffers(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got []BufferDTO
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Len(t, got, 1)
+	assert.Equal(t, "p1-out-0", got[0].Name)
+	assert.Equal(t, int64(5), got[0].Pending)
+}
+
+func TestHandler_GetPipelineEdgeWatermarks(t *testing.T) {
+	dc := &fakeDaemonClient{watermarks: []*daemon.EdgeWatermark{
+		{From: "in", To: "out", Watermarks: []*wrapperspb.Int64Value{wrapperspb.Int64(123)}, IsWatermarkEnabled: wrapperspb.Bool(true)},
+	}}
+	h := pipelineDaemonHandler(t, dc, twoVertexPipeline())
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "pipeline", Value: "p1"}})
+
+	h.GetPipelineEdgeWatermarks(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got []EdgeWatermarkDTO
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Len(t, got, 1)
+	assert.Equal(t, []int64{123}, got[0].Watermarks)
+	assert.True(t, got[0].IsEnabled)
+}
+
+func TestHandler_GetMonoVertexThroughputMetrics(t *testing.T) {
+	cache, _ := lru.New[string, mvtdaemonclient.MonoVertexDaemonClient](10)
+	cache.Add(monoVertexDaemonSvcAddress("ns1", "mv1"), &fakeMvtClient{metrics: &mvtxdaemon.MonoVertexMetrics{
+		MonoVertex:      "mv1",
+		ProcessingRates: map[string]*wrapperspb.DoubleValue{"1m": wrapperspb.Double(3.5)},
+		Pendings:        map[string]*wrapperspb.Int64Value{"1m": wrapperspb.Int64(11)},
+	}})
+	h := &handler{mvtDaemonClientsCache: cache, opts: &handlerOptions{}}
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "mono-vertex", Value: "mv1"}})
+
+	h.GetMonoVertexThroughputMetrics(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got MonoVertexMetricsDTO
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, 3.5, got.ProcessingRates["1m"])
+	assert.Equal(t, int64(11), got.Pending["1m"])
+}
+
+func TestHandler_GetVertexEvents_UsesCRName(t *testing.T) {
+	// Event involvedObject uses the Vertex CR name "p1-out", not "out".
+	ev := corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Namespace: "ns1", Name: "e1"},
+		InvolvedObject: corev1.ObjectReference{Kind: dfv1.VertexGroupVersionKind.Kind, Name: "p1-out"},
+		Type:           "Warning",
+		Reason:         "BackOff",
+		Message:        "crashloop",
+		Count:          3,
+		LastTimestamp:  metav1.Now(),
+	}
+	kube := fakeKube.NewSimpleClientset(&ev)
+	h := &handler{kubeClient: kube, opts: &handlerOptions{}}
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "pipeline", Value: "p1"}, {Key: "vertex", Value: "out"}})
+
+	h.GetVertexEvents(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got []K8sEventsResponse
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Len(t, got, 1)
+	assert.Equal(t, "p1-out", got[0].InvolvedObjectName)
+	assert.Equal(t, dfv1.VertexGroupVersionKind.Kind, got[0].InvolvedObjectKind)
+	assert.Equal(t, "Vertex/p1-out", got[0].Object) // legacy field preserved
+	assert.Equal(t, int32(3), got[0].Count)
+}
+
+func TestHandler_GetPipelineDebugSnapshot_Composes(t *testing.T) {
+	dc := &fakeDaemonClient{
+		status:     &daemon.PipelineStatus{Status: "warning", Code: "D2"},
+		watermarks: []*daemon.EdgeWatermark{{From: "in", To: "out", Watermarks: []*wrapperspb.Int64Value{wrapperspb.Int64(100)}}},
+		buffers:    []*daemon.BufferInfo{{BufferName: "p1-out-0", PendingCount: wrapperspb.Int64(7)}},
+		metrics:    []*daemon.VertexMetrics{{Pendings: map[string]*wrapperspb.Int64Value{"1m": wrapperspb.Int64(7)}}},
+		errors:     []*daemon.ReplicaErrors{{Replica: "p1-out-0", ContainerErrors: []*daemon.ContainerError{{Container: "udsink", Message: "boom"}}}},
+	}
+	h := pipelineDaemonHandler(t, dc, twoVertexPipeline())
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "pipeline", Value: "p1"}})
+
+	h.GetPipelineDebugSnapshot(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got DebugSnapshotDTO
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.NotEmpty(t, got.ObservedAt)
+	assert.NotNil(t, got.DataHealth.Data)
+	assert.Equal(t, "warning", got.DataHealth.Data.Status)
+	assert.Len(t, got.Buffers.Data, 1)
+	assert.NotNil(t, got.WatermarkLag.Data)
+	// both vertices report the same canned error, so both appear
+	assert.Len(t, got.RuntimeErrors.Data, 2)
+}
+
+func TestHandler_GetPipelineDebugSnapshot_DegradesGracefully(t *testing.T) {
+	// Daemon sub-calls all fail; resource health (k8s) still works, and the
+	// response is 200 with per-section errors rather than a 502.
+	dc := &fakeDaemonClient{failAll: true}
+	h := pipelineDaemonHandler(t, dc, twoVertexPipeline())
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "pipeline", Value: "p1"}})
+
+	h.GetPipelineDebugSnapshot(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got DebugSnapshotDTO
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	// daemon-backed sections carry structured errors, not a whole-response 502
+	assert.NotNil(t, got.DataHealth.Error)
+	assert.Equal(t, SnapshotErrCodeDaemonUnavailable, got.DataHealth.Error.Code)
+	assert.NotNil(t, got.Buffers.Error)
+	assert.NotNil(t, got.WatermarkLag.Error)
+	// resource health (k8s-backed) is attempted independently of the daemon
+	assert.NotEmpty(t, got.ResourceHealth.ObservedAt)
+}
+
+func TestHandler_GetPipelineDebugSnapshot_TimeoutClassified(t *testing.T) {
+	dc := &fakeDaemonClient{timeoutAll: true}
+	h := pipelineDaemonHandler(t, dc, twoVertexPipeline())
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "pipeline", Value: "p1"}})
+
+	h.GetPipelineDebugSnapshot(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got DebugSnapshotDTO
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	// deadline errors must classify as timeout, not daemon_unavailable
+	assert.NotNil(t, got.DataHealth.Error)
+	assert.Equal(t, SnapshotErrCodeTimeout, got.DataHealth.Error.Code)
+}
+
+func TestHandler_GetPipelineDebugSnapshot_TotalErrorsCapped(t *testing.T) {
+	// Many replicas, each at the per-replica cap, returned for every vertex.
+	// Across vertices this far exceeds the total cap; ensure the snapshot never
+	// returns more than snapshotMaxTotalErrors errors overall.
+	manyReplicas := make([]*daemon.ReplicaErrors, 100)
+	for r := range manyReplicas {
+		ces := make([]*daemon.ContainerError, snapshotMaxErrorsPerVtx)
+		for i := range ces {
+			ces[i] = &daemon.ContainerError{Container: "udsink", Message: "boom"}
+		}
+		manyReplicas[r] = &daemon.ReplicaErrors{Replica: fmt.Sprintf("p1-out-%d", r), ContainerErrors: ces}
+	}
+	dc := &fakeDaemonClient{errors: manyReplicas}
+	h := pipelineDaemonHandler(t, dc, twoVertexPipeline())
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "pipeline", Value: "p1"}})
+
+	h.GetPipelineDebugSnapshot(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got DebugSnapshotDTO
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	total := 0
+	for _, ve := range got.RuntimeErrors.Data {
+		for _, re := range ve.Errors {
+			total += len(re.Errors)
+		}
+	}
+	assert.LessOrEqual(t, total, snapshotMaxTotalErrors)
+	assert.Equal(t, snapshotMaxTotalErrors, total) // exactly the budget is consumed
+}
+
+func TestHandler_GetVertexEvents_PushesFieldSelector(t *testing.T) {
+	kube := fakeKube.NewSimpleClientset()
+	var gotFields string
+	kube.PrependReactor("list", "events", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		la := action.(k8stesting.ListAction)
+		gotFields = la.GetListRestrictions().Fields.String()
+		return true, &corev1.EventList{}, nil
+	})
+	h := &handler{kubeClient: kube, opts: &handlerOptions{}}
+	c, _ := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "pipeline", Value: "p1"}, {Key: "vertex", Value: "out"}})
+
+	h.GetVertexEvents(c)
+
+	// the involvedObject kind+name filter is pushed into the API call rather than
+	// loading every namespace event and filtering in memory
+	assert.Contains(t, gotFields, "involvedObject.kind=Vertex")
+	assert.Contains(t, gotFields, "involvedObject.name=p1-out")
+}
+
+func TestHandler_GetPipelineEvents_SignalsScanCeiling(t *testing.T) {
+	kube := fakeKube.NewSimpleClientset()
+	calls := 0
+	kube.PrependReactor("list", "events", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		calls++
+		items := make([]corev1.Event, int(eventListPageSize))
+		for i := range items {
+			items[i] = corev1.Event{
+				ObjectMeta:     metav1.ObjectMeta{Namespace: "ns1", Name: fmt.Sprintf("event-%d-%d", calls, i)},
+				InvolvedObject: corev1.ObjectReference{Kind: dfv1.PipelineGroupVersionKind.Kind, Name: "p1"},
+				Type:           "Warning",
+				Reason:         "BackOff",
+				Message:        "still failing",
+				LastTimestamp:  metav1.Now(),
+			}
+		}
+		return true, &corev1.EventList{
+			ListMeta: metav1.ListMeta{Continue: "next"},
+			Items:    items,
+		}, nil
+	})
+	h := &handler{kubeClient: kube, opts: &handlerOptions{}}
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "pipeline", Value: "p1"}})
+
+	h.GetPipelineEvents(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "true", w.Header().Get("X-Numaflow-Events-Truncated"))
+	assert.Equal(t, "true", w.Header().Get("X-Numaflow-Events-Scan-Ceiling-Reached"))
+	assert.Equal(t, eventScanCeiling/int(eventListPageSize), calls)
+	var got []K8sEventsResponse
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Len(t, got, int(defaultScopedEventLimit))
+}

--- a/server/apis/v1/handler_debug_test.go
+++ b/server/apis/v1/handler_debug_test.go
@@ -102,17 +102,40 @@ var _ daemonclient.DaemonClient = (*fakeDaemonClient)(nil)
 
 type fakeMvtClient struct {
 	metrics *mvtxdaemon.MonoVertexMetrics
+	status  *mvtxdaemon.MonoVertexStatus
+	errors  []*mvtxdaemon.ReplicaErrors
+	failAll bool
+	// timeoutAll makes every sub-call return context.DeadlineExceeded.
+	timeoutAll bool
 }
 
 func (f *fakeMvtClient) Close() error { return nil }
 func (f *fakeMvtClient) GetMonoVertexMetrics(context.Context) (*mvtxdaemon.MonoVertexMetrics, error) {
+	if f.timeoutAll {
+		return nil, context.DeadlineExceeded
+	}
+	if f.failAll {
+		return nil, fmt.Errorf("boom")
+	}
 	return f.metrics, nil
 }
 func (f *fakeMvtClient) GetMonoVertexStatus(context.Context) (*mvtxdaemon.MonoVertexStatus, error) {
-	return &mvtxdaemon.MonoVertexStatus{}, nil
+	if f.timeoutAll {
+		return nil, context.DeadlineExceeded
+	}
+	if f.failAll {
+		return nil, fmt.Errorf("boom")
+	}
+	return f.status, nil
 }
 func (f *fakeMvtClient) GetMonoVertexErrors(context.Context, string) ([]*mvtxdaemon.ReplicaErrors, error) {
-	return nil, nil
+	if f.timeoutAll {
+		return nil, context.DeadlineExceeded
+	}
+	if f.failAll {
+		return nil, fmt.Errorf("boom")
+	}
+	return f.errors, nil
 }
 
 var _ mvtdaemonclient.MonoVertexDaemonClient = (*fakeMvtClient)(nil)
@@ -158,6 +181,18 @@ func twoVertexPipeline() *dfv1.Pipeline {
 	}
 }
 
+func monoVertex() *dfv1.MonoVertex {
+	mv := &dfv1.MonoVertex{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "mv1"},
+	}
+	mv.Status.InitConditions()
+	mv.Status.MarkDeployed()
+	mv.Status.MarkDaemonHealthy()
+	mv.Status.MarkPodHealthy("Running", "all pods are healthy")
+	mv.Status.MarkPhaseRunning()
+	return mv
+}
+
 func TestHandler_GetPipelineTopology(t *testing.T) {
 	h := &handler{numaflowClient: seedClient(t, twoVertexPipeline()), opts: &handlerOptions{}}
 	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "pipeline", Value: "p1"}})
@@ -191,6 +226,19 @@ func pipelineDaemonHandler(t *testing.T, dc daemonclient.DaemonClient, objs ...r
 		daemonClientsCache: cache,
 		opts:               &handlerOptions{},
 		healthChecker:      NewHealthChecker(context.Background()),
+	}
+}
+
+func monoVertexDaemonHandler(t *testing.T, dc mvtdaemonclient.MonoVertexDaemonClient, objs ...runtime.Object) *handler {
+	t.Helper()
+	cache, _ := lru.New[string, mvtdaemonclient.MonoVertexDaemonClient](10)
+	cache.Add(monoVertexDaemonSvcAddress("ns1", "mv1"), dc)
+	return &handler{
+		numaflowClient:        seedClient(t, objs...),
+		kubeClient:            fakeKube.NewSimpleClientset(),
+		mvtDaemonClientsCache: cache,
+		opts:                  &handlerOptions{},
+		healthChecker:         NewHealthChecker(context.Background()),
 	}
 }
 
@@ -364,6 +412,61 @@ func TestHandler_GetPipelineDebugSnapshot_TotalErrorsCapped(t *testing.T) {
 	}
 	assert.LessOrEqual(t, total, snapshotMaxTotalErrors)
 	assert.Equal(t, snapshotMaxTotalErrors, total) // exactly the budget is consumed
+}
+
+func TestHandler_GetMonoVertexDebugSnapshot_Composes(t *testing.T) {
+	dc := &fakeMvtClient{
+		status:  &mvtxdaemon.MonoVertexStatus{Status: "healthy", Code: "M1"},
+		metrics: &mvtxdaemon.MonoVertexMetrics{ProcessingRates: map[string]*wrapperspb.DoubleValue{"1m": wrapperspb.Double(4.5)}, Pendings: map[string]*wrapperspb.Int64Value{"1m": wrapperspb.Int64(12)}},
+		errors:  []*mvtxdaemon.ReplicaErrors{{Replica: "mv1-0", ContainerErrors: []*mvtxdaemon.ContainerError{{Container: "udsource", Message: "boom"}}}},
+	}
+	h := monoVertexDaemonHandler(t, dc, monoVertex())
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "mono-vertex", Value: "mv1"}})
+
+	h.GetMonoVertexDebugSnapshot(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got MonoVertexDebugSnapshotDTO
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.NotEmpty(t, got.ObservedAt)
+	assert.NotNil(t, got.ResourceHealth.Data)
+	assert.NotNil(t, got.DataHealth.Data)
+	assert.Equal(t, "healthy", got.DataHealth.Data.Status)
+	assert.NotNil(t, got.Metrics.Data)
+	assert.Equal(t, 4.5, got.Metrics.Data.ProcessingRates["1m"])
+	assert.Len(t, got.RuntimeErrors.Data, 1)
+	assert.Equal(t, "mv1-0", got.RuntimeErrors.Data[0].Replica)
+}
+
+func TestHandler_GetMonoVertexDebugSnapshot_DegradesGracefully(t *testing.T) {
+	dc := &fakeMvtClient{failAll: true}
+	h := monoVertexDaemonHandler(t, dc, monoVertex())
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "mono-vertex", Value: "mv1"}})
+
+	h.GetMonoVertexDebugSnapshot(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got MonoVertexDebugSnapshotDTO
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.NotNil(t, got.ResourceHealth.Data)
+	assert.NotNil(t, got.DataHealth.Error)
+	assert.Equal(t, SnapshotErrCodeDaemonUnavailable, got.DataHealth.Error.Code)
+	assert.NotNil(t, got.Metrics.Error)
+	assert.NotNil(t, got.RuntimeErrors.Error)
+}
+
+func TestHandler_GetMonoVertexDebugSnapshot_TimeoutClassified(t *testing.T) {
+	dc := &fakeMvtClient{timeoutAll: true}
+	h := monoVertexDaemonHandler(t, dc, monoVertex())
+	c, w := debugTestContext(gin.Params{{Key: "namespace", Value: "ns1"}, {Key: "mono-vertex", Value: "mv1"}})
+
+	h.GetMonoVertexDebugSnapshot(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got MonoVertexDebugSnapshotDTO
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.NotNil(t, got.DataHealth.Error)
+	assert.Equal(t, SnapshotErrCodeTimeout, got.DataHealth.Error.Code)
 }
 
 func TestHandler_GetVertexEvents_PushesFieldSelector(t *testing.T) {

--- a/server/apis/v1/response_debug.go
+++ b/server/apis/v1/response_debug.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaflow/pkg/apis/proto/daemon"
+	"github.com/numaproj/numaflow/pkg/apis/proto/mvtxdaemon"
+)
+
+// This file holds the DTOs for the discovery (topology) and correlation
+// (debug-snapshot) endpoints, plus the typed wrappers for raw daemon responses.
+
+// PipelineTopologyDTO is the discovery view of a pipeline's graph: its vertices
+// (with roles, partitions, scale bounds, and expected container names) and edges.
+// It is derived purely from the spec and carries no secret-bearing config.
+type PipelineTopologyDTO struct {
+	Pipeline string              `json:"pipeline"`
+	Vertices []TopologyVertexDTO `json:"vertices"`
+	Edges    []TopologyEdgeDTO   `json:"edges"`
+}
+
+// TopologyVertexDTO describes a pipeline vertex in the topology response.
+type TopologyVertexDTO struct {
+	Name string `json:"name"`
+	// Type is one of: source, sink, map-udf, reduce-udf.
+	Type       string `json:"type"`
+	Partitions int    `json:"partitions"`
+	ScaleMin   int32  `json:"scaleMin"`
+	ScaleMax   int32  `json:"scaleMax"`
+	// ExpectedContainers are the container names this vertex's pods should run,
+	// derived from the spec (not observed from live pods).
+	ExpectedContainers []string `json:"expectedContainers"`
+}
+
+// TopologyEdgeDTO describes a directed edge in the pipeline topology response.
+type TopologyEdgeDTO struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// vertexRole classifies an AbstractVertex for the topology DTO.
+func vertexRole(v v1alpha1.AbstractVertex) string {
+	switch {
+	case v.IsASource():
+		return "source"
+	case v.IsASink():
+		return "sink"
+	case v.IsReduceUDF():
+		return "reduce-udf"
+	default:
+		return "map-udf"
+	}
+}
+
+// expectedContainers returns the container names a vertex's pods are expected to
+// run, derived from the spec. Every vertex has the main and monitor containers;
+// role-specific user-defined containers are added based on what the spec configures.
+func expectedContainers(v v1alpha1.AbstractVertex) []string {
+	names := []string{v1alpha1.CtrMain, v1alpha1.CtrMonitor}
+	switch {
+	case v.IsASource():
+		if v.IsUDSource() {
+			names = append(names, v1alpha1.CtrUdsource)
+		}
+		if v.HasUDTransformer() {
+			names = append(names, v1alpha1.CtrUdtransformer)
+		}
+	case v.IsASink():
+		if v.IsUDSink() {
+			names = append(names, v1alpha1.CtrUdsink)
+		}
+		if v.HasFallbackUDSink() {
+			names = append(names, v1alpha1.CtrFallbackUdsink)
+		}
+		if v.HasOnSuccessUDSink() {
+			names = append(names, v1alpha1.CtrOnSuccessUdsink)
+		}
+	default: // udf
+		names = append(names, v1alpha1.CtrUdf)
+	}
+	// Vertices with side inputs also run the side-inputs synchronizer sidecar.
+	if len(v.SideInputs) > 0 {
+		names = append(names, v1alpha1.CtrSideInputsWatcher)
+	}
+	return names
+}
+
+func newPipelineTopologyDTO(pl *v1alpha1.Pipeline) PipelineTopologyDTO {
+	dto := PipelineTopologyDTO{Pipeline: pl.Name}
+	for _, v := range pl.Spec.Vertices {
+		dto.Vertices = append(dto.Vertices, TopologyVertexDTO{
+			Name:               v.Name,
+			Type:               vertexRole(v),
+			Partitions:         pl.NumOfPartitions(v.Name),
+			ScaleMin:           v.Scale.GetMinReplicas(),
+			ScaleMax:           v.Scale.GetMaxReplicas(),
+			ExpectedContainers: expectedContainers(v),
+		})
+	}
+	for _, e := range pl.Spec.Edges {
+		dto.Edges = append(dto.Edges, TopologyEdgeDTO{From: e.From, To: e.To})
+	}
+	return dto
+}
+
+// EdgeWatermarkDTO is a typed projection of a pipeline edge's watermarks (per
+// partition, in epoch milliseconds).
+type EdgeWatermarkDTO struct {
+	From       string  `json:"from"`
+	To         string  `json:"to"`
+	Watermarks []int64 `json:"watermarks"`
+	IsEnabled  bool    `json:"isEnabled"`
+}
+
+func newEdgeWatermarkDTOs(watermarks []*daemon.EdgeWatermark) []EdgeWatermarkDTO {
+	out := make([]EdgeWatermarkDTO, 0, len(watermarks))
+	for _, w := range watermarks {
+		if w == nil {
+			continue
+		}
+		wms := make([]int64, 0, len(w.GetWatermarks()))
+		for _, v := range w.GetWatermarks() {
+			wms = append(wms, v.GetValue())
+		}
+		out = append(out, EdgeWatermarkDTO{
+			From:       w.GetFrom(),
+			To:         w.GetTo(),
+			Watermarks: wms,
+			IsEnabled:  w.GetIsWatermarkEnabled().GetValue(),
+		})
+	}
+	return out
+}
+
+// MonoVertexMetricsDTO is the typed processing rates and pending counts for a
+// mono vertex, keyed by lookback window ("1m", "5m", "15m", "default").
+type MonoVertexMetricsDTO struct {
+	MonoVertex      string             `json:"monoVertex"`
+	ProcessingRates map[string]float64 `json:"processingRates,omitempty"`
+	Pending         map[string]int64   `json:"pending,omitempty"`
+}
+
+func newMonoVertexMetricsDTO(monoVertex string, m *mvtxdaemon.MonoVertexMetrics) MonoVertexMetricsDTO {
+	dto := MonoVertexMetricsDTO{MonoVertex: monoVertex}
+	if m == nil {
+		return dto
+	}
+	if len(m.GetProcessingRates()) > 0 {
+		dto.ProcessingRates = make(map[string]float64, len(m.GetProcessingRates()))
+		for k, v := range m.GetProcessingRates() {
+			dto.ProcessingRates[k] = v.GetValue()
+		}
+	}
+	if len(m.GetPendings()) > 0 {
+		dto.Pending = make(map[string]int64, len(m.GetPendings()))
+		for k, v := range m.GetPendings() {
+			dto.Pending[k] = v.GetValue()
+		}
+	}
+	return dto
+}
+
+// --- Debug snapshot ---
+
+// Stable error codes for a debug-snapshot section that failed to populate.
+const (
+	SnapshotErrCodeDaemonUnavailable = "daemon_unavailable"
+	SnapshotErrCodeTimeout           = "timeout"
+	SnapshotErrCodeNotFound          = "not_found"
+	SnapshotErrCodeInternal          = "internal"
+)
+
+// SnapshotSectionError is the structured error attached to a snapshot section when its
+// underlying fetch failed. Agents can branch on Code.
+type SnapshotSectionError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// DebugSnapshotDTO is a bounded, read-only correlation of a pipeline's current
+// state, composed from existing single-purpose data sources. Each section is
+// independently fetched; a failed section carries an error rather than failing
+// the whole response. Notes are mechanical fetch facts only (e.g. truncation),
+// never inferred diagnosis.
+type DebugSnapshotDTO struct {
+	Pipeline       string                        `json:"pipeline"`
+	Namespace      string                        `json:"namespace"`
+	ObservedAt     string                        `json:"observedAt"`
+	ResourceHealth SnapshotResourceHealthSection `json:"resourceHealth"`
+	DataHealth     SnapshotDataHealthSection     `json:"dataHealth"`
+	WatermarkLag   SnapshotWatermarkLagSection   `json:"watermarkLag"`
+	Vertices       SnapshotVertexMetricsSection  `json:"vertices"`
+	Buffers        SnapshotBuffersSection        `json:"buffers"`
+	RuntimeErrors  SnapshotRuntimeErrorsSection  `json:"runtimeErrors"`
+	WarningEvents  SnapshotEventsSection         `json:"warningEvents"`
+	Notes          []string                      `json:"notes,omitempty"`
+}
+
+// SnapshotResourceHealthSection carries the pipeline resource health portion of a debug snapshot.
+type SnapshotResourceHealthSection struct {
+	Data       *ResourceHealthData   `json:"data,omitempty"`
+	Error      *SnapshotSectionError `json:"error,omitempty"`
+	ObservedAt string                `json:"observedAt"`
+}
+
+// ResourceHealthData is the resource-level health summary of a pipeline.
+type ResourceHealthData struct {
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+	Code    string `json:"code,omitempty"`
+}
+
+// SnapshotDataHealthSection carries daemon-reported data health in a debug snapshot.
+type SnapshotDataHealthSection struct {
+	Data       *DataHealthDTO        `json:"data,omitempty"`
+	Error      *SnapshotSectionError `json:"error,omitempty"`
+	ObservedAt string                `json:"observedAt"`
+}
+
+// SnapshotWatermarkLagSection carries end-to-end watermark lag in a debug snapshot.
+type SnapshotWatermarkLagSection struct {
+	Data       *WatermarkLagDTO      `json:"data,omitempty"`
+	Error      *SnapshotSectionError `json:"error,omitempty"`
+	ObservedAt string                `json:"observedAt"`
+}
+
+// SnapshotVertexMetrics carries per-vertex pending and rates within the snapshot.
+type SnapshotVertexMetrics struct {
+	Vertex     string                  `json:"vertex"`
+	Partitions []VertexPartitionMetric `json:"partitions"`
+}
+
+// SnapshotVertexMetricsSection carries per-vertex metrics in a debug snapshot.
+type SnapshotVertexMetricsSection struct {
+	Data       []SnapshotVertexMetrics `json:"data,omitempty"`
+	Error      *SnapshotSectionError   `json:"error,omitempty"`
+	ObservedAt string                  `json:"observedAt"`
+}
+
+// SnapshotBuffersSection carries inter-step buffer metrics in a debug snapshot.
+type SnapshotBuffersSection struct {
+	Data       []BufferDTO           `json:"data,omitempty"`
+	Error      *SnapshotSectionError `json:"error,omitempty"`
+	ObservedAt string                `json:"observedAt"`
+}
+
+// SnapshotVertexErrors groups runtime errors under their vertex.
+type SnapshotVertexErrors struct {
+	Vertex string            `json:"vertex"`
+	Errors []ReplicaErrorDTO `json:"errors,omitempty"`
+}
+
+// SnapshotRuntimeErrorsSection carries runtime errors in a debug snapshot.
+type SnapshotRuntimeErrorsSection struct {
+	Data       []SnapshotVertexErrors `json:"data,omitempty"`
+	Error      *SnapshotSectionError  `json:"error,omitempty"`
+	ObservedAt string                 `json:"observedAt"`
+}
+
+// SnapshotEventsSection carries recent Kubernetes events in a debug snapshot.
+type SnapshotEventsSection struct {
+	Data       []K8sEventsResponse   `json:"data,omitempty"`
+	Error      *SnapshotSectionError `json:"error,omitempty"`
+	ObservedAt string                `json:"observedAt"`
+}

--- a/server/apis/v1/response_debug.go
+++ b/server/apis/v1/response_debug.go
@@ -175,8 +175,6 @@ func newMonoVertexMetricsDTO(monoVertex string, m *mvtxdaemon.MonoVertexMetrics)
 	return dto
 }
 
-// --- Debug snapshot ---
-
 // Stable error codes for a debug-snapshot section that failed to populate.
 const (
 	SnapshotErrCodeDaemonUnavailable = "daemon_unavailable"
@@ -195,8 +193,7 @@ type SnapshotSectionError struct {
 // DebugSnapshotDTO is a bounded, read-only correlation of a pipeline's current
 // state, composed from existing single-purpose data sources. Each section is
 // independently fetched; a failed section carries an error rather than failing
-// the whole response. Notes are mechanical fetch facts only (e.g. truncation),
-// never inferred diagnosis.
+// the whole response.
 type DebugSnapshotDTO struct {
 	Pipeline       string                        `json:"pipeline"`
 	Namespace      string                        `json:"namespace"`
@@ -209,6 +206,21 @@ type DebugSnapshotDTO struct {
 	RuntimeErrors  SnapshotRuntimeErrorsSection  `json:"runtimeErrors"`
 	WarningEvents  SnapshotEventsSection         `json:"warningEvents"`
 	Notes          []string                      `json:"notes,omitempty"`
+}
+
+// MonoVertexDebugSnapshotDTO is a bounded, read-only correlation of a mono
+// vertex's current state. It mirrors DebugSnapshotDTO where mono-vertex data
+// sources have parity with pipeline data sources.
+type MonoVertexDebugSnapshotDTO struct {
+	MonoVertex     string                                 `json:"monoVertex"`
+	Namespace      string                                 `json:"namespace"`
+	ObservedAt     string                                 `json:"observedAt"`
+	ResourceHealth SnapshotResourceHealthSection          `json:"resourceHealth"`
+	DataHealth     SnapshotDataHealthSection              `json:"dataHealth"`
+	Metrics        SnapshotMonoVertexMetricsSection       `json:"metrics"`
+	RuntimeErrors  SnapshotMonoVertexRuntimeErrorsSection `json:"runtimeErrors"`
+	WarningEvents  SnapshotEventsSection                  `json:"warningEvents"`
+	Notes          []string                               `json:"notes,omitempty"`
 }
 
 // SnapshotResourceHealthSection carries the pipeline resource health portion of a debug snapshot.
@@ -259,6 +271,13 @@ type SnapshotBuffersSection struct {
 	ObservedAt string                `json:"observedAt"`
 }
 
+// SnapshotMonoVertexMetricsSection carries mono-vertex metrics in a debug snapshot.
+type SnapshotMonoVertexMetricsSection struct {
+	Data       *MonoVertexMetricsDTO `json:"data,omitempty"`
+	Error      *SnapshotSectionError `json:"error,omitempty"`
+	ObservedAt string                `json:"observedAt"`
+}
+
 // SnapshotVertexErrors groups runtime errors under their vertex.
 type SnapshotVertexErrors struct {
 	Vertex string            `json:"vertex"`
@@ -270,6 +289,13 @@ type SnapshotRuntimeErrorsSection struct {
 	Data       []SnapshotVertexErrors `json:"data,omitempty"`
 	Error      *SnapshotSectionError  `json:"error,omitempty"`
 	ObservedAt string                 `json:"observedAt"`
+}
+
+// SnapshotMonoVertexRuntimeErrorsSection carries mono-vertex runtime errors in a debug snapshot.
+type SnapshotMonoVertexRuntimeErrorsSection struct {
+	Data       []ReplicaErrorDTO     `json:"data,omitempty"`
+	Error      *SnapshotSectionError `json:"error,omitempty"`
+	ObservedAt string                `json:"observedAt"`
 }
 
 // SnapshotEventsSection carries recent Kubernetes events in a debug snapshot.

--- a/server/apis/v1/response_dto.go
+++ b/server/apis/v1/response_dto.go
@@ -1,0 +1,439 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"math"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaflow/pkg/apis/proto/daemon"
+	"github.com/numaproj/numaflow/pkg/apis/proto/mvtxdaemon"
+)
+
+// This file holds the response DTOs for the single-purpose endpoints. They use
+// bare scalars instead of protobuf wrapper types (which serialize as
+// {"value":"123"}), format timestamps as RFC3339, and carry only the data the
+// endpoint is named for. They are returned directly, without the
+// NumaflowAPIResponse envelope.
+
+// ConditionDTO is a projection of metav1.Condition.
+type ConditionDTO struct {
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func newConditionDTOs(conditions []metav1.Condition) []ConditionDTO {
+	if len(conditions) == 0 {
+		return nil
+	}
+	out := make([]ConditionDTO, 0, len(conditions))
+	for _, c := range conditions {
+		out = append(out, ConditionDTO{
+			Type:    c.Type,
+			Status:  string(c.Status),
+			Reason:  c.Reason,
+			Message: c.Message,
+		})
+	}
+	return out
+}
+
+// rfc3339 formats a metav1.Time as an RFC3339 string, returning "" when unset.
+func rfc3339(t metav1.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// DataHealthDTO is the data-plane (criticality) health of a pipeline or mono
+// vertex. status is one of: healthy, warning, critical, unknown.
+type DataHealthDTO struct {
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+	Code    string `json:"code,omitempty"`
+}
+
+// VertexMetricsDTO holds the processing rates and pending counts for a single
+// vertex, broken down per partition. The daemon returns one entry per partition
+// in buffer order; Partition is that positional index. The rate/pending maps are
+// keyed by lookback window ("1m", "5m", "15m", "default").
+type VertexMetricsDTO struct {
+	Pipeline   string                  `json:"pipeline"`
+	Vertex     string                  `json:"vertex"`
+	Partitions []VertexPartitionMetric `json:"partitions"`
+}
+
+type VertexPartitionMetric struct {
+	Partition       int                `json:"partition"`
+	ProcessingRates map[string]float64 `json:"processingRates,omitempty"`
+	Pending         map[string]int64   `json:"pending,omitempty"`
+}
+
+func newVertexMetricsDTO(pipeline, vertex string, metrics []*daemon.VertexMetrics) VertexMetricsDTO {
+	dto := VertexMetricsDTO{Pipeline: pipeline, Vertex: vertex}
+	for i, m := range metrics {
+		if m == nil {
+			continue
+		}
+		part := VertexPartitionMetric{Partition: i}
+		if len(m.GetProcessingRates()) > 0 {
+			part.ProcessingRates = make(map[string]float64, len(m.GetProcessingRates()))
+			for k, v := range m.GetProcessingRates() {
+				part.ProcessingRates[k] = v.GetValue()
+			}
+		}
+		if len(m.GetPendings()) > 0 {
+			part.Pending = make(map[string]int64, len(m.GetPendings()))
+			for k, v := range m.GetPendings() {
+				part.Pending[k] = v.GetValue()
+			}
+		}
+		dto.Partitions = append(dto.Partitions, part)
+	}
+	return dto
+}
+
+// PendingDTO holds the pending (backlog) message counts for a vertex or mono
+// vertex, broken down per partition so multi-partition vertices are not
+// collapsed. Each partition's counts are keyed by lookback window ("1m", "5m",
+// "15m", "default").
+type PendingDTO struct {
+	Pipeline   string             `json:"pipeline,omitempty"`
+	Vertex     string             `json:"vertex,omitempty"`
+	MonoVertex string             `json:"monoVertex,omitempty"`
+	Partitions []PartitionPending `json:"partitions"`
+}
+
+type PartitionPending struct {
+	Partition int              `json:"partition"`
+	Pending   map[string]int64 `json:"pending,omitempty"`
+}
+
+func newVertexPendingDTO(pipeline, vertex string, metrics []*daemon.VertexMetrics) PendingDTO {
+	dto := PendingDTO{Pipeline: pipeline, Vertex: vertex}
+	for i, m := range metrics {
+		if m == nil {
+			continue
+		}
+		pp := PartitionPending{Partition: i}
+		if len(m.GetPendings()) > 0 {
+			pp.Pending = make(map[string]int64, len(m.GetPendings()))
+			for k, v := range m.GetPendings() {
+				pp.Pending[k] = v.GetValue()
+			}
+		}
+		dto.Partitions = append(dto.Partitions, pp)
+	}
+	return dto
+}
+
+func newMonoVertexPendingDTO(monoVertex string, metrics *mvtxdaemon.MonoVertexMetrics) PendingDTO {
+	// A mono vertex has a single partition.
+	pp := PartitionPending{Partition: 0}
+	if metrics != nil && len(metrics.GetPendings()) > 0 {
+		pp.Pending = make(map[string]int64, len(metrics.GetPendings()))
+		for k, v := range metrics.GetPendings() {
+			pp.Pending[k] = v.GetValue()
+		}
+	}
+	return PendingDTO{MonoVertex: monoVertex, Partitions: []PartitionPending{pp}}
+}
+
+// BufferDTO is the metrics for a single inter-step buffer: how many messages are
+// pending/unacked, total depth, and how full it is.
+type BufferDTO struct {
+	Name             string  `json:"name"`
+	Pending          int64   `json:"pending"`
+	AckPending       int64   `json:"ackPending"`
+	TotalMessages    int64   `json:"totalMessages"`
+	BufferLength     int64   `json:"bufferLength"`
+	BufferUsageLimit float64 `json:"bufferUsageLimit"`
+	BufferUsage      float64 `json:"bufferUsage"`
+	IsFull           bool    `json:"isFull"`
+}
+
+func newBufferDTO(b *daemon.BufferInfo) BufferDTO {
+	return BufferDTO{
+		Name:             b.GetBufferName(),
+		Pending:          b.GetPendingCount().GetValue(),
+		AckPending:       b.GetAckPendingCount().GetValue(),
+		TotalMessages:    b.GetTotalMessages().GetValue(),
+		BufferLength:     b.GetBufferLength().GetValue(),
+		BufferUsageLimit: b.GetBufferUsageLimit().GetValue(),
+		BufferUsage:      b.GetBufferUsage().GetValue(),
+		IsFull:           b.GetIsFull().GetValue(),
+	}
+}
+
+// BufferPendingDTO holds the pending (backlog) message counts for a single
+// inter-step buffer.
+type BufferPendingDTO struct {
+	Name       string `json:"name"`
+	Pending    int64  `json:"pending"`
+	AckPending int64  `json:"ackPending"`
+}
+
+func newBufferPendingDTO(b *daemon.BufferInfo) BufferPendingDTO {
+	return BufferPendingDTO{
+		Name:       b.GetBufferName(),
+		Pending:    b.GetPendingCount().GetValue(),
+		AckPending: b.GetAckPendingCount().GetValue(),
+	}
+}
+
+// PipelineStatusDTO is the status subresource of a pipeline, without the spec.
+type PipelineStatusDTO struct {
+	Phase              string         `json:"phase"`
+	Message            string         `json:"message,omitempty"`
+	LastUpdated        string         `json:"lastUpdated,omitempty"`
+	ObservedGeneration int64          `json:"observedGeneration"`
+	DrainedOnPause     bool           `json:"drainedOnPause"`
+	VertexCount        *uint32        `json:"vertexCount,omitempty"`
+	SourceCount        *uint32        `json:"sourceCount,omitempty"`
+	SinkCount          *uint32        `json:"sinkCount,omitempty"`
+	UDFCount           *uint32        `json:"udfCount,omitempty"`
+	Conditions         []ConditionDTO `json:"conditions,omitempty"`
+}
+
+func newPipelineStatusDTO(pl *v1alpha1.Pipeline) PipelineStatusDTO {
+	s := pl.Status
+	return PipelineStatusDTO{
+		Phase:              string(s.Phase),
+		Message:            s.Message,
+		LastUpdated:        rfc3339(s.LastUpdated),
+		ObservedGeneration: s.ObservedGeneration,
+		DrainedOnPause:     s.DrainedOnPause,
+		VertexCount:        s.VertexCount,
+		SourceCount:        s.SourceCount,
+		SinkCount:          s.SinkCount,
+		UDFCount:           s.UDFCount,
+		Conditions:         newConditionDTOs(s.Conditions),
+	}
+}
+
+// VertexStatusDTO is the status subresource of a single vertex, without the spec.
+type VertexStatusDTO struct {
+	Phase              string         `json:"phase"`
+	Reason             string         `json:"reason,omitempty"`
+	Message            string         `json:"message,omitempty"`
+	Replicas           uint32         `json:"replicas"`
+	DesiredReplicas    uint32         `json:"desiredReplicas"`
+	ReadyReplicas      uint32         `json:"readyReplicas"`
+	UpdatedReplicas    uint32         `json:"updatedReplicas"`
+	CurrentHash        string         `json:"currentHash,omitempty"`
+	UpdateHash         string         `json:"updateHash,omitempty"`
+	LastScaledAt       string         `json:"lastScaledAt,omitempty"`
+	ObservedGeneration int64          `json:"observedGeneration"`
+	Conditions         []ConditionDTO `json:"conditions,omitempty"`
+}
+
+func newVertexStatusDTO(v *v1alpha1.Vertex) VertexStatusDTO {
+	s := v.Status
+	return VertexStatusDTO{
+		Phase:              string(s.Phase),
+		Reason:             s.Reason,
+		Message:            s.Message,
+		Replicas:           s.Replicas,
+		DesiredReplicas:    s.DesiredReplicas,
+		ReadyReplicas:      s.ReadyReplicas,
+		UpdatedReplicas:    s.UpdatedReplicas,
+		CurrentHash:        s.CurrentHash,
+		UpdateHash:         s.UpdateHash,
+		LastScaledAt:       rfc3339(s.LastScaledAt),
+		ObservedGeneration: s.ObservedGeneration,
+		Conditions:         newConditionDTOs(s.Conditions),
+	}
+}
+
+// MonoVertexStatusDTO is the status subresource of a mono vertex, without the spec.
+type MonoVertexStatusDTO struct {
+	Phase              string         `json:"phase"`
+	Reason             string         `json:"reason,omitempty"`
+	Message            string         `json:"message,omitempty"`
+	Replicas           uint32         `json:"replicas"`
+	DesiredReplicas    uint32         `json:"desiredReplicas"`
+	ReadyReplicas      uint32         `json:"readyReplicas"`
+	UpdatedReplicas    uint32         `json:"updatedReplicas"`
+	LastUpdated        string         `json:"lastUpdated,omitempty"`
+	ObservedGeneration int64          `json:"observedGeneration"`
+	Conditions         []ConditionDTO `json:"conditions,omitempty"`
+}
+
+func newMonoVertexStatusDTO(mv *v1alpha1.MonoVertex) MonoVertexStatusDTO {
+	s := mv.Status
+	return MonoVertexStatusDTO{
+		Phase:              string(s.Phase),
+		Reason:             s.Reason,
+		Message:            s.Message,
+		Replicas:           s.Replicas,
+		DesiredReplicas:    s.DesiredReplicas,
+		ReadyReplicas:      s.ReadyReplicas,
+		UpdatedReplicas:    s.UpdatedReplicas,
+		LastUpdated:        rfc3339(s.LastUpdated),
+		ObservedGeneration: s.ObservedGeneration,
+		Conditions:         newConditionDTOs(s.Conditions),
+	}
+}
+
+// WatermarkLagDTO is the end-to-end watermark lag of a pipeline in milliseconds
+// (max source watermark minus min sink watermark). LagMillis is -1 when data has
+// not yet reached the sink.
+type WatermarkLagDTO struct {
+	LagMillis          int64 `json:"lagMillis"`
+	MaxSourceWatermark int64 `json:"maxSourceWatermark"`
+	MinSinkWatermark   int64 `json:"minSinkWatermark"`
+}
+
+// computePipelineWatermarkLag derives the end-to-end watermark lag of a pipeline
+// from its edge watermarks: the largest source watermark minus the smallest sink
+// watermark. When the data has not yet reached a sink (sink watermark is -1),
+// LagMillis is reported as -1.
+func computePipelineWatermarkLag(pl *v1alpha1.Pipeline, watermarks []*daemon.EdgeWatermark) WatermarkLagDTO {
+	source := make(map[string]bool)
+	sink := make(map[string]bool)
+	for _, vertex := range pl.Spec.Vertices {
+		if vertex.IsASource() {
+			source[vertex.Name] = true
+		} else if vertex.IsASink() {
+			sink[vertex.Name] = true
+		}
+	}
+
+	var (
+		minWM       int64 = math.MaxInt64
+		maxWM       int64 = math.MinInt64
+		foundSink         = false
+		foundSource       = false
+	)
+	for _, watermark := range watermarks {
+		if watermark == nil {
+			continue
+		}
+		if _, ok := source[watermark.From]; ok {
+			for _, wm := range watermark.Watermarks {
+				if wm.GetValue() > maxWM {
+					maxWM = wm.GetValue()
+				}
+				foundSource = true
+			}
+		}
+		if _, ok := sink[watermark.To]; ok {
+			for _, wm := range watermark.Watermarks {
+				if wm.GetValue() < minWM {
+					minWM = wm.GetValue()
+				}
+				foundSink = true
+			}
+		}
+	}
+
+	lag := int64(-1)
+	if !foundSource {
+		maxWM = -1
+	}
+	if !foundSink {
+		minWM = -1
+	}
+	if foundSource && foundSink && minWM != -1 {
+		lag = maxWM - minWM
+	}
+	return WatermarkLagDTO{
+		LagMillis:          lag,
+		MaxSourceWatermark: maxWM,
+		MinSinkWatermark:   minWM,
+	}
+}
+
+// ReplicaErrorDTO is the set of runtime errors observed on a single replica,
+// broken down per container.
+type ReplicaErrorDTO struct {
+	Replica string              `json:"replica"`
+	Errors  []ContainerErrorDTO `json:"errors,omitempty"`
+}
+
+type ContainerErrorDTO struct {
+	Container string `json:"container"`
+	Timestamp string `json:"timestamp,omitempty"`
+	Code      string `json:"code,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Details   string `json:"details,omitempty"`
+}
+
+func newReplicaErrorDTOs(replicas []*daemon.ReplicaErrors) []ReplicaErrorDTO {
+	out := make([]ReplicaErrorDTO, 0, len(replicas))
+	for _, r := range replicas {
+		if r == nil {
+			continue
+		}
+		re := ReplicaErrorDTO{Replica: r.GetReplica()}
+		for _, ce := range r.GetContainerErrors() {
+			if ce == nil {
+				continue
+			}
+			ts := ""
+			if ce.GetTimestamp() != nil {
+				ts = ce.GetTimestamp().AsTime().UTC().Format(time.RFC3339)
+			}
+			re.Errors = append(re.Errors, ContainerErrorDTO{
+				Container: ce.GetContainer(),
+				Timestamp: ts,
+				Code:      ce.GetCode(),
+				Message:   ce.GetMessage(),
+				Details:   ce.GetDetails(),
+			})
+		}
+		out = append(out, re)
+	}
+	return out
+}
+
+// newMonoVertexReplicaErrorDTOs maps mono vertex daemon replica errors. The
+// mvtxdaemon proto types mirror the pipeline daemon's but are distinct Go types,
+// so they need their own mapper.
+func newMonoVertexReplicaErrorDTOs(replicas []*mvtxdaemon.ReplicaErrors) []ReplicaErrorDTO {
+	out := make([]ReplicaErrorDTO, 0, len(replicas))
+	for _, r := range replicas {
+		if r == nil {
+			continue
+		}
+		re := ReplicaErrorDTO{Replica: r.GetReplica()}
+		for _, ce := range r.GetContainerErrors() {
+			if ce == nil {
+				continue
+			}
+			ts := ""
+			if ce.GetTimestamp() != nil {
+				ts = ce.GetTimestamp().AsTime().UTC().Format(time.RFC3339)
+			}
+			re.Errors = append(re.Errors, ContainerErrorDTO{
+				Container: ce.GetContainer(),
+				Timestamp: ts,
+				Code:      ce.GetCode(),
+				Message:   ce.GetMessage(),
+				Details:   ce.GetDetails(),
+			})
+		}
+		out = append(out, re)
+	}
+	return out
+}

--- a/server/apis/v1/response_k8s_events.go
+++ b/server/apis/v1/response_k8s_events.go
@@ -21,20 +21,32 @@ import "fmt"
 type K8sEventsResponse struct {
 	TimeStamp int64  `json:"timestamp"`
 	Type      string `json:"type"`
-	// Object is in the format of "kind/name", e.g. "Pipeline/simple-pipeline"
-	Object  string `json:"object"`
-	Reason  string `json:"reason"`
-	Message string `json:"message"`
+	// Object is in the format of "kind/name", e.g. "Pipeline/simple-pipeline".
+	// Retained for existing UI callers; prefer InvolvedObjectKind/Name for parsing.
+	Object string `json:"object"`
+	// InvolvedObjectKind and InvolvedObjectName are the split form of Object.
+	InvolvedObjectKind string `json:"involvedObjectKind"`
+	InvolvedObjectName string `json:"involvedObjectName"`
+	Reason             string `json:"reason"`
+	Message            string `json:"message"`
+	// Count is how many times this event has occurred.
+	Count int32 `json:"count"`
 }
 
 // NewK8sEventsResponse creates a new K8sEventsResponse object with the given inputs.
-func NewK8sEventsResponse(timestamp int64, eventType, objectKind, objectName, reason, message string) K8sEventsResponse {
-
+func NewK8sEventsResponse(timestamp int64, eventType, objectKind, objectName, reason, message string, count ...int32) K8sEventsResponse {
+	var eventCount int32
+	if len(count) > 0 {
+		eventCount = count[0]
+	}
 	return K8sEventsResponse{
-		TimeStamp: timestamp,
-		Type:      eventType,
-		Object:    fmt.Sprintf("%s/%s", objectKind, objectName),
-		Reason:    reason,
-		Message:   message,
+		TimeStamp:          timestamp,
+		Type:               eventType,
+		Object:             fmt.Sprintf("%s/%s", objectKind, objectName),
+		InvolvedObjectKind: objectKind,
+		InvolvedObjectName: objectName,
+		Reason:             reason,
+		Message:            message,
+		Count:              eventCount,
 	}
 }

--- a/server/apis/v1/response_pod.go
+++ b/server/apis/v1/response_pod.go
@@ -8,6 +8,10 @@ type PodDetails struct {
 	ContainerDetailsMap map[string]ContainerDetails `json:"containerDetailsMap"`
 	TotalCPU            string                      `json:"totalCPU"`
 	TotalMemory         string                      `json:"totalMemory"`
+	// Node is the name of the node the pod is scheduled on.
+	Node string `json:"node,omitempty"`
+	// CreatedAt is the pod's creation time (RFC3339), useful for age.
+	CreatedAt string `json:"createdAt,omitempty"`
 }
 
 type ContainerDetails struct {
@@ -27,4 +31,8 @@ type ContainerDetails struct {
 	RequestedMemory         string `json:"requestedMemory"`
 	LimitCPU                string `json:"limitCPU"`
 	LimitMemory             string `json:"limitMemory"`
+	// Image is the container image.
+	Image string `json:"image,omitempty"`
+	// Ready reflects the container's readiness.
+	Ready bool `json:"ready"`
 }

--- a/server/cmd/server/start.go
+++ b/server/cmd/server/start.go
@@ -213,5 +213,32 @@ func CreateAuthRouteMap(baseHref string) authz.RouteMap {
 		"GET:" + baseHref + "api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/errors":              authz.NewRouteInfo(authz.ObjectMonoVertex, true),
 		"POST:" + baseHref + "api/v1/metrics-proxy":                                                       authz.NewRouteInfo(authz.ObjectAll, true),
 		"GET:" + baseHref + "api/v1/metrics-discovery/object/:object":                                     authz.NewRouteInfo(authz.ObjectAll, true),
+		// Single-purpose endpoints returning typed DTOs.
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/metrics":        authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/pending":        authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/pending":                  authz.NewRouteInfo(authz.ObjectMonoVertex, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/buffers/:buffer":                 authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/buffers/:buffer/pending":         authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/data-health":                     authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/data-health":              authz.NewRouteInfo(authz.ObjectMonoVertex, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/watermark-lag":                   authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/status":                          authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/status":         authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/status":                   authz.NewRouteInfo(authz.ObjectMonoVertex, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/logs":           authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/logs":                     authz.NewRouteInfo(authz.ObjectMonoVertex, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/runtime-errors": authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/runtime-errors":           authz.NewRouteInfo(authz.ObjectMonoVertex, true),
+		// Discovery, correlation, and typed-wrapper endpoints. Scoped events use
+		// the resource object (pipeline/mono-vertex), not ObjectEvents, since each
+		// route is tied to a specific resource.
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/topology":                authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/debug-snapshot":          authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/buffers":                 authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/edge-watermarks":         authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/throughput":       authz.NewRouteInfo(authz.ObjectMonoVertex, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/events":                  authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/events": authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/events":           authz.NewRouteInfo(authz.ObjectMonoVertex, true),
 	}
 }

--- a/server/cmd/server/start.go
+++ b/server/cmd/server/start.go
@@ -234,6 +234,7 @@ func CreateAuthRouteMap(baseHref string) authz.RouteMap {
 		// route is tied to a specific resource.
 		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/topology":                authz.NewRouteInfo(authz.ObjectPipeline, true),
 		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/debug-snapshot":          authz.NewRouteInfo(authz.ObjectPipeline, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/debug-snapshot":   authz.NewRouteInfo(authz.ObjectMonoVertex, true),
 		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/buffers":                 authz.NewRouteInfo(authz.ObjectPipeline, true),
 		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/edge-watermarks":         authz.NewRouteInfo(authz.ObjectPipeline, true),
 		"GET:" + baseHref + "api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/throughput":       authz.NewRouteInfo(authz.ObjectMonoVertex, true),

--- a/server/cmd/server/start_test.go
+++ b/server/cmd/server/start_test.go
@@ -25,12 +25,26 @@ import (
 func TestCreateAuthRouteMap(t *testing.T) {
 	t.Run("empty base", func(t *testing.T) {
 		got := CreateAuthRouteMap("")
-		assert.Equal(t, 36, len(got))
+		assert.Equal(t, 59, len(got))
+		// Assert the new discovery/correlation route keys exist (catches path typos
+		// that a count-only check would miss).
+		for _, key := range []string{
+			"GET:api/v1/namespaces/:namespace/pipelines/:pipeline/topology",
+			"GET:api/v1/namespaces/:namespace/pipelines/:pipeline/debug-snapshot",
+			"GET:api/v1/namespaces/:namespace/pipelines/:pipeline/buffers",
+			"GET:api/v1/namespaces/:namespace/pipelines/:pipeline/edge-watermarks",
+			"GET:api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/throughput",
+			"GET:api/v1/namespaces/:namespace/pipelines/:pipeline/events",
+			"GET:api/v1/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/events",
+			"GET:api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/events",
+		} {
+			assert.Contains(t, got, key)
+		}
 	})
 
 	t.Run("customize base", func(t *testing.T) {
 		got := CreateAuthRouteMap("abcdefg")
-		assert.Equal(t, 36, len(got))
+		assert.Equal(t, 59, len(got))
 		for k := range got {
 			assert.Contains(t, k, "abcdefg")
 		}

--- a/server/cmd/server/start_test.go
+++ b/server/cmd/server/start_test.go
@@ -25,12 +25,13 @@ import (
 func TestCreateAuthRouteMap(t *testing.T) {
 	t.Run("empty base", func(t *testing.T) {
 		got := CreateAuthRouteMap("")
-		assert.Equal(t, 59, len(got))
+		assert.Equal(t, 60, len(got))
 		// Assert the new discovery/correlation route keys exist (catches path typos
 		// that a count-only check would miss).
 		for _, key := range []string{
 			"GET:api/v1/namespaces/:namespace/pipelines/:pipeline/topology",
 			"GET:api/v1/namespaces/:namespace/pipelines/:pipeline/debug-snapshot",
+			"GET:api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/debug-snapshot",
 			"GET:api/v1/namespaces/:namespace/pipelines/:pipeline/buffers",
 			"GET:api/v1/namespaces/:namespace/pipelines/:pipeline/edge-watermarks",
 			"GET:api/v1/namespaces/:namespace/mono-vertices/:mono-vertex/throughput",
@@ -44,7 +45,7 @@ func TestCreateAuthRouteMap(t *testing.T) {
 
 	t.Run("customize base", func(t *testing.T) {
 		got := CreateAuthRouteMap("abcdefg")
-		assert.Equal(t, 59, len(got))
+		assert.Equal(t, 60, len(got))
 		for k := range got {
 			assert.Contains(t, k, "abcdefg")
 		}

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -224,6 +224,8 @@ func v1Routes(ctx context.Context, r gin.IRouter, dexObj *v1.DexObject, localUse
 	r.GET("/namespaces/:namespace/pipelines/:pipeline/topology", handler.GetPipelineTopology)
 	// Get a bounded debug snapshot correlating a pipeline's current state.
 	r.GET("/namespaces/:namespace/pipelines/:pipeline/debug-snapshot", handler.GetPipelineDebugSnapshot)
+	// Get a bounded debug snapshot correlating a mono vertex's current state.
+	r.GET("/namespaces/:namespace/mono-vertices/:mono-vertex/debug-snapshot", handler.GetMonoVertexDebugSnapshot)
 	// Get all inter-step buffers of a pipeline as typed DTOs.
 	r.GET("/namespaces/:namespace/pipelines/:pipeline/buffers", handler.GetPipelineBuffers)
 	// Get the per-edge watermarks of a pipeline as typed DTOs.

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -186,4 +186,54 @@ func v1Routes(ctx context.Context, r gin.IRouter, dexObj *v1.DexObject, localUse
 	r.POST("/metrics-proxy", handler.GetMetricData)
 	// Discover the metrics for a given object type.
 	r.GET("/metrics-discovery/object/:object", handler.DiscoverMetrics)
+
+	// Single-purpose endpoints returning typed DTOs.
+	// Get the metrics for a single named vertex of a pipeline.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/metrics", handler.GetVertexMetrics)
+	// Get the pending counts for a single named vertex of a pipeline.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/pending", handler.GetVertexPending)
+	// Get the pending counts for a mono vertex.
+	r.GET("/namespaces/:namespace/mono-vertices/:mono-vertex/pending", handler.GetMonoVertexPending)
+	// Get the metrics for a single inter-step buffer of a pipeline.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/buffers/:buffer", handler.GetPipelineBufferInfo)
+	// Get the pending counts for a single inter-step buffer of a pipeline.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/buffers/:buffer/pending", handler.GetPipelineBufferPending)
+	// Get the data-plane (criticality) health of a pipeline.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/data-health", handler.GetPipelineDataHealth)
+	// Get the data-plane (criticality) health of a mono vertex.
+	r.GET("/namespaces/:namespace/mono-vertices/:mono-vertex/data-health", handler.GetMonoVertexDataHealth)
+	// Get the watermark lag of a pipeline.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/watermark-lag", handler.GetPipelineWatermarkLag)
+	// Get the status subresource of a pipeline (no spec).
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/status", handler.GetPipelineStatusInfo)
+	// Get the status subresource of a single vertex (no spec).
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/status", handler.GetVertexStatus)
+	// Get the status subresource of a mono vertex (no spec).
+	r.GET("/namespaces/:namespace/mono-vertices/:mono-vertex/status", handler.GetMonoVertexStatusInfo)
+	// Get the logs of a pipeline vertex by container, merged across replicas.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/logs", handler.GetVertexLogs)
+	// Get the logs of a mono vertex by container, merged across replicas.
+	r.GET("/namespaces/:namespace/mono-vertices/:mono-vertex/logs", handler.GetMonoVertexLogs)
+	// Get the runtime errors of a pipeline vertex.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/runtime-errors", handler.GetVertexRuntimeErrors)
+	// Get the runtime errors of a mono vertex.
+	r.GET("/namespaces/:namespace/mono-vertices/:mono-vertex/runtime-errors", handler.GetMonoVertexRuntimeErrors)
+
+	// Discovery, correlation, and typed-wrapper endpoints.
+	// Get the topology (graph) of a pipeline.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/topology", handler.GetPipelineTopology)
+	// Get a bounded debug snapshot correlating a pipeline's current state.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/debug-snapshot", handler.GetPipelineDebugSnapshot)
+	// Get all inter-step buffers of a pipeline as typed DTOs.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/buffers", handler.GetPipelineBuffers)
+	// Get the per-edge watermarks of a pipeline as typed DTOs.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/edge-watermarks", handler.GetPipelineEdgeWatermarks)
+	// Get the throughput metrics (rates + pending) of a mono vertex as a typed DTO.
+	r.GET("/namespaces/:namespace/mono-vertices/:mono-vertex/throughput", handler.GetMonoVertexThroughputMetrics)
+	// Get Kubernetes events scoped to a pipeline.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/events", handler.GetPipelineEvents)
+	// Get Kubernetes events scoped to a pipeline vertex.
+	r.GET("/namespaces/:namespace/pipelines/:pipeline/vertices/:vertex/events", handler.GetVertexEvents)
+	// Get Kubernetes events scoped to a mono vertex.
+	r.GET("/namespaces/:namespace/mono-vertices/:mono-vertex/events", handler.GetMonoVertexEvents)
 }


### PR DESCRIPTION
### Summary

This PR adds MCP/agent-friendly diagnostic APIs for Numaflow pipelines and mono-vertices. The goal is to expose small, typed, read-only responses that LLMs, automation tools can query directly.

### Why

The existing server APIs are useful for the UI, but many of them return raw daemon/Kubernetes shapes, large resource objects, making automated debugging harder because agents first need to discover topology, correlate health/metrics/errors/events across several APIs, and normalize response formats themselves.

### What Changed

Added single-purpose typed endpoints for diagnostics:

- Vertex metrics and pending counts.
- Pipeline buffer info and buffer pending counts.
- Pipeline and mono-vertex data health.
- Pipeline watermark lag.
- Pipeline, vertex, and mono-vertex status summaries.
- Vertex and mono-vertex logs.
- Vertex and mono-vertex runtime errors.
- Debug snapshots for both pipeline and monovertex
- Events and Discovery APIs

### Backward Compatibility

Existing UI/raw endpoints are preserved. New fields are additive.