### PR TITLE
fix: remove the trailing `&` from the Install k3d step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -248,7 +248,7 @@ jobs:
         with:
           name: entrypoint-linux-amd64
       - name: Install k3d
-        run: curl -sfL https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash &
+        run: curl -sfL https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
       - name: Create a cluster
         run: |
           k3d cluster create e2e


### PR DESCRIPTION
### Summary
Fixes the CI race in the E2E workflow by removing the background & from the Install k3d step. This ensures the workflow waits for k3d installation to complete before creating the test cluster.