### PR TITLE
fix: wait for deployments during e2e startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ start: image
 	kubectl apply -f test/manifests/numaflow-ns.yaml
 	kubectl -n numaflow-system delete cm numaflow-cmd-params-config --ignore-not-found=true
 	kubectl kustomize test/manifests | sed 's@quay.io/numaproj/@$(IMAGE_NAMESPACE)/@' | sed 's/:$(BASE_VERSION)/:$(VERSION)/' | kubectl -n numaflow-system apply -l app.kubernetes.io/part-of=numaflow --prune=false --force -f -
-	kubectl -n numaflow-system wait -lapp.kubernetes.io/part-of=numaflow --for=condition=Ready --timeout 60s pod --all
+	kubectl -n numaflow-system wait deployment -lapp.kubernetes.io/part-of=numaflow --for=condition=Available --timeout 60s
 
 .PHONY: e2eapi-image
 e2eapi-image: clean dist/e2eapi


### PR DESCRIPTION
## Summary

This fixes a CI race in the e2e setup where `make start` waited for Numaflow pods to be `Ready` immediately after applying the manifests. In some runs, the deployments had been created but no matching pods existed yet, causing `kubectl wait` to fail with `no matching resources found`.

The startup flow now waits for Numaflow deployments to become `Available`, which is tied to the resources created by the install step and avoids the empty pod-list race.

Eg of failed runs: https://github.com/numaproj/numaflow/actions/runs/27187287242/job/80260735600?pr=3464 
https://github.com/numaproj/numaflow/actions/runs/27140727178/job/80243027174
https://github.com/numaproj/numaflow/actions/runs/27140727178/job/80243027170 