### PR TITLE
feat(UI): jetstream summary & raft details

### DIFF
--- a/server/apis/v1/handler.go
+++ b/server/apis/v1/handler.go
@@ -101,8 +101,9 @@ type handler struct {
 	dexObj                *DexObject
 	localUsersAuthObject  *LocalUsersAuthObject
 	healthChecker         *HealthChecker
-	httpClient            *http.Client
-	opts                  *handlerOptions
+	// httpClient is used for direct calls to pod-local monitor endpoints.
+	httpClient *http.Client
+	opts       *handlerOptions
 }
 
 // NewHandler is used to provide a new instance of the handler type

--- a/server/apis/v1/handler.go
+++ b/server/apis/v1/handler.go
@@ -101,6 +101,7 @@ type handler struct {
 	dexObj                *DexObject
 	localUsersAuthObject  *LocalUsersAuthObject
 	healthChecker         *HealthChecker
+	httpClient            *http.Client
 	opts                  *handlerOptions
 }
 
@@ -143,6 +144,7 @@ func NewHandler(ctx context.Context, dexObj *DexObject, localUsersAuthObject *Lo
 		dexObj:                dexObj,
 		localUsersAuthObject:  localUsersAuthObject,
 		healthChecker:         NewHealthChecker(ctx),
+		httpClient:            &http.Client{Timeout: 5 * time.Second},
 		opts:                  o,
 	}, nil
 }

--- a/server/apis/v1/jetstream_monitor.go
+++ b/server/apis/v1/jetstream_monitor.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -52,7 +54,7 @@ func (h *handler) GetISBServiceJetStream(c *gin.Context) {
 			continue
 		}
 		response.Summary = append(response.Summary, newJetStreamSummaryDTO(pod.Name, jsInfo))
-		response.RaftMetaGroup = append(response.RaftMetaGroup, newJetStreamRaftMetaDTOs(jsInfo)...)
+		response.RaftMetaGroup = append(response.RaftMetaGroup, newJetStreamRaftMetaDTOs(pod.Name, jsInfo)...)
 	}
 	if len(response.Summary) == 0 && len(response.Errors) > 0 {
 		message := fmt.Sprintf("Failed to fetch JetStream monitor data for interstepbuffer service %q namespace %q", isbsvcName, ns)
@@ -116,7 +118,8 @@ func (h *handler) fetchJetStreamInfo(ctx context.Context, pod corev1.Pod) (*nats
 	if client == nil {
 		client = &http.Client{Timeout: 5 * time.Second}
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s:%d/jsz?accounts=true&streams=true&consumers=true&config=true", pod.Status.PodIP, jetStreamMonitorPort), nil)
+	hostPort := net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(jetStreamMonitorPort))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s/jsz?accounts=true&streams=true&consumers=true&config=true", hostPort), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +127,9 @@ func (h *handler) fetchJetStreamInfo(ctx context.Context, pod corev1.Pod) (*nats
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("JetStream monitor returned status %d", resp.StatusCode)
 	}
@@ -163,10 +168,25 @@ func newJetStreamSummaryDTO(defaultServer string, jsInfo *natsserver.JSInfo) Jet
 }
 
 // newJetStreamRaftMetaDTOs converts NATS meta cluster peer information into RAFT debug rows.
-func newJetStreamRaftMetaDTOs(jsInfo *natsserver.JSInfo) []JetStreamRaftMetaDTO {
+func newJetStreamRaftMetaDTOs(defaultServer string, jsInfo *natsserver.JSInfo) []JetStreamRaftMetaDTO {
 	if jsInfo.Meta == nil {
 		return nil
 	}
+	if len(jsInfo.Meta.Replicas) == 0 {
+		id := jsInfo.ID
+		if id == "" {
+			id = jsInfo.Meta.Peer
+		}
+		return []JetStreamRaftMetaDTO{
+			{
+				Name:   defaultServer,
+				ID:     id,
+				Leader: jsInfo.Meta.Leader == defaultServer || jsInfo.Meta.Leader == jsInfo.ID,
+				Online: true,
+			},
+		}
+	}
+	current := true
 	raftMeta := make([]JetStreamRaftMetaDTO, 0, len(jsInfo.Meta.Replicas)+1)
 	seen := make(map[string]struct{})
 	if jsInfo.Meta.Leader != "" {
@@ -174,7 +194,7 @@ func newJetStreamRaftMetaDTOs(jsInfo *natsserver.JSInfo) []JetStreamRaftMetaDTO 
 			Name:    jsInfo.Meta.Leader,
 			ID:      jsInfo.Meta.Peer,
 			Leader:  true,
-			Current: true,
+			Current: &current,
 			Online:  true,
 		})
 		seen[jsInfo.Meta.Leader] = struct{}{}
@@ -192,14 +212,15 @@ func newJetStreamRaftMetaDTOs(jsInfo *natsserver.JSInfo) []JetStreamRaftMetaDTO 
 		if _, ok := seen[replica.Peer]; ok && replica.Peer != "" {
 			continue
 		}
+		lag := replica.Lag
 		raftMeta = append(raftMeta, JetStreamRaftMetaDTO{
 			Name:    replica.Name,
 			ID:      replica.Peer,
 			Leader:  replica.Name == jsInfo.Meta.Leader || replica.Peer == jsInfo.Meta.Peer,
-			Current: replica.Current,
+			Current: &replica.Current,
 			Online:  !replica.Offline,
 			Active:  replica.Active.String(),
-			Lag:     replica.Lag,
+			Lag:     &lag,
 		})
 	}
 	return raftMeta
@@ -208,20 +229,60 @@ func newJetStreamRaftMetaDTOs(jsInfo *natsserver.JSInfo) []JetStreamRaftMetaDTO 
 // dedupeJetStreamRaftMetaDTOs removes duplicate peers reported by multiple JetStream pods.
 func dedupeJetStreamRaftMetaDTOs(items []JetStreamRaftMetaDTO) []JetStreamRaftMetaDTO {
 	deduped := make([]JetStreamRaftMetaDTO, 0, len(items))
-	seen := make(map[string]struct{}, len(items))
+	seenIDs := make(map[string]int, len(items))
+	seenNames := make(map[string]int, len(items))
 	for _, item := range items {
-		key := item.ID
-		if key == "" {
-			key = item.Name
+		existingIndex := -1
+		if item.ID != "" {
+			if index, ok := seenIDs[item.ID]; ok {
+				existingIndex = index
+			}
 		}
-		if key == "" {
-			key = fmt.Sprintf("%t/%t/%t/%s/%d", item.Leader, item.Current, item.Online, item.Active, item.Lag)
+		if existingIndex == -1 && item.Name != "" {
+			if index, ok := seenNames[item.Name]; ok {
+				existingIndex = index
+			}
 		}
-		if _, ok := seen[key]; ok {
+		if existingIndex != -1 {
+			if isRicherJetStreamRaftMetaDTO(item, deduped[existingIndex]) {
+				deduped[existingIndex] = item
+				if item.ID != "" {
+					seenIDs[item.ID] = existingIndex
+				}
+				if item.Name != "" {
+					seenNames[item.Name] = existingIndex
+				}
+			}
 			continue
 		}
-		seen[key] = struct{}{}
+		if item.ID != "" {
+			seenIDs[item.ID] = len(deduped)
+		}
+		if item.Name != "" {
+			seenNames[item.Name] = len(deduped)
+		}
 		deduped = append(deduped, item)
 	}
 	return deduped
+}
+
+func isRicherJetStreamRaftMetaDTO(candidate, existing JetStreamRaftMetaDTO) bool {
+	return jetStreamRaftMetaDTOScore(candidate) > jetStreamRaftMetaDTOScore(existing)
+}
+
+func jetStreamRaftMetaDTOScore(item JetStreamRaftMetaDTO) int {
+	score := 0
+	if item.ID != "" {
+		score++
+	}
+	if item.Current != nil {
+		score++
+	}
+	if item.Active != "" {
+		score++
+	}
+	if item.Lag != nil {
+		score++
+	}
+	return score
 }

--- a/server/apis/v1/jetstream_monitor.go
+++ b/server/apis/v1/jetstream_monitor.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2026 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+)
+
+const jetStreamMonitorPort = 8222
+
+func (h *handler) GetISBServiceJetStream(c *gin.Context) {
+	ns, isbsvcName := c.Param("namespace"), c.Param("isb-service")
+	_, pods, ok := h.getJetStreamISBMonitorPods(c, ns, isbsvcName)
+	if !ok {
+		return
+	}
+	response := ISBJetStreamDTO{
+		Summary:       []JetStreamSummaryDTO{},
+		RaftMetaGroup: []JetStreamRaftMetaDTO{},
+	}
+	for _, pod := range pods {
+		jsInfo, err := h.fetchJetStreamInfo(c.Request.Context(), pod)
+		if err != nil {
+			response.Errors = append(response.Errors, ISBMonitorErrorDTO{Pod: pod.Name, Message: err.Error()})
+			continue
+		}
+		response.Summary = append(response.Summary, newJetStreamSummaryDTO(pod.Name, jsInfo))
+		response.RaftMetaGroup = append(response.RaftMetaGroup, newJetStreamRaftMetaDTOs(jsInfo)...)
+	}
+	if len(response.Summary) == 0 && len(response.Errors) > 0 {
+		message := fmt.Sprintf("Failed to fetch JetStream monitor data for interstepbuffer service %q namespace %q", isbsvcName, ns)
+		c.JSON(http.StatusBadGateway, NewNumaflowAPIResponse(&message, nil))
+		return
+	}
+	response.RaftMetaGroup = dedupeJetStreamRaftMetaDTOs(response.RaftMetaGroup)
+	sort.Slice(response.Summary, func(i, j int) bool {
+		return response.Summary[i].Server < response.Summary[j].Server
+	})
+	sort.Slice(response.RaftMetaGroup, func(i, j int) bool {
+		if response.RaftMetaGroup[i].Name != response.RaftMetaGroup[j].Name {
+			return response.RaftMetaGroup[i].Name < response.RaftMetaGroup[j].Name
+		}
+		return response.RaftMetaGroup[i].ID < response.RaftMetaGroup[j].ID
+	})
+	c.JSON(http.StatusOK, NewNumaflowAPIResponse(nil, response))
+}
+
+func (h *handler) getJetStreamISBMonitorPods(c *gin.Context, ns, isbsvcName string) (*dfv1.InterStepBufferService, []corev1.Pod, bool) {
+	isbsvc, err := h.numaflowClient.InterStepBufferServices(ns).Get(c, isbsvcName, metav1.GetOptions{})
+	if err != nil {
+		message := fmt.Sprintf("Failed to fetch interstepbuffer service %q namespace %q, %s", isbsvcName, ns, err.Error())
+		c.JSON(http.StatusNotFound, NewNumaflowAPIResponse(&message, nil))
+		return nil, nil, false
+	}
+	if isbsvc.Spec.JetStream == nil {
+		message := fmt.Sprintf("Interstepbuffer service %q namespace %q is not JetStream backed", isbsvcName, ns)
+		c.JSON(http.StatusBadRequest, NewNumaflowAPIResponse(&message, nil))
+		return nil, nil, false
+	}
+	pods, err := h.kubeClient.CoreV1().Pods(ns).List(c, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s,%s=%s", dfv1.KeyComponent, dfv1.ComponentISBSvc, dfv1.KeyISBSvcName, isbsvcName),
+	})
+	if err != nil {
+		message := fmt.Sprintf("Failed to list JetStream pods for interstepbuffer service %q namespace %q, %s", isbsvcName, ns, err.Error())
+		c.JSON(http.StatusBadGateway, NewNumaflowAPIResponse(&message, nil))
+		return nil, nil, false
+	}
+	runningPods := make([]corev1.Pod, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
+			runningPods = append(runningPods, pod)
+		}
+	}
+	if len(runningPods) == 0 {
+		message := fmt.Sprintf("No running JetStream pods found for interstepbuffer service %q namespace %q", isbsvcName, ns)
+		c.JSON(http.StatusNotFound, NewNumaflowAPIResponse(&message, nil))
+		return nil, nil, false
+	}
+	sort.Slice(runningPods, func(i, j int) bool {
+		return runningPods[i].Name < runningPods[j].Name
+	})
+	return isbsvc, runningPods, true
+}
+
+func (h *handler) fetchJetStreamInfo(ctx context.Context, pod corev1.Pod) (*natsserver.JSInfo, error) {
+	client := h.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s:%d/jsz?accounts=true&streams=true&consumers=true&config=true", pod.Status.PodIP, jetStreamMonitorPort), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("JetStream monitor returned status %d", resp.StatusCode)
+	}
+	var jsInfo natsserver.JSInfo
+	if err = json.NewDecoder(resp.Body).Decode(&jsInfo); err != nil {
+		return nil, fmt.Errorf("failed to decode JetStream monitor response: %w", err)
+	}
+	return &jsInfo, nil
+}
+
+func newJetStreamSummaryDTO(defaultServer string, jsInfo *natsserver.JSInfo) JetStreamSummaryDTO {
+	clusterName := ""
+	metaLeader := false
+	if jsInfo.Meta != nil {
+		clusterName = jsInfo.Meta.Name
+		metaLeader = jsInfo.Meta.Leader == defaultServer || jsInfo.Meta.Peer == jsInfo.ID
+	}
+	apiErrorRate := 0.0
+	if jsInfo.API.Total > 0 {
+		apiErrorRate = float64(jsInfo.API.Errors) / float64(jsInfo.API.Total)
+	}
+	return JetStreamSummaryDTO{
+		Server:       defaultServer,
+		ServerID:     jsInfo.ID,
+		Cluster:      clusterName,
+		Streams:      jsInfo.Streams,
+		Consumers:    jsInfo.Consumers,
+		Messages:     jsInfo.Messages,
+		Bytes:        jsInfo.Bytes,
+		APIRequests:  jsInfo.API.Total,
+		APIErrors:    jsInfo.API.Errors,
+		APIErrorRate: apiErrorRate,
+		MetaLeader:   metaLeader,
+	}
+}
+
+func newJetStreamRaftMetaDTOs(jsInfo *natsserver.JSInfo) []JetStreamRaftMetaDTO {
+	if jsInfo.Meta == nil {
+		return nil
+	}
+	raftMeta := make([]JetStreamRaftMetaDTO, 0, len(jsInfo.Meta.Replicas)+1)
+	seen := make(map[string]struct{})
+	if jsInfo.Meta.Leader != "" {
+		raftMeta = append(raftMeta, JetStreamRaftMetaDTO{
+			Name:    jsInfo.Meta.Leader,
+			ID:      jsInfo.Meta.Peer,
+			Leader:  true,
+			Current: true,
+			Online:  true,
+		})
+		seen[jsInfo.Meta.Leader] = struct{}{}
+		if jsInfo.Meta.Peer != "" {
+			seen[jsInfo.Meta.Peer] = struct{}{}
+		}
+	}
+	for _, replica := range jsInfo.Meta.Replicas {
+		if replica == nil {
+			continue
+		}
+		if _, ok := seen[replica.Name]; ok {
+			continue
+		}
+		if _, ok := seen[replica.Peer]; ok && replica.Peer != "" {
+			continue
+		}
+		raftMeta = append(raftMeta, JetStreamRaftMetaDTO{
+			Name:    replica.Name,
+			ID:      replica.Peer,
+			Leader:  replica.Name == jsInfo.Meta.Leader || replica.Peer == jsInfo.Meta.Peer,
+			Current: replica.Current,
+			Online:  !replica.Offline,
+			Active:  replica.Active.String(),
+			Lag:     replica.Lag,
+		})
+	}
+	return raftMeta
+}
+
+func dedupeJetStreamRaftMetaDTOs(items []JetStreamRaftMetaDTO) []JetStreamRaftMetaDTO {
+	deduped := make([]JetStreamRaftMetaDTO, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		key := item.ID
+		if key == "" {
+			key = item.Name
+		}
+		if key == "" {
+			key = fmt.Sprintf("%t/%t/%t/%s/%d", item.Leader, item.Current, item.Online, item.Active, item.Lag)
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		deduped = append(deduped, item)
+	}
+	return deduped
+}

--- a/server/apis/v1/jetstream_monitor.go
+++ b/server/apis/v1/jetstream_monitor.go
@@ -34,6 +34,7 @@ import (
 
 const jetStreamMonitorPort = 8222
 
+// GetISBServiceJetStream returns JetStream monitor summary and RAFT meta group information for an ISB service.
 func (h *handler) GetISBServiceJetStream(c *gin.Context) {
 	ns, isbsvcName := c.Param("namespace"), c.Param("isb-service")
 	_, pods, ok := h.getJetStreamISBMonitorPods(c, ns, isbsvcName)
@@ -71,6 +72,7 @@ func (h *handler) GetISBServiceJetStream(c *gin.Context) {
 	c.JSON(http.StatusOK, NewNumaflowAPIResponse(nil, response))
 }
 
+// getJetStreamISBMonitorPods validates that the ISB service is JetStream backed and returns running pods with Pod IPs.
 func (h *handler) getJetStreamISBMonitorPods(c *gin.Context, ns, isbsvcName string) (*dfv1.InterStepBufferService, []corev1.Pod, bool) {
 	isbsvc, err := h.numaflowClient.InterStepBufferServices(ns).Get(c, isbsvcName, metav1.GetOptions{})
 	if err != nil {
@@ -108,6 +110,7 @@ func (h *handler) getJetStreamISBMonitorPods(c *gin.Context, ns, isbsvcName stri
 	return isbsvc, runningPods, true
 }
 
+// fetchJetStreamInfo queries the NATS monitor endpoint on a JetStream pod and decodes the /jsz response.
 func (h *handler) fetchJetStreamInfo(ctx context.Context, pod corev1.Pod) (*natsserver.JSInfo, error) {
 	client := h.httpClient
 	if client == nil {
@@ -132,6 +135,7 @@ func (h *handler) fetchJetStreamInfo(ctx context.Context, pod corev1.Pod) (*nats
 	return &jsInfo, nil
 }
 
+// newJetStreamSummaryDTO converts NATS JetStream monitor stats into the API summary payload.
 func newJetStreamSummaryDTO(defaultServer string, jsInfo *natsserver.JSInfo) JetStreamSummaryDTO {
 	clusterName := ""
 	metaLeader := false
@@ -158,6 +162,7 @@ func newJetStreamSummaryDTO(defaultServer string, jsInfo *natsserver.JSInfo) Jet
 	}
 }
 
+// newJetStreamRaftMetaDTOs converts NATS meta cluster peer information into RAFT debug rows.
 func newJetStreamRaftMetaDTOs(jsInfo *natsserver.JSInfo) []JetStreamRaftMetaDTO {
 	if jsInfo.Meta == nil {
 		return nil
@@ -200,6 +205,7 @@ func newJetStreamRaftMetaDTOs(jsInfo *natsserver.JSInfo) []JetStreamRaftMetaDTO 
 	return raftMeta
 }
 
+// dedupeJetStreamRaftMetaDTOs removes duplicate peers reported by multiple JetStream pods.
 func dedupeJetStreamRaftMetaDTOs(items []JetStreamRaftMetaDTO) []JetStreamRaftMetaDTO {
 	deduped := make([]JetStreamRaftMetaDTO, 0, len(items))
 	seen := make(map[string]struct{}, len(items))

--- a/server/apis/v1/jetstream_monitor_test.go
+++ b/server/apis/v1/jetstream_monitor_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -74,7 +75,8 @@ func TestGetISBServiceJetStream(t *testing.T) {
 	assert.Equal(t, "js-0", got.Data.RaftMetaGroup[0].Name)
 	assert.True(t, got.Data.RaftMetaGroup[0].Leader)
 	assert.Equal(t, "js-1", got.Data.RaftMetaGroup[1].Name)
-	assert.Equal(t, uint64(2), got.Data.RaftMetaGroup[1].Lag)
+	require.NotNil(t, got.Data.RaftMetaGroup[1].Lag)
+	assert.Equal(t, uint64(2), *got.Data.RaftMetaGroup[1].Lag)
 	require.Empty(t, got.Data.Errors)
 }
 
@@ -98,6 +100,42 @@ func TestGetISBServiceJetStreamPartialFailure(t *testing.T) {
 	require.Len(t, got.Data.RaftMetaGroup, 2)
 	require.Len(t, got.Data.Errors, 1)
 	assert.Equal(t, "js-1", got.Data.Errors[0].Pod)
+}
+
+func TestGetISBServiceJetStreamPartialLeaderFailureUsesFollowerRows(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newJetStreamMonitorTestHandler(t, map[string]any{
+		"10.0.0.1": errors.New("connection refused"),
+		"10.0.0.2": testJSInfoWithoutReplicas("server-b", "js-0"),
+		"10.0.0.3": testJSInfoWithoutReplicas("server-c", "js-0"),
+	}, []corev1.Pod{
+		testISBPod("js-0", "10.0.0.1"),
+		testISBPod("js-1", "10.0.0.2"),
+		testISBPod("js-2", "10.0.0.3"),
+	}, true)
+	c, w := newISBMonitorTestContext("/api/v1/namespaces/ns/isb-services/default/jetstream")
+
+	h.GetISBServiceJetStream(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var got struct {
+		Data ISBJetStreamDTO `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Len(t, got.Data.Summary, 2)
+	assert.Equal(t, "js-1", got.Data.Summary[0].Server)
+	assert.Equal(t, "js-2", got.Data.Summary[1].Server)
+	require.Len(t, got.Data.Errors, 1)
+	assert.Equal(t, "js-0", got.Data.Errors[0].Pod)
+	require.Len(t, got.Data.RaftMetaGroup, 2)
+	assert.Equal(t, "js-1", got.Data.RaftMetaGroup[0].Name)
+	assert.Equal(t, "server-b", got.Data.RaftMetaGroup[0].ID)
+	assert.False(t, got.Data.RaftMetaGroup[0].Leader)
+	assert.True(t, got.Data.RaftMetaGroup[0].Online)
+	assert.Nil(t, got.Data.RaftMetaGroup[0].Current)
+	assert.Nil(t, got.Data.RaftMetaGroup[0].Lag)
+	assert.Equal(t, "js-2", got.Data.RaftMetaGroup[1].Name)
+	assert.Equal(t, "server-c", got.Data.RaftMetaGroup[1].ID)
 }
 
 func TestGetISBServiceJetStreamAllPodsFail(t *testing.T) {
@@ -139,6 +177,50 @@ func TestGetISBServiceJetStreamNoRunningPods(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+func TestGetISBServiceJetStreamIPv6PodIP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newJetStreamMonitorTestHandler(t, map[string]any{
+		"fd00::5": testJSInfo("server-a", "js-0"),
+	}, []corev1.Pod{
+		testISBPod("js-0", "fd00::5"),
+	}, true)
+	c, w := newISBMonitorTestContext("/api/v1/namespaces/ns/isb-services/default/jetstream")
+
+	h.GetISBServiceJetStream(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestDedupeJetStreamRaftMetaDTOsPrefersRicherSameNameRow(t *testing.T) {
+	current := true
+	lag := uint64(0)
+	items := []JetStreamRaftMetaDTO{
+		{
+			Name:   "js-0",
+			ID:     "server-id-from-fallback",
+			Online: true,
+		},
+		{
+			Name:    "js-0",
+			ID:      "peer-id-from-leader",
+			Current: &current,
+			Online:  true,
+			Active:  "698.81ms",
+			Lag:     &lag,
+		},
+	}
+
+	got := dedupeJetStreamRaftMetaDTOs(items)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "peer-id-from-leader", got[0].ID)
+	require.NotNil(t, got[0].Current)
+	assert.True(t, *got[0].Current)
+	assert.Equal(t, "698.81ms", got[0].Active)
+	require.NotNil(t, got[0].Lag)
+	assert.Equal(t, uint64(0), *got[0].Lag)
+}
+
 func newJetStreamMonitorTestHandler(t *testing.T, responses map[string]any, pods []corev1.Pod, jetStream bool) *handler {
 	t.Helper()
 	isbsvc := &dfv1.InterStepBufferService{
@@ -168,7 +250,12 @@ func newJetStreamMonitorTestHandler(t *testing.T, responses map[string]any, pods
 				assert.Equal(t, "true", req.URL.Query().Get("accounts"))
 				assert.Equal(t, "true", req.URL.Query().Get("streams"))
 				assert.Equal(t, "true", req.URL.Query().Get("consumers"))
-				host := strings.Split(req.URL.Host, ":")[0]
+				host, port, err := net.SplitHostPort(req.URL.Host)
+				require.NoError(t, err)
+				assert.Equal(t, "8222", port)
+				if strings.Contains(host, ":") {
+					assert.Equal(t, "["+host+"]:"+port, req.URL.Host)
+				}
 				value, ok := responses[host]
 				if !ok {
 					return nil, errors.New("unexpected host")
@@ -238,4 +325,10 @@ func testJSInfo(serverID, leader string) natsserver.JSInfo {
 			},
 		},
 	}
+}
+
+func testJSInfoWithoutReplicas(serverID, leader string) natsserver.JSInfo {
+	jsInfo := testJSInfo(serverID, leader)
+	jsInfo.Meta.Replicas = nil
+	return jsInfo
 }

--- a/server/apis/v1/jetstream_monitor_test.go
+++ b/server/apis/v1/jetstream_monitor_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2026 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	numaflowfake "github.com/numaproj/numaflow/pkg/client/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestGetISBServiceJetStream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newJetStreamMonitorTestHandler(t, map[string]any{
+		"10.0.0.1": testJSInfo("server-a", "js-0"),
+		"10.0.0.2": testJSInfo("server-b", "js-0"),
+	}, nil, true)
+	c, w := newISBMonitorTestContext("/api/v1/namespaces/ns/isb-services/default/jetstream")
+
+	h.GetISBServiceJetStream(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var got struct {
+		Data ISBJetStreamDTO `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Len(t, got.Data.Summary, 2)
+	assert.Equal(t, "js-0", got.Data.Summary[0].Server)
+	assert.Equal(t, "js-1", got.Data.Summary[1].Server)
+	assert.Equal(t, "default", got.Data.Summary[0].Cluster)
+	assert.Equal(t, 2, got.Data.Summary[0].Streams)
+	assert.Equal(t, 3, got.Data.Summary[0].Consumers)
+	assert.Equal(t, uint64(10), got.Data.Summary[0].Messages)
+	assert.Equal(t, uint64(50), got.Data.Summary[0].Bytes)
+	assert.Equal(t, uint64(100), got.Data.Summary[0].APIRequests)
+	assert.Equal(t, uint64(5), got.Data.Summary[0].APIErrors)
+	assert.Equal(t, 0.05, got.Data.Summary[0].APIErrorRate)
+	require.Len(t, got.Data.RaftMetaGroup, 2)
+	assert.Equal(t, "js-0", got.Data.RaftMetaGroup[0].Name)
+	assert.True(t, got.Data.RaftMetaGroup[0].Leader)
+	assert.Equal(t, "js-1", got.Data.RaftMetaGroup[1].Name)
+	assert.Equal(t, uint64(2), got.Data.RaftMetaGroup[1].Lag)
+	require.Empty(t, got.Data.Errors)
+}
+
+func TestGetISBServiceJetStreamPartialFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newJetStreamMonitorTestHandler(t, map[string]any{
+		"10.0.0.1": testJSInfo("server-a", "js-0"),
+		"10.0.0.2": errors.New("connection refused"),
+	}, nil, true)
+	c, w := newISBMonitorTestContext("/api/v1/namespaces/ns/isb-services/default/jetstream")
+
+	h.GetISBServiceJetStream(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var got struct {
+		Data ISBJetStreamDTO `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Len(t, got.Data.Summary, 1)
+	assert.Equal(t, "js-0", got.Data.Summary[0].Server)
+	require.Len(t, got.Data.RaftMetaGroup, 2)
+	require.Len(t, got.Data.Errors, 1)
+	assert.Equal(t, "js-1", got.Data.Errors[0].Pod)
+}
+
+func TestGetISBServiceJetStreamAllPodsFail(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newJetStreamMonitorTestHandler(t, map[string]any{
+		"10.0.0.1": errors.New("connection refused"),
+		"10.0.0.2": errors.New("connection refused"),
+	}, nil, true)
+	c, w := newISBMonitorTestContext("/api/v1/namespaces/ns/isb-services/default/jetstream")
+
+	h.GetISBServiceJetStream(c)
+
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	var got NumaflowAPIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.NotNil(t, got.ErrMsg)
+	assert.Contains(t, *got.ErrMsg, "Failed to fetch JetStream monitor data")
+}
+
+func TestGetISBServiceJetStreamNonJetStreamISB(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newJetStreamMonitorTestHandler(t, nil, nil, false)
+	c, w := newISBMonitorTestContext("/api/v1/namespaces/ns/isb-services/default/jetstream")
+
+	h.GetISBServiceJetStream(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetISBServiceJetStreamNoRunningPods(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	pod := testISBPod("js-0", "")
+	pod.Status.Phase = corev1.PodPending
+	h := newJetStreamMonitorTestHandler(t, nil, []corev1.Pod{pod}, true)
+	c, w := newISBMonitorTestContext("/api/v1/namespaces/ns/isb-services/default/jetstream")
+
+	h.GetISBServiceJetStream(c)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func newJetStreamMonitorTestHandler(t *testing.T, responses map[string]any, pods []corev1.Pod, jetStream bool) *handler {
+	t.Helper()
+	isbsvc := &dfv1.InterStepBufferService{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"},
+		Spec:       dfv1.InterStepBufferServiceSpec{},
+	}
+	if jetStream {
+		isbsvc.Spec.JetStream = &dfv1.JetStreamBufferService{}
+	}
+	if pods == nil {
+		pods = []corev1.Pod{
+			testISBPod("js-0", "10.0.0.1"),
+			testISBPod("js-1", "10.0.0.2"),
+		}
+	}
+	kubeObjects := make([]runtime.Object, 0, len(pods))
+	for i := range pods {
+		kubeObjects = append(kubeObjects, &pods[i])
+	}
+	return &handler{
+		kubeClient:     kubefake.NewSimpleClientset(kubeObjects...),
+		numaflowClient: numaflowfake.NewSimpleClientset(isbsvc).NumaflowV1alpha1(),
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, "/jsz", req.URL.Path)
+				assert.Equal(t, "true", req.URL.Query().Get("config"))
+				assert.Equal(t, "true", req.URL.Query().Get("accounts"))
+				assert.Equal(t, "true", req.URL.Query().Get("streams"))
+				assert.Equal(t, "true", req.URL.Query().Get("consumers"))
+				host := strings.Split(req.URL.Host, ":")[0]
+				value, ok := responses[host]
+				if !ok {
+					return nil, errors.New("unexpected host")
+				}
+				if err, ok := value.(error); ok {
+					return nil, err
+				}
+				body, err := json.Marshal(value)
+				require.NoError(t, err)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(string(body))),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+}
+
+func newISBMonitorTestContext(path string) (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, path, nil)
+	c.Params = gin.Params{
+		{Key: "namespace", Value: "ns"},
+		{Key: "isb-service", Value: "default"},
+	}
+	return c, w
+}
+
+func testISBPod(name, ip string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "ns",
+			Labels: map[string]string{
+				dfv1.KeyComponent:  dfv1.ComponentISBSvc,
+				dfv1.KeyISBSvcName: "default",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: ip,
+		},
+	}
+}
+
+func testJSInfo(serverID, leader string) natsserver.JSInfo {
+	return natsserver.JSInfo{
+		JetStreamStats: natsserver.JetStreamStats{
+			API: natsserver.JetStreamAPIStats{
+				Total:  100,
+				Errors: 5,
+			},
+		},
+		ID:        serverID,
+		Streams:   2,
+		Consumers: 3,
+		Messages:  10,
+		Bytes:     50,
+		Meta: &natsserver.MetaClusterInfo{
+			Name:   "default",
+			Leader: leader,
+			Peer:   serverID,
+			Replicas: []*natsserver.PeerInfo{
+				{Name: "js-1", Peer: "server-b", Current: true, Active: time.Second, Lag: 2},
+			},
+		},
+	}
+}

--- a/server/apis/v1/response_isb_jetstream.go
+++ b/server/apis/v1/response_isb_jetstream.go
@@ -16,12 +16,14 @@ limitations under the License.
 
 package v1
 
+// ISBJetStreamDTO is the response payload for JetStream monitor data on an ISB service.
 type ISBJetStreamDTO struct {
 	Summary       []JetStreamSummaryDTO  `json:"summary"`
 	RaftMetaGroup []JetStreamRaftMetaDTO `json:"raftMetaGroup"`
 	Errors        []ISBMonitorErrorDTO   `json:"errors,omitempty"`
 }
 
+// JetStreamSummaryDTO contains per-server JetStream monitor summary metrics.
 type JetStreamSummaryDTO struct {
 	Server       string  `json:"server"`
 	ServerID     string  `json:"serverId,omitempty"`
@@ -36,6 +38,7 @@ type JetStreamSummaryDTO struct {
 	MetaLeader   bool    `json:"metaLeader"`
 }
 
+// JetStreamRaftMetaDTO contains RAFT meta group peer status for a JetStream cluster.
 type JetStreamRaftMetaDTO struct {
 	Name    string `json:"name"`
 	ID      string `json:"id,omitempty"`
@@ -46,6 +49,7 @@ type JetStreamRaftMetaDTO struct {
 	Lag     uint64 `json:"lag"`
 }
 
+// ISBMonitorErrorDTO captures a per-pod JetStream monitor collection error.
 type ISBMonitorErrorDTO struct {
 	Pod     string `json:"pod"`
 	Message string `json:"message"`

--- a/server/apis/v1/response_isb_jetstream.go
+++ b/server/apis/v1/response_isb_jetstream.go
@@ -40,13 +40,13 @@ type JetStreamSummaryDTO struct {
 
 // JetStreamRaftMetaDTO contains RAFT meta group peer status for a JetStream cluster.
 type JetStreamRaftMetaDTO struct {
-	Name    string `json:"name"`
-	ID      string `json:"id,omitempty"`
-	Leader  bool   `json:"leader"`
-	Current bool   `json:"current"`
-	Online  bool   `json:"online"`
-	Active  string `json:"active,omitempty"`
-	Lag     uint64 `json:"lag"`
+	Name    string  `json:"name"`
+	ID      string  `json:"id,omitempty"`
+	Leader  bool    `json:"leader"`
+	Current *bool   `json:"current,omitempty"`
+	Online  bool    `json:"online"`
+	Active  string  `json:"active,omitempty"`
+	Lag     *uint64 `json:"lag,omitempty"`
 }
 
 // ISBMonitorErrorDTO captures a per-pod JetStream monitor collection error.

--- a/server/apis/v1/response_isb_jetstream.go
+++ b/server/apis/v1/response_isb_jetstream.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+type ISBJetStreamDTO struct {
+	Summary       []JetStreamSummaryDTO  `json:"summary"`
+	RaftMetaGroup []JetStreamRaftMetaDTO `json:"raftMetaGroup"`
+	Errors        []ISBMonitorErrorDTO   `json:"errors,omitempty"`
+}
+
+type JetStreamSummaryDTO struct {
+	Server       string  `json:"server"`
+	ServerID     string  `json:"serverId,omitempty"`
+	Cluster      string  `json:"cluster,omitempty"`
+	Streams      int     `json:"streams"`
+	Consumers    int     `json:"consumers"`
+	Messages     uint64  `json:"messages"`
+	Bytes        uint64  `json:"bytes"`
+	APIRequests  uint64  `json:"apiRequests"`
+	APIErrors    uint64  `json:"apiErrors"`
+	APIErrorRate float64 `json:"apiErrorRate"`
+	MetaLeader   bool    `json:"metaLeader"`
+}
+
+type JetStreamRaftMetaDTO struct {
+	Name    string `json:"name"`
+	ID      string `json:"id,omitempty"`
+	Leader  bool   `json:"leader"`
+	Current bool   `json:"current"`
+	Online  bool   `json:"online"`
+	Active  string `json:"active,omitempty"`
+	Lag     uint64 `json:"lag"`
+}
+
+type ISBMonitorErrorDTO struct {
+	Pod     string `json:"pod"`
+	Message string `json:"message"`
+}

--- a/server/cmd/server/start.go
+++ b/server/cmd/server/start.go
@@ -191,6 +191,7 @@ func CreateAuthRouteMap(baseHref string) authz.RouteMap {
 		"POST:" + baseHref + "api/v1/namespaces/:namespace/isb-services":                                  authz.NewRouteInfo(authz.ObjectISBSvc, true),
 		"GET:" + baseHref + "api/v1/namespaces/:namespace/isb-services":                                   authz.NewRouteInfo(authz.ObjectISBSvc, true),
 		"GET:" + baseHref + "api/v1/namespaces/:namespace/isb-services/:isb-service":                      authz.NewRouteInfo(authz.ObjectISBSvc, true),
+		"GET:" + baseHref + "api/v1/namespaces/:namespace/isb-services/:isb-service/jetstream":            authz.NewRouteInfo(authz.ObjectISBSvc, true),
 		"PUT:" + baseHref + "api/v1/namespaces/:namespace/isb-services/:isb-service":                      authz.NewRouteInfo(authz.ObjectISBSvc, true),
 		"DELETE:" + baseHref + "api/v1/namespaces/:namespace/isb-services/:isb-service":                   authz.NewRouteInfo(authz.ObjectISBSvc, true),
 		"GET:" + baseHref + "api/v1/namespaces/:namespace/pipelines/:pipeline/isbs":                       authz.NewRouteInfo(authz.ObjectPipeline, true),

--- a/server/cmd/server/start_test.go
+++ b/server/cmd/server/start_test.go
@@ -25,12 +25,13 @@ import (
 func TestCreateAuthRouteMap(t *testing.T) {
 	t.Run("empty base", func(t *testing.T) {
 		got := CreateAuthRouteMap("")
-		assert.Equal(t, 36, len(got))
+		assert.Equal(t, 37, len(got))
+		assert.Contains(t, got, "GET:api/v1/namespaces/:namespace/isb-services/:isb-service/jetstream")
 	})
 
 	t.Run("customize base", func(t *testing.T) {
 		got := CreateAuthRouteMap("abcdefg")
-		assert.Equal(t, 36, len(got))
+		assert.Equal(t, 37, len(got))
 		for k := range got {
 			assert.Contains(t, k, "abcdefg")
 		}

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -140,6 +140,8 @@ func v1Routes(ctx context.Context, r gin.IRouter, dexObj *v1.DexObject, localUse
 	r.GET("/namespaces/:namespace/isb-services", handler.ListInterStepBufferServices)
 	// Get an InterStepBufferService object.
 	r.GET("/namespaces/:namespace/isb-services/:isb-service", handler.GetInterStepBufferService)
+	// Get JetStream monitor information for an InterStepBufferService object.
+	r.GET("/namespaces/:namespace/isb-services/:isb-service/jetstream", handler.GetISBServiceJetStream)
 	// Update an InterStepBufferService object.
 	r.PUT("/namespaces/:namespace/isb-services/:isb-service", handler.UpdateInterStepBufferService)
 	// Delete an InterStepBufferService object.

--- a/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.test.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.test.tsx
@@ -8,8 +8,14 @@ import {
 } from "@testing-library/react";
 import { ISBUpdate } from "./index";
 import fetch from "jest-fetch-mock";
+import { MemoryRouter, Route, Switch } from "react-router-dom";
 
 import "@testing-library/jest-dom";
+
+const renderISBUpdate = (component: React.ReactElement) =>
+  render(
+    <MemoryRouter initialEntries={["/isb-services"]}>{component}</MemoryRouter>
+  );
 
 // Mock SpecEditor
 jest.mock("../../../SpecEditor", () => {
@@ -65,7 +71,7 @@ describe("ISBUpdate", () => {
 
   it("renders title and spec editor", async () => {
     const mockSetModalOnClose = jest.fn();
-    render(
+    renderISBUpdate(
       <ISBUpdate
         initialYaml="test"
         namespaceId="test-namespace"
@@ -104,7 +110,7 @@ describe("ISBUpdate", () => {
   it("validation success", async () => {
     fetch.mockResponseOnce(JSON.stringify({ data: {} }));
     const mockSetModalOnClose = jest.fn();
-    render(
+    renderISBUpdate(
       <ISBUpdate
         initialYaml="test"
         namespaceId="test-namespace"
@@ -135,7 +141,7 @@ describe("ISBUpdate", () => {
   it("validation failure", async () => {
     fetch.mockResponseOnce(JSON.stringify({ errMsg: "failed" }));
     const mockSetModalOnClose = jest.fn();
-    render(
+    renderISBUpdate(
       <ISBUpdate
         initialYaml="test"
         namespaceId="test-namespace"
@@ -164,7 +170,7 @@ describe("ISBUpdate", () => {
   it("submit success", async () => {
     fetch.mockResponseOnce(JSON.stringify({ data: {} }));
     const mockUpdateComplete = jest.fn();
-    render(
+    renderISBUpdate(
       <ISBUpdate
         initialYaml="test"
         namespaceId="test-namespace"
@@ -198,7 +204,7 @@ describe("ISBUpdate", () => {
   it("submit failure", async () => {
     fetch.mockResponseOnce(JSON.stringify({ errMsg: "failed" }));
     const mockUpdateComplete = jest.fn();
-    render(
+    renderISBUpdate(
       <ISBUpdate
         initialYaml="test"
         namespaceId="test-namespace"
@@ -253,6 +259,18 @@ describe("ISBUpdate", () => {
               apiErrorRate: 0,
               metaLeader: false,
             },
+            {
+              server: "js-2",
+              cluster: "default",
+              streams: 0,
+              consumers: 0,
+              messages: 0,
+              bytes: 0,
+              apiRequests: 149687,
+              apiErrors: 4,
+              apiErrorRate: 0.0000267224,
+              metaLeader: false,
+            },
           ],
           raftMetaGroup: [
             {
@@ -263,6 +281,33 @@ describe("ISBUpdate", () => {
               online: true,
               active: "450.793757ms",
               lag: 0,
+            },
+            {
+              name: "js-1",
+              id: "server-b",
+              leader: false,
+              current: true,
+              online: true,
+              active: "1m30s",
+              lag: 2,
+            },
+            {
+              name: "js-2",
+              id: "server-c",
+              leader: false,
+              current: true,
+              online: true,
+              active: "1h2m3s",
+              lag: 3,
+            },
+            {
+              name: "js-3",
+              id: "server-d",
+              leader: false,
+              current: true,
+              online: true,
+              active: "1.005s",
+              lag: 4,
             },
           ],
         },
@@ -300,7 +345,7 @@ describe("ISBUpdate", () => {
       })
     );
 
-    render(
+    renderISBUpdate(
       <ISBUpdate
         initialYaml={{
           metadata: { name: "test-isb" },
@@ -329,13 +374,17 @@ describe("ISBUpdate", () => {
       expect(screen.getByText("JetStream Summary")).toBeInTheDocument();
       expect(screen.getByText("RAFT Meta Group Information")).toBeInTheDocument();
       expect(screen.getAllByText("js-0").length).toBeGreaterThan(0);
-      expect(screen.getByText("js-1")).toBeInTheDocument();
+      expect(screen.getAllByText("js-1").length).toBeGreaterThan(0);
       expect(screen.getByText("400,006")).toBeInTheDocument();
-      expect(screen.getByText("100,576")).toBeInTheDocument();
-      expect(screen.getByText("12 / 0.02%")).toBeInTheDocument();
-      expect(screen.getByText("12 / 0.01%")).toBeInTheDocument();
+      expect(screen.getByText("250,263")).toBeInTheDocument();
+      expect(screen.getByText("12 / 0.018%")).toBeInTheDocument();
+      expect(screen.getByText("4 / 0.003%")).toBeInTheDocument();
+      expect(screen.getByText("16 / 0.006%")).toBeInTheDocument();
       expect(screen.getByText("Last Active")).toBeInTheDocument();
       expect(screen.getByText("450.79ms")).toBeInTheDocument();
+      expect(screen.getByText("1m 30s")).toBeInTheDocument();
+      expect(screen.getByText("1h 2m 3s")).toBeInTheDocument();
+      expect(screen.getByText("1.01s")).toBeInTheDocument();
       expect(screen.queryByText("ID")).not.toBeInTheDocument();
       expect(screen.queryByText("server-a")).not.toBeInTheDocument();
       expect(
@@ -359,6 +408,40 @@ describe("ISBUpdate", () => {
       expect(fetch).toHaveBeenCalledTimes(2);
       expect(screen.getAllByText("300,000")).toHaveLength(2);
       expect(screen.getAllByText("1 / 0.10%")).toHaveLength(2);
+    });
+  });
+
+  it("redirects to login on JetStream debug 401", async () => {
+    fetch.mockResponseOnce("", { status: 401 });
+
+    render(
+      <MemoryRouter initialEntries={["/isb-services"]}>
+        <Switch>
+          <Route path="/login">
+            <div>Login Page</div>
+          </Route>
+          <Route path="/isb-services">
+            <ISBUpdate
+              initialYaml={{
+                metadata: { name: "test-isb" },
+                spec: { jetstream: {} },
+              }}
+              namespaceId="test-namespace"
+              isbId="test-isb"
+              viewType={0}
+              onUpdateComplete={jest.fn()}
+              setModalOnClose={jest.fn()}
+            />
+          </Route>
+        </Switch>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Login Page")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Error loading JetStream information: Response code: 401")
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.test.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.test.tsx
@@ -366,10 +366,6 @@ describe("ISBUpdate", () => {
       expect(screen.queryByText("KV Stores")).not.toBeInTheDocument();
     });
 
-    act(() => {
-      fireEvent.click(screen.getByText("JetStream"));
-    });
-
     await waitFor(() => {
       expect(screen.getByText("JetStream Summary")).toBeInTheDocument();
       expect(screen.getByText("RAFT Meta Group Information")).toBeInTheDocument();

--- a/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.test.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.test.tsx
@@ -261,6 +261,7 @@ describe("ISBUpdate", () => {
               leader: true,
               current: true,
               online: true,
+              active: "450.793757ms",
               lag: 0,
             },
           ],
@@ -291,6 +292,7 @@ describe("ISBUpdate", () => {
               leader: true,
               current: true,
               online: true,
+              active: "450.736306ms",
               lag: 0,
             },
           ],
@@ -330,8 +332,19 @@ describe("ISBUpdate", () => {
       expect(screen.getByText("js-1")).toBeInTheDocument();
       expect(screen.getByText("400,006")).toBeInTheDocument();
       expect(screen.getByText("100,576")).toBeInTheDocument();
-      expect(screen.getByText("12 / 0.018%")).toBeInTheDocument();
-      expect(screen.getByText("12 / 0.012%")).toBeInTheDocument();
+      expect(screen.getByText("12 / 0.02%")).toBeInTheDocument();
+      expect(screen.getByText("12 / 0.01%")).toBeInTheDocument();
+      expect(screen.getByText("Last Active")).toBeInTheDocument();
+      expect(screen.getByText("450.79ms")).toBeInTheDocument();
+      expect(screen.queryByText("ID")).not.toBeInTheDocument();
+      expect(screen.queryByText("server-a")).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("isb-debug-header-help-api-errors")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("isb-debug-header-help-current")
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("isb-debug-header-help-lag")).toBeInTheDocument();
       expect(screen.queryByText("Memory")).not.toBeInTheDocument();
       expect(screen.queryByText("File")).not.toBeInTheDocument();
       expect(screen.queryByText("Stream Information")).not.toBeInTheDocument();
@@ -345,7 +358,7 @@ describe("ISBUpdate", () => {
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledTimes(2);
       expect(screen.getAllByText("300,000")).toHaveLength(2);
-      expect(screen.getAllByText("1 / 0.100%")).toHaveLength(2);
+      expect(screen.getAllByText("1 / 0.10%")).toHaveLength(2);
     });
   });
 });

--- a/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.test.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.test.tsx
@@ -30,7 +30,7 @@ jest.mock("../../../SpecEditor", () => {
         <div data-testid="spec-editor-mock">
           <div>{JSON.stringify(props.validationMessage)}</div>
           <div>{JSON.stringify(props.statusIndicator)}</div>
-          <div>{props.initialYaml}</div>
+          <div>{JSON.stringify(props.initialYaml)}</div>
           <button
             data-testid="spec-editor-reset"
             onClick={props.onResetApplied}
@@ -221,6 +221,131 @@ describe("ISBUpdate", () => {
       expect(
         screen.getByText(`{"type":"error","message":"Error: failed"}`)
       ).toBeInTheDocument();
+    });
+  });
+
+  it("renders JetStream summary and RAFT debug information for read-only JetStream ISB", async () => {
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        data: {
+          summary: [
+            {
+              server: "js-0",
+              cluster: "default",
+              streams: 7,
+              consumers: 3,
+              messages: 200003,
+              bytes: 41523609,
+              apiRequests: 65431,
+              apiErrors: 12,
+              apiErrorRate: 0.00018,
+              metaLeader: true,
+            },
+            {
+              server: "js-1",
+              cluster: "default",
+              streams: 7,
+              consumers: 3,
+              messages: 200003,
+              bytes: 41523609,
+              apiRequests: 35145,
+              apiErrors: 0,
+              apiErrorRate: 0,
+              metaLeader: false,
+            },
+          ],
+          raftMetaGroup: [
+            {
+              name: "js-0",
+              id: "server-a",
+              leader: true,
+              current: true,
+              online: true,
+              lag: 0,
+            },
+          ],
+        },
+      })
+    );
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        data: {
+          summary: [
+            {
+              server: "js-0",
+              cluster: "default",
+              streams: 8,
+              consumers: 4,
+              messages: 300000,
+              bytes: 1048576,
+              apiRequests: 1000,
+              apiErrors: 1,
+              apiErrorRate: 0.001,
+              metaLeader: true,
+            },
+          ],
+          raftMetaGroup: [
+            {
+              name: "js-0",
+              id: "server-a",
+              leader: true,
+              current: true,
+              online: true,
+              lag: 0,
+            },
+          ],
+        },
+      })
+    );
+
+    render(
+      <ISBUpdate
+        initialYaml={{
+          metadata: { name: "test-isb" },
+          spec: { jetstream: {} },
+        }}
+        namespaceId="test-namespace"
+        isbId="test-isb"
+        viewType={0}
+        onUpdateComplete={jest.fn()}
+        setModalOnClose={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Spec")).toBeInTheDocument();
+      expect(screen.getByText("JetStream")).toBeInTheDocument();
+      expect(screen.getByText("Refresh")).toBeInTheDocument();
+      expect(screen.queryByText("KV Stores")).not.toBeInTheDocument();
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByText("JetStream"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("JetStream Summary")).toBeInTheDocument();
+      expect(screen.getByText("RAFT Meta Group Information")).toBeInTheDocument();
+      expect(screen.getAllByText("js-0").length).toBeGreaterThan(0);
+      expect(screen.getByText("js-1")).toBeInTheDocument();
+      expect(screen.getByText("400,006")).toBeInTheDocument();
+      expect(screen.getByText("100,576")).toBeInTheDocument();
+      expect(screen.getByText("12 / 0.018%")).toBeInTheDocument();
+      expect(screen.getByText("12 / 0.012%")).toBeInTheDocument();
+      expect(screen.queryByText("Memory")).not.toBeInTheDocument();
+      expect(screen.queryByText("File")).not.toBeInTheDocument();
+      expect(screen.queryByText("Stream Information")).not.toBeInTheDocument();
+      expect(screen.queryByText("Consumer Information")).not.toBeInTheDocument();
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByText("Refresh"));
+    });
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(screen.getAllByText("300,000")).toHaveLength(2);
+      expect(screen.getAllByText("1 / 0.100%")).toHaveLength(2);
     });
   });
 });

--- a/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.tsx
@@ -1,16 +1,27 @@
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import YAML from "yaml";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Tab from "@mui/material/Tab";
+import Tabs from "@mui/material/Tabs";
 import {
   SpecEditor,
   Status,
   StatusIndicator,
   ValidationMessage,
+  ViewType,
 } from "../../../SpecEditor";
+import TabPanel from "../../../Tab-Panel";
 import { SpecEditorSidebarProps } from "../..";
 import { AppContextProps } from "../../../../../types/declarations/app";
 import { AppContext } from "../../../../../App";
-import { getAPIResponseError, getBaseHref } from "../../../../../utils";
+import {
+  a11yProps,
+  getAPIResponseError,
+  getBaseHref,
+} from "../../../../../utils";
+import { useISBServiceDebugFetch } from "../../../../../utils/fetchWrappers/isbServiceDebugFetch";
+import { ISBDebugInfo } from "./partials/ISBDebugInfo";
 
 import "./style.css";
 
@@ -30,7 +41,15 @@ export function ISBUpdate({
     ValidationMessage | undefined
   >();
   const [status, setStatus] = useState<StatusIndicator | undefined>();
+  const [tabValue, setTabValue] = useState(0);
   const { host } = useContext<AppContextProps>(AppContext);
+  const showDebugTabs =
+    viewType === ViewType.READ_ONLY && !!initialYaml?.spec?.jetstream;
+  const debugFetch = useISBServiceDebugFetch({
+    namespaceId,
+    isbId,
+    enabled: showDebugTabs,
+  });
 
   // Submit API call
   useEffect(() => {
@@ -200,6 +219,24 @@ export function ISBUpdate({
     [setModalOnClose]
   );
 
+  const handleTabsChange = useCallback((_: any, newValue: any) => {
+    setTabValue(newValue);
+  }, []);
+
+  const specEditor = (
+    <SpecEditor
+      initialYaml={initialYaml}
+      viewType={viewType}
+      loading={loading}
+      onValidate={handleValidate}
+      onSubmit={handleSubmit}
+      onResetApplied={handleReset}
+      onMutatedChange={handleMutationChange}
+      statusIndicator={status}
+      validationMessage={validationMessage}
+    />
+  );
+
   return (
     <Box
       sx={{
@@ -219,17 +256,65 @@ export function ISBUpdate({
           {titleOverride ? titleOverride : `Edit ISB Service: ${isbId}`}
         </span>
       </Box>
-      <SpecEditor
-        initialYaml={initialYaml}
-        viewType={viewType}
-        loading={loading}
-        onValidate={handleValidate}
-        onSubmit={handleSubmit}
-        onResetApplied={handleReset}
-        onMutatedChange={handleMutationChange}
-        statusIndicator={status}
-        validationMessage={validationMessage}
-      />
+      {showDebugTabs ? (
+        <Box>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <Tabs
+              value={tabValue}
+              onChange={handleTabsChange}
+              aria-label="ISB service tabs"
+              sx={{
+                "& .MuiTab-root": {
+                  fontSize: "1.2rem",
+                  fontWeight: 600,
+                  minWidth: "12rem",
+                },
+              }}
+            >
+              <Tab label="Spec" {...a11yProps(0)} />
+              <Tab label="JetStream" {...a11yProps(1)} />
+            </Tabs>
+            <Button
+              variant="outlined"
+              size="medium"
+              onClick={debugFetch.refresh}
+              disabled={debugFetch.loading}
+              sx={{
+                fontSize: "1.2rem",
+                fontWeight: 600,
+                minWidth: "10rem",
+              }}
+            >
+              {debugFetch.loading ? "Refreshing..." : "Refresh"}
+            </Button>
+          </Box>
+          <TabPanel value={tabValue} index={0}>
+            <Box
+              sx={{
+                height: "calc(100vh - 20rem)",
+                minHeight: "45rem",
+              }}
+            >
+              {specEditor}
+            </Box>
+          </TabPanel>
+          <TabPanel value={tabValue} index={1}>
+            <ISBDebugInfo
+              jetStream={debugFetch.data?.jetStream}
+              loading={debugFetch.loading}
+              error={debugFetch.error}
+            />
+          </TabPanel>
+        </Box>
+      ) : (
+        specEditor
+      )}
     </Box>
   );
 }

--- a/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.tsx
@@ -41,7 +41,7 @@ export function ISBUpdate({
     ValidationMessage | undefined
   >();
   const [status, setStatus] = useState<StatusIndicator | undefined>();
-  const [tabValue, setTabValue] = useState(1);
+  const [tabValue, setTabValue] = useState(0);
   const { host } = useContext<AppContextProps>(AppContext);
   const showDebugTabs =
     viewType === ViewType.READ_ONLY && !!initialYaml?.spec?.jetstream;
@@ -277,8 +277,8 @@ export function ISBUpdate({
                 },
               }}
             >
-              <Tab label="Spec" {...a11yProps(0)} />
-              <Tab label="JetStream" {...a11yProps(1)} />
+              <Tab label="JetStream" {...a11yProps(0)} />
+              <Tab label="Spec" {...a11yProps(1)} />
             </Tabs>
             <Button
               variant="outlined"
@@ -295,6 +295,13 @@ export function ISBUpdate({
             </Button>
           </Box>
           <TabPanel value={tabValue} index={0}>
+            <ISBDebugInfo
+              jetStream={debugFetch.data?.jetStream}
+              loading={debugFetch.loading}
+              error={debugFetch.error}
+            />
+          </TabPanel>
+          <TabPanel value={tabValue} index={1}>
             <Box
               sx={{
                 height: "calc(100vh - 20rem)",
@@ -303,13 +310,6 @@ export function ISBUpdate({
             >
               {specEditor}
             </Box>
-          </TabPanel>
-          <TabPanel value={tabValue} index={1}>
-            <ISBDebugInfo
-              jetStream={debugFetch.data?.jetStream}
-              loading={debugFetch.loading}
-              error={debugFetch.error}
-            />
           </TabPanel>
         </Box>
       ) : (

--- a/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/index.tsx
@@ -41,7 +41,7 @@ export function ISBUpdate({
     ValidationMessage | undefined
   >();
   const [status, setStatus] = useState<StatusIndicator | undefined>();
-  const [tabValue, setTabValue] = useState(0);
+  const [tabValue, setTabValue] = useState(1);
   const { host } = useContext<AppContextProps>(AppContext);
   const showDebugTabs =
     viewType === ViewType.READ_ONLY && !!initialYaml?.spec?.jetstream;

--- a/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/partials/ISBDebugInfo/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/partials/ISBDebugInfo/index.tsx
@@ -62,7 +62,15 @@ const HeaderCell = ({
   tooltip?: string;
   testId?: string;
 }) => (
-  <TableCell>
+  <TableCell
+    sx={{
+      backgroundColor: "#F4F4F4",
+      borderBottom: "0.1rem solid #C6C6C6",
+      color: "#393939",
+      fontSize: "1.1rem",
+      fontWeight: 700,
+    }}
+  >
     <Box sx={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
       {label}
       {tooltip && (
@@ -243,8 +251,8 @@ export function ISBDebugInfo({ jetStream, loading, error }: ISBDebugInfoProps) {
             <Table stickyHeader>
               <TableHead>
                 <TableRow>
-                  <TableCell>Pod</TableCell>
-                  <TableCell>Error</TableCell>
+                  <HeaderCell label="Pod" />
+                  <HeaderCell label="Error" />
                 </TableRow>
               </TableHead>
               <TableBody>

--- a/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/partials/ISBDebugInfo/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/partials/ISBDebugInfo/index.tsx
@@ -1,0 +1,216 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import CircularProgress from "@mui/material/CircularProgress";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import { ISBJetStreamResponse } from "../../../../../../../types/declarations/pipeline";
+
+interface ISBDebugInfoProps {
+  jetStream?: ISBJetStreamResponse;
+  loading: boolean;
+  error?: any;
+}
+
+const formatNumber = (value?: number) => (value ?? 0).toLocaleString();
+
+const formatBytes = (value?: number) => {
+  const bytes = value ?? 0;
+  if (bytes === 0) {
+    return "0 B";
+  }
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  const index = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1
+  );
+  const scaled = bytes / Math.pow(1024, index);
+  return `${scaled.toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
+};
+
+const formatPercent = (value?: number) => `${((value ?? 0) * 100).toFixed(3)}%`;
+
+const formatApiErrors = (errors?: number, rate?: number) =>
+  `${formatNumber(errors)} / ${formatPercent(rate)}`;
+
+const DebugSection = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) => (
+  <Box sx={{ marginBottom: "2.4rem" }}>
+    <Box sx={{ fontSize: "1.4rem", fontWeight: 600, marginBottom: "1.2rem" }}>
+      {title}
+    </Box>
+    {children}
+  </Box>
+);
+
+export function ISBDebugInfo({ jetStream, loading, error }: ISBDebugInfoProps) {
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", padding: "2.4rem" }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Box>{`Error loading JetStream information: ${error}`}</Box>;
+  }
+
+  const summary = jetStream?.summary || [];
+  const total = summary.reduce(
+    (acc, item) => {
+      acc.streams += item.streams || 0;
+      acc.consumers += item.consumers || 0;
+      acc.messages += item.messages || 0;
+      acc.bytes += item.bytes || 0;
+      acc.apiRequests += item.apiRequests || 0;
+      acc.apiErrors += item.apiErrors || 0;
+      return acc;
+    },
+    {
+      streams: 0,
+      consumers: 0,
+      messages: 0,
+      bytes: 0,
+      apiRequests: 0,
+      apiErrors: 0,
+    }
+  );
+  const totalApiErrorRate =
+    total.apiRequests > 0 ? total.apiErrors / total.apiRequests : 0;
+
+  return (
+    <Box>
+      <DebugSection title="JetStream Summary">
+        <TableContainer sx={{ maxHeight: "60rem", backgroundColor: "#FFF" }}>
+          <Table stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell>Server</TableCell>
+                <TableCell>Cluster</TableCell>
+                <TableCell>Streams</TableCell>
+                <TableCell>Consumers</TableCell>
+                <TableCell>Messages</TableCell>
+                <TableCell>Bytes</TableCell>
+                <TableCell>API Req</TableCell>
+                <TableCell>API Err</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {!summary.length && (
+                <TableRow>
+                  <TableCell colSpan={8}>No information found</TableCell>
+                </TableRow>
+              )}
+              {summary.map((item) => (
+                <TableRow key={item.server}>
+                  <TableCell>{item.server}</TableCell>
+                  <TableCell>{item.cluster || "-"}</TableCell>
+                  <TableCell>{formatNumber(item.streams)}</TableCell>
+                  <TableCell>{formatNumber(item.consumers)}</TableCell>
+                  <TableCell>{formatNumber(item.messages)}</TableCell>
+                  <TableCell>{formatBytes(item.bytes)}</TableCell>
+                  <TableCell>{formatNumber(item.apiRequests)}</TableCell>
+                  <TableCell>
+                    {formatApiErrors(item.apiErrors, item.apiErrorRate)}
+                  </TableCell>
+                </TableRow>
+              ))}
+              {!!summary.length && (
+                <TableRow>
+                  <TableCell sx={{ fontWeight: 600 }}>Total</TableCell>
+                  <TableCell>-</TableCell>
+                  <TableCell sx={{ fontWeight: 600 }}>
+                    {formatNumber(total.streams)}
+                  </TableCell>
+                  <TableCell sx={{ fontWeight: 600 }}>
+                    {formatNumber(total.consumers)}
+                  </TableCell>
+                  <TableCell sx={{ fontWeight: 600 }}>
+                    {formatNumber(total.messages)}
+                  </TableCell>
+                  <TableCell sx={{ fontWeight: 600 }}>
+                    {formatBytes(total.bytes)}
+                  </TableCell>
+                  <TableCell sx={{ fontWeight: 600 }}>
+                    {formatNumber(total.apiRequests)}
+                  </TableCell>
+                  <TableCell sx={{ fontWeight: 600 }}>
+                    {formatApiErrors(total.apiErrors, totalApiErrorRate)}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </DebugSection>
+
+      <DebugSection title="RAFT Meta Group Information">
+        <TableContainer sx={{ maxHeight: "60rem", backgroundColor: "#FFF" }}>
+          <Table stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>ID</TableCell>
+                <TableCell>Leader</TableCell>
+                <TableCell>Current</TableCell>
+                <TableCell>Online</TableCell>
+                <TableCell>Active</TableCell>
+                <TableCell>Lag</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {!(jetStream?.raftMetaGroup || []).length && (
+                <TableRow>
+                  <TableCell colSpan={7}>No information found</TableCell>
+                </TableRow>
+              )}
+              {(jetStream?.raftMetaGroup || []).map((item) => (
+                <TableRow key={`${item.name}-${item.id || ""}`}>
+                  <TableCell>{item.name}</TableCell>
+                  <TableCell>{item.id || "-"}</TableCell>
+                  <TableCell>{item.leader ? "Yes" : "No"}</TableCell>
+                  <TableCell>{item.current ? "Yes" : "No"}</TableCell>
+                  <TableCell>{item.online ? "Yes" : "No"}</TableCell>
+                  <TableCell>{item.active || "-"}</TableCell>
+                  <TableCell>{formatNumber(item.lag)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </DebugSection>
+
+      {!!jetStream?.errors?.length && (
+        <DebugSection title="Monitor Errors">
+          <TableContainer sx={{ maxHeight: "60rem", backgroundColor: "#FFF" }}>
+            <Table stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Pod</TableCell>
+                  <TableCell>Error</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {jetStream.errors.map((item) => (
+                  <TableRow key={`${item.pod}-${item.message}`}>
+                    <TableCell>{item.pod}</TableCell>
+                    <TableCell>{item.message}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </DebugSection>
+      )}
+    </Box>
+  );
+}

--- a/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/partials/ISBDebugInfo/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/partials/ISBDebugInfo/index.tsx
@@ -8,6 +8,7 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import { ISBJetStreamResponse } from "../../../../../../../types/declarations/pipeline";
+import { Help } from "../../../../../Help";
 
 interface ISBDebugInfoProps {
   jetStream?: ISBJetStreamResponse;
@@ -16,6 +17,8 @@ interface ISBDebugInfoProps {
 }
 
 const formatNumber = (value?: number) => (value ?? 0).toLocaleString();
+
+const formatDecimal = (value: number) => value.toFixed(2);
 
 const formatBytes = (value?: number) => {
   const bytes = value ?? 0;
@@ -28,13 +31,48 @@ const formatBytes = (value?: number) => {
     units.length - 1
   );
   const scaled = bytes / Math.pow(1024, index);
-  return `${scaled.toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
+  return `${index === 0 ? formatNumber(scaled) : formatDecimal(scaled)} ${
+    units[index]
+  }`;
 };
 
-const formatPercent = (value?: number) => `${((value ?? 0) * 100).toFixed(3)}%`;
+const formatPercent = (value?: number) =>
+  `${formatDecimal((value ?? 0) * 100)}%`;
 
 const formatApiErrors = (errors?: number, rate?: number) =>
   `${formatNumber(errors)} / ${formatPercent(rate)}`;
+
+const formatDuration = (value?: string) => {
+  if (!value) {
+    return "-";
+  }
+  const match = value.match(/^(-?\d+(?:\.\d+)?)([a-zµμ]+)$/i);
+  if (!match) {
+    return value;
+  }
+  return `${formatDecimal(Number(match[1]))}${match[2]}`;
+};
+
+const HeaderCell = ({
+  label,
+  tooltip,
+  testId,
+}: {
+  label: string;
+  tooltip?: string;
+  testId?: string;
+}) => (
+  <TableCell>
+    <Box sx={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+      {label}
+      {tooltip && (
+        <Box data-testid={testId}>
+          <Help tooltip={tooltip} />
+        </Box>
+      )}
+    </Box>
+  </TableCell>
+);
 
 const DebugSection = ({
   title,
@@ -94,14 +132,18 @@ export function ISBDebugInfo({ jetStream, loading, error }: ISBDebugInfoProps) {
           <Table stickyHeader>
             <TableHead>
               <TableRow>
-                <TableCell>Server</TableCell>
-                <TableCell>Cluster</TableCell>
-                <TableCell>Streams</TableCell>
-                <TableCell>Consumers</TableCell>
-                <TableCell>Messages</TableCell>
-                <TableCell>Bytes</TableCell>
-                <TableCell>API Req</TableCell>
-                <TableCell>API Err</TableCell>
+                <HeaderCell label="Server" />
+                <HeaderCell label="Cluster" />
+                <HeaderCell label="Streams" />
+                <HeaderCell label="Consumers" />
+                <HeaderCell label="Messages" />
+                <HeaderCell label="Bytes" />
+                <HeaderCell label="API Requests" />
+                <HeaderCell
+                  label="API Errors"
+                  tooltip="API error count / API error rate."
+                  testId="isb-debug-header-help-api-errors"
+                />
               </TableRow>
             </TableHead>
             <TableBody>
@@ -158,29 +200,35 @@ export function ISBDebugInfo({ jetStream, loading, error }: ISBDebugInfoProps) {
           <Table stickyHeader>
             <TableHead>
               <TableRow>
-                <TableCell>Name</TableCell>
-                <TableCell>ID</TableCell>
-                <TableCell>Leader</TableCell>
-                <TableCell>Current</TableCell>
-                <TableCell>Online</TableCell>
-                <TableCell>Active</TableCell>
-                <TableCell>Lag</TableCell>
+                <HeaderCell label="Name" />
+                <HeaderCell label="Leader" />
+                <HeaderCell
+                  label="Current"
+                  tooltip="Whether this peer is caught up with the RAFT meta group leader."
+                  testId="isb-debug-header-help-current"
+                />
+                <HeaderCell label="Online" />
+                <HeaderCell label="Last Active" />
+                <HeaderCell
+                  label="Lag"
+                  tooltip="Number of RAFT log entries this peer is behind the leader."
+                  testId="isb-debug-header-help-lag"
+                />
               </TableRow>
             </TableHead>
             <TableBody>
               {!(jetStream?.raftMetaGroup || []).length && (
                 <TableRow>
-                  <TableCell colSpan={7}>No information found</TableCell>
+                  <TableCell colSpan={6}>No information found</TableCell>
                 </TableRow>
               )}
               {(jetStream?.raftMetaGroup || []).map((item) => (
                 <TableRow key={`${item.name}-${item.id || ""}`}>
                   <TableCell>{item.name}</TableCell>
-                  <TableCell>{item.id || "-"}</TableCell>
                   <TableCell>{item.leader ? "Yes" : "No"}</TableCell>
                   <TableCell>{item.current ? "Yes" : "No"}</TableCell>
                   <TableCell>{item.online ? "Yes" : "No"}</TableCell>
-                  <TableCell>{item.active || "-"}</TableCell>
+                  <TableCell>{formatDuration(item.active)}</TableCell>
                   <TableCell>{formatNumber(item.lag)}</TableCell>
                 </TableRow>
               ))}

--- a/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/partials/ISBDebugInfo/index.tsx
+++ b/ui/src/components/common/SlidingSidebar/partials/ISBUpdate/partials/ISBDebugInfo/index.tsx
@@ -16,9 +16,14 @@ interface ISBDebugInfoProps {
   error?: any;
 }
 
-const formatNumber = (value?: number) => (value ?? 0).toLocaleString();
+const formatNumber = (value?: number) => (value ?? 0).toLocaleString("en-US");
 
-const formatDecimal = (value: number) => value.toFixed(2);
+const formatDecimal = (value: number, precision = 2) => {
+  const multiplier = Math.pow(10, precision);
+  return (
+    Math.round((value + Number.EPSILON) * multiplier) / multiplier
+  ).toFixed(precision);
+};
 
 const formatBytes = (value?: number) => {
   const bytes = value ?? 0;
@@ -36,21 +41,52 @@ const formatBytes = (value?: number) => {
   }`;
 };
 
-const formatPercent = (value?: number) =>
-  `${formatDecimal((value ?? 0) * 100)}%`;
+const formatPercent = (value?: number) => {
+  const percent = (value ?? 0) * 100;
+  const precision = percent > 0 && percent < 0.1 ? 3 : 2;
+  return `${formatDecimal(percent, precision)}%`;
+};
 
 const formatApiErrors = (errors?: number, rate?: number) =>
   `${formatNumber(errors)} / ${formatPercent(rate)}`;
+
+const formatDurationNumber = (value: string) => {
+  const numberValue = Number(value);
+  return Number.isInteger(numberValue)
+    ? `${numberValue}`
+    : formatDecimal(numberValue);
+};
 
 const formatDuration = (value?: string) => {
   if (!value) {
     return "-";
   }
-  const match = value.match(/^(-?\d+(?:\.\d+)?)([a-zµμ]+)$/i);
-  if (!match) {
+  const tokenRegex = /(-?\d+(?:\.\d+)?)([a-zµμ]+)/gi;
+  const parts = [];
+  let consumed = "";
+  let match;
+  while ((match = tokenRegex.exec(value)) !== null) {
+    consumed += match[0];
+    parts.push(`${formatDurationNumber(match[1])}${match[2]}`);
+  }
+  if (!parts.length || consumed !== value) {
     return value;
   }
-  return `${formatDecimal(Number(match[1]))}${match[2]}`;
+  return parts.join(" ");
+};
+
+const formatOptionalBoolean = (value?: boolean) => {
+  if (value === undefined) {
+    return "-";
+  }
+  return value ? "Yes" : "No";
+};
+
+const formatOptionalNumber = (value?: number) => {
+  if (value === undefined) {
+    return "-";
+  }
+  return formatNumber(value);
 };
 
 const HeaderCell = ({
@@ -74,7 +110,14 @@ const HeaderCell = ({
     <Box sx={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
       {label}
       {tooltip && (
-        <Box data-testid={testId}>
+        <Box
+          data-testid={testId}
+          sx={{
+            display: "inline-flex",
+            alignItems: "center",
+            lineHeight: 0,
+          }}
+        >
           <Help tooltip={tooltip} />
         </Box>
       )}
@@ -234,10 +277,10 @@ export function ISBDebugInfo({ jetStream, loading, error }: ISBDebugInfoProps) {
                 <TableRow key={`${item.name}-${item.id || ""}`}>
                   <TableCell>{item.name}</TableCell>
                   <TableCell>{item.leader ? "Yes" : "No"}</TableCell>
-                  <TableCell>{item.current ? "Yes" : "No"}</TableCell>
+                  <TableCell>{formatOptionalBoolean(item.current)}</TableCell>
                   <TableCell>{item.online ? "Yes" : "No"}</TableCell>
                   <TableCell>{formatDuration(item.active)}</TableCell>
-                  <TableCell>{formatNumber(item.lag)}</TableCell>
+                  <TableCell>{formatOptionalNumber(item.lag)}</TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/ui/src/components/pages/Namespace/partials/NamespaceListingWrapper/ISBServiceCard/ISBServiceCard.test.tsx
+++ b/ui/src/components/pages/Namespace/partials/NamespaceListingWrapper/ISBServiceCard/ISBServiceCard.test.tsx
@@ -7,6 +7,7 @@ import userEvent from "@testing-library/user-event";
 import { ISBServiceCard } from "./ISBServiceCard";
 import { AppContext } from "../../../../../../App";
 import { BrowserRouter } from "react-router-dom";
+import { SidebarType } from "../../../../../common/SlidingSidebar";
 
 const mockSetSidebarProps = jest.fn();
 
@@ -251,6 +252,38 @@ describe("ISBServiceCard", () => {
     const editButton = screen.getByTestId("edit-isb");
     expect(editButton).toBeInTheDocument();
     userEvent.click(editButton);
+  });
+
+  it("opens read-only ISB sidebar when service name is clicked", async () => {
+    render(
+      <BrowserRouter>
+        <AppContext.Provider
+          value={{
+            setSidebarProps: mockSetSidebarProps,
+          }}
+        >
+          <ISBServiceCard
+            namespace={mockNamespace}
+            data={mockData}
+            refresh={mockRefresh}
+          />
+        </AppContext.Provider>
+      </BrowserRouter>
+    );
+
+    await userEvent.click(screen.getByTestId("view-isb-name"));
+
+    expect(mockSetSidebarProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: SidebarType.ISB_UPDATE,
+        specEditorProps: expect.objectContaining({
+          titleOverride: "View ISB Service: default",
+          namespaceId: mockNamespace,
+          isbId: "default",
+          viewType: 0,
+        }),
+      })
+    );
   });
 
   it("Tests clicking cancel on the delete confirmation", async () => {

--- a/ui/src/components/pages/Namespace/partials/NamespaceListingWrapper/ISBServiceCard/ISBServiceCard.tsx
+++ b/ui/src/components/pages/Namespace/partials/NamespaceListingWrapper/ISBServiceCard/ISBServiceCard.tsx
@@ -57,7 +57,7 @@ export function ISBServiceCard({
         onUpdateComplete: handleUpdateComplete,
       },
     });
-  }, [setSidebarProps, handleUpdateComplete, data]);
+  }, [setSidebarProps, handleUpdateComplete, data, namespace]);
 
   const handleEditChange = useCallback(() => {
     setSidebarProps({
@@ -132,7 +132,21 @@ export function ISBServiceCard({
               marginLeft: "1.6rem",
             }}
           >
-            <span className="pipeline-card-name">{data?.name}</span>
+            <span
+              className="pipeline-card-name"
+              data-testid="view-isb-name"
+              onClick={handleViewChange}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  handleViewChange();
+                }
+              }}
+              role="button"
+              tabIndex={0}
+            >
+              {data?.name}
+            </span>
           </Box>
         </Box>
 

--- a/ui/src/components/pages/Pipeline/index.tsx
+++ b/ui/src/components/pages/Pipeline/index.tsx
@@ -177,6 +177,7 @@ export function Pipeline({ namespaceId: nsIdProp }: PipelineProps) {
         customComponent: (
           <PipelineISBSummaryStatus
             isbData={isbData}
+            namespaceId={namespaceId}
             key={"pipeline-isb-status"}
           />
         ),

--- a/ui/src/components/pages/Pipeline/partials/PipelineISBSummaryStatus/index.test.tsx
+++ b/ui/src/components/pages/Pipeline/partials/PipelineISBSummaryStatus/index.test.tsx
@@ -4,6 +4,8 @@ import "@testing-library/jest-dom";
 import { AppContext } from "../../../../../App";
 import { BrowserRouter } from "react-router-dom";
 import { PipelineISBSummaryStatus } from "./index";
+import userEvent from "@testing-library/user-event";
+import { SidebarType } from "../../../../common/SlidingSidebar";
 
 const mockData = {
   name: "default",
@@ -160,11 +162,20 @@ const mockData = {
 };
 
 describe("PipelineISBSummaryStatus", () => {
+  const mockSetSidebarProps = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should render the ISB summary status", () => {
     render(
-      <AppContext.Provider value={{ isbData: mockData }}>
+      <AppContext.Provider value={{ setSidebarProps: mockSetSidebarProps }}>
         <BrowserRouter>
-          <PipelineISBSummaryStatus isbData={mockData} />
+          <PipelineISBSummaryStatus
+            isbData={mockData}
+            namespaceId="numaflow-system"
+          />
         </BrowserRouter>
       </AppContext.Provider>
     );
@@ -172,16 +183,46 @@ describe("PipelineISBSummaryStatus", () => {
     expect(screen.getByText("default")).toBeInTheDocument();
     expect(screen.getByText("3")).toBeInTheDocument();
     expect(screen.getByText("jetstream")).toBeInTheDocument();
+    expect(screen.getByText("View More")).toBeInTheDocument();
   });
 
   it("should render the ISB summary status with unknown values", () => {
     render(
-      <AppContext.Provider value={{ isbData: mockData }}>
+      <AppContext.Provider value={{ setSidebarProps: mockSetSidebarProps }}>
         <BrowserRouter>
           <PipelineISBSummaryStatus isbData={null} />
         </BrowserRouter>
       </AppContext.Provider>
     );
     expect(screen.getByText("ISB SERVICES SUMMARY")).toBeInTheDocument();
+    expect(screen.queryByText("View More")).not.toBeInTheDocument();
+  });
+
+  it("should open ISB details sidebar when View More is clicked", async () => {
+    render(
+      <AppContext.Provider value={{ setSidebarProps: mockSetSidebarProps }}>
+        <BrowserRouter>
+          <PipelineISBSummaryStatus
+            isbData={mockData}
+            namespaceId="numaflow-system"
+          />
+        </BrowserRouter>
+      </AppContext.Provider>
+    );
+
+    await userEvent.click(screen.getByTestId("pipeline-isb-view-more"));
+
+    expect(mockSetSidebarProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: SidebarType.ISB_UPDATE,
+        specEditorProps: expect.objectContaining({
+          titleOverride: "ISB Service Details: default",
+          initialYaml: mockData.isbService,
+          namespaceId: "numaflow-system",
+          isbId: "default",
+          viewType: 0,
+        }),
+      })
+    );
   });
 });

--- a/ui/src/components/pages/Pipeline/partials/PipelineISBSummaryStatus/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/PipelineISBSummaryStatus/index.tsx
@@ -1,9 +1,31 @@
-import React from "react";
+import React, { useCallback, useContext } from "react";
 import Box from "@mui/material/Box";
 import { GetISBType, UNKNOWN } from "../../../../../utils";
+import { AppContext } from "../../../../../App";
+import { AppContextProps } from "../../../../../types/declarations/app";
+import { SidebarType } from "../../../../common/SlidingSidebar";
+import { ViewType } from "../../../../common/SpecEditor";
 
-export function PipelineISBSummaryStatus({ isbData }: any) {
+export function PipelineISBSummaryStatus({ isbData, namespaceId }: any) {
   const isbType = GetISBType(isbData?.isbService?.spec) || UNKNOWN;
+  const { setSidebarProps } = useContext<AppContextProps>(AppContext);
+
+  const handleViewMoreClick = useCallback(() => {
+    if (!namespaceId || !isbData?.name || !setSidebarProps) {
+      return;
+    }
+    setSidebarProps({
+      type: SidebarType.ISB_UPDATE,
+      specEditorProps: {
+        titleOverride: `ISB Service Details: ${isbData.name}`,
+        initialYaml: isbData.isbService,
+        namespaceId,
+        isbId: isbData.name,
+        viewType: ViewType.READ_ONLY,
+      },
+    });
+  }, [namespaceId, isbData, setSidebarProps]);
+
   return (
     <Box
       sx={{
@@ -71,6 +93,19 @@ export function PipelineISBSummaryStatus({ isbData }: any) {
                   </div>
                 </span>
               </div>
+              {isbData?.name && (
+                <div className="pipeline-summary-text">
+                  <span className="pipeline-summary-subtitle">
+                    <div
+                      className="pipeline-onclick-events"
+                      onClick={handleViewMoreClick}
+                      data-testid="pipeline-isb-view-more"
+                    >
+                      View More
+                    </div>
+                  </span>
+                </div>
+              )}
             </Box>
           </Box>
         </Box>

--- a/ui/src/components/pages/Pipeline/partials/PipelineISBSummaryStatus/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/PipelineISBSummaryStatus/index.tsx
@@ -3,11 +3,29 @@ import Box from "@mui/material/Box";
 import { GetISBType, UNKNOWN } from "../../../../../utils";
 import { AppContext } from "../../../../../App";
 import { AppContextProps } from "../../../../../types/declarations/app";
+import { IsbSummary } from "../../../../../types/declarations/pipeline";
 import { SidebarType } from "../../../../common/SlidingSidebar";
 import { ViewType } from "../../../../common/SpecEditor";
 
-export function PipelineISBSummaryStatus({ isbData, namespaceId }: any) {
-  const isbType = GetISBType(isbData?.isbService?.spec) || UNKNOWN;
+interface PipelineISBSummaryStatusProps {
+  isbData?: IsbSummary | null;
+  namespaceId?: string;
+}
+
+interface IsbSpecWithReplicas {
+  [key: string]: { replicas?: number } | undefined;
+}
+
+export function PipelineISBSummaryStatus({
+  isbData,
+  namespaceId,
+}: PipelineISBSummaryStatusProps) {
+  const isbSpec = isbData?.isbService?.spec as unknown as
+    | IsbSpecWithReplicas
+    | undefined;
+  const isbType = isbData?.isbService?.spec
+    ? GetISBType(isbData.isbService.spec) || UNKNOWN
+    : UNKNOWN;
   const { setSidebarProps } = useContext<AppContextProps>(AppContext);
 
   const handleViewMoreClick = useCallback(() => {
@@ -86,8 +104,8 @@ export function PipelineISBSummaryStatus({ isbData, namespaceId }: any) {
                   <div className="pipeline-summary-text">
                     <span className="pipeline-summary-subtitle">Size: </span>
                     <span>
-                      {isbType && isbData?.isbService?.spec[isbType]
-                        ? isbData?.isbService?.spec[isbType].replicas
+                      {isbType && isbSpec?.[isbType]?.replicas
+                        ? isbSpec[isbType]?.replicas
                         : UNKNOWN}
                     </span>
                   </div>

--- a/ui/src/types/declarations/pipeline.d.ts
+++ b/ui/src/types/declarations/pipeline.d.ts
@@ -90,6 +90,50 @@ export interface IsbServiceSpec {
   redis?: Redis;
 }
 
+export interface ISBJetStreamSummary {
+  server: string;
+  serverId?: string;
+  cluster?: string;
+  streams: number;
+  consumers: number;
+  messages: number;
+  bytes: number;
+  apiRequests: number;
+  apiErrors: number;
+  apiErrorRate: number;
+  metaLeader: boolean;
+}
+
+export interface ISBJetStreamRaftMeta {
+  name: string;
+  id?: string;
+  leader: boolean;
+  current: boolean;
+  online: boolean;
+  active?: string;
+  lag: number;
+}
+
+export interface ISBMonitorError {
+  pod: string;
+  message: string;
+}
+
+export interface ISBJetStreamResponse {
+  summary: ISBJetStreamSummary[];
+  raftMetaGroup: ISBJetStreamRaftMeta[];
+  errors?: ISBMonitorError[];
+}
+
+export interface ISBServiceDebugFetchResult {
+  data?: {
+    jetStream: ISBJetStreamResponse;
+  };
+  loading: boolean;
+  error: any;
+  refresh: () => void;
+}
+
 export interface PipelineSummary {
   name: string;
   status: string;

--- a/ui/src/types/declarations/pipeline.d.ts
+++ b/ui/src/types/declarations/pipeline.d.ts
@@ -108,10 +108,10 @@ export interface ISBJetStreamRaftMeta {
   name: string;
   id?: string;
   leader: boolean;
-  current: boolean;
+  current?: boolean;
   online: boolean;
   active?: string;
-  lag: number;
+  lag?: number;
 }
 
 export interface ISBMonitorError {

--- a/ui/src/utils/fetchWrappers/isbServiceDebugFetch.ts
+++ b/ui/src/utils/fetchWrappers/isbServiceDebugFetch.ts
@@ -6,6 +6,7 @@ import {
   ISBServiceDebugFetchResult,
 } from "../../types/declarations/pipeline";
 import { getBaseHref } from "..";
+import { Options, useFetch } from "./fetch";
 
 export const useISBServiceDebugFetch = ({
   namespaceId,
@@ -17,63 +18,84 @@ export const useISBServiceDebugFetch = ({
   enabled: boolean;
 }): ISBServiceDebugFetchResult => {
   const { host } = useContext<AppContextProps>(AppContext);
-  const [requestKey, setRequestKey] = useState("");
+  const shouldFetch = enabled && !!namespaceId && !!isbId;
+  const [options, setOptions] = useState<Options>({
+    skip: !shouldFetch,
+    requestKey: "",
+  });
   const [data, setData] = useState<
     | {
         jetStream: ISBJetStreamResponse;
       }
     | undefined
   >();
-  const [loading, setLoading] = useState(enabled);
+  const [loading, setLoading] = useState(shouldFetch);
   const [error, setError] = useState<any>(undefined);
 
   const refresh = useCallback(() => {
-    setRequestKey("id" + Math.random().toString(16).slice(2));
-  }, []);
+    setOptions({
+      skip: !shouldFetch,
+      requestKey: "id" + Math.random().toString(16).slice(2),
+    });
+  }, [shouldFetch]);
+
+  const {
+    data: jetStreamData,
+    loading: jetStreamLoading,
+    error: jetStreamError,
+  } = useFetch(
+    `${host}${getBaseHref()}/api/v1/namespaces/${namespaceId}/isb-services/${isbId}/jetstream`,
+    undefined,
+    options
+  );
 
   useEffect(() => {
-    if (!enabled || !namespaceId || !isbId) {
-      setLoading(false);
+    setOptions((previousOptions) => {
+      if (previousOptions.skip === !shouldFetch) {
+        return previousOptions;
+      }
+      return {
+        ...previousOptions,
+        skip: !shouldFetch,
+      };
+    });
+    if (!shouldFetch) {
       setData(undefined);
       setError(undefined);
+      setLoading(false);
+    }
+  }, [shouldFetch]);
+
+  useEffect(() => {
+    if (!shouldFetch) {
       return;
     }
-
-    let cancelled = false;
-    const fetchData = async () => {
+    if (jetStreamLoading) {
       setLoading(true);
-      try {
-        const response = await fetch(
-          `${host}${getBaseHref()}/api/v1/namespaces/${namespaceId}/isb-services/${isbId}/jetstream`
-        );
-        const responseJSON = await response.json();
-        const responseError = responseJSON?.errMsg;
-        if (!response.ok || responseError) {
-          throw new Error(responseError || `Response code: ${response.status}`);
-        }
-        if (!cancelled) {
-          setData({
-            jetStream: responseJSON?.data,
-          });
-          setError(undefined);
-        }
-      } catch (e: any) {
-        if (!cancelled) {
-          setError(e.message);
-          setData(undefined);
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
-    fetchData();
-    return () => {
-      cancelled = true;
-    };
-  }, [enabled, namespaceId, isbId, host, requestKey]);
+      return;
+    }
+    if (jetStreamError) {
+      setData(undefined);
+      setError(jetStreamError);
+      setLoading(false);
+      return;
+    }
+    if (jetStreamData?.errMsg) {
+      setData(undefined);
+      setError(jetStreamData.errMsg);
+      setLoading(false);
+      return;
+    }
+    if (jetStreamData?.data) {
+      setData({
+        jetStream: jetStreamData.data,
+      });
+      setError(undefined);
+      setLoading(false);
+      return;
+    }
+    setLoading(false);
+  }, [jetStreamData, jetStreamLoading, jetStreamError, shouldFetch]);
 
   return { data, loading, error, refresh };
 };

--- a/ui/src/utils/fetchWrappers/isbServiceDebugFetch.ts
+++ b/ui/src/utils/fetchWrappers/isbServiceDebugFetch.ts
@@ -1,0 +1,79 @@
+import { useCallback, useContext, useEffect, useState } from "react";
+import { AppContext } from "../../App";
+import { AppContextProps } from "../../types/declarations/app";
+import {
+  ISBJetStreamResponse,
+  ISBServiceDebugFetchResult,
+} from "../../types/declarations/pipeline";
+import { getBaseHref } from "..";
+
+export const useISBServiceDebugFetch = ({
+  namespaceId,
+  isbId,
+  enabled,
+}: {
+  namespaceId?: string;
+  isbId?: string;
+  enabled: boolean;
+}): ISBServiceDebugFetchResult => {
+  const { host } = useContext<AppContextProps>(AppContext);
+  const [requestKey, setRequestKey] = useState("");
+  const [data, setData] = useState<
+    | {
+        jetStream: ISBJetStreamResponse;
+      }
+    | undefined
+  >();
+  const [loading, setLoading] = useState(enabled);
+  const [error, setError] = useState<any>(undefined);
+
+  const refresh = useCallback(() => {
+    setRequestKey("id" + Math.random().toString(16).slice(2));
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !namespaceId || !isbId) {
+      setLoading(false);
+      setData(undefined);
+      setError(undefined);
+      return;
+    }
+
+    let cancelled = false;
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const response = await fetch(
+          `${host}${getBaseHref()}/api/v1/namespaces/${namespaceId}/isb-services/${isbId}/jetstream`
+        );
+        const responseJSON = await response.json();
+        const responseError = responseJSON?.errMsg;
+        if (!response.ok || responseError) {
+          throw new Error(responseError || `Response code: ${response.status}`);
+        }
+        if (!cancelled) {
+          setData({
+            jetStream: responseJSON?.data,
+          });
+          setError(undefined);
+        }
+      } catch (e: any) {
+        if (!cancelled) {
+          setError(e.message);
+          setData(undefined);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, namespaceId, isbId, host, requestKey]);
+
+  return { data, loading, error, refresh };
+};


### PR DESCRIPTION
### What this PR does / why we need it

Adds ISB-level JetStream debug information in the UI, focused on JetStream Summary and RAFT Meta Group details.

### Related issues

#3235

### Testing

Tested with focused UI and backend checks:

```bash
npm test -- --runTestsByPath src/components/common/SlidingSidebar/partials/ISBUpdate/index.test.tsx --watchAll=false --coverage=false --ci
go test ./server/apis/v1 ./server/cmd/server
```

Also manually verified the ISB sidebar shows JetStream Summary, RAFT Meta Group Information, refresh behavior, and clickable ISB service details.

### Special notes for reviewers

This PR intentionally keeps scope small: Streams, Consumers and KV Stores per vertex are deferred to follow-up work.

https://github.com/user-attachments/assets/25084427-a443-48e3-b638-a2a07153628c

