### PR TITLE
fix: pod logs streaming blocked by cleanResponseMiddleware buffering

### DIFF
--- a/server/routes/clean_response_middleware.go
+++ b/server/routes/clean_response_middleware.go
@@ -25,21 +25,13 @@ import (
 )
 
 var (
-	// "managedFields" is too annoying
+	// Fields stripped from buffered JSON responses.
 	cleanupFields = []string{"managedFields"}
 )
 
-// customResponseWriter wraps gin.ResponseWriter to buffer the response body for
-// post-processing. A handler that calls Flush() is treated as streaming: the
-// writer drains any buffered bytes, flips into pass-through mode, and forwards
-// every subsequent Write directly to the underlying ResponseWriter. Handlers
-// that never call Flush() remain fully buffered so the middleware can rewrite
-// the response (e.g. stripping managedFields).
-//
-// Note: a handler that streams without ever calling Flush() would still be
-// buffered. All current streaming endpoints (pod logs follow, c.Stream-based
-// handlers) call Flush(), so this is sufficient in practice. Hijacked
-// connections (e.g. websockets) bypass Write entirely and are unaffected.
+// customResponseWriter buffers non-streaming responses so the middleware can
+// rewrite them. Calling Flush marks the response as streaming: buffered bytes
+// are drained and subsequent writes pass through directly.
 type customResponseWriter struct {
 	gin.ResponseWriter
 	body      *bytes.Buffer
@@ -55,14 +47,12 @@ func (w *customResponseWriter) Write(b []byte) (int, error) {
 
 func (w *customResponseWriter) WriteString(s string) (int, error) {
 	if w.streaming {
-		return w.ResponseWriter.Write([]byte(s))
+		return w.ResponseWriter.WriteString(s)
 	}
 	return w.body.WriteString(s)
 }
 
-// Flush is the streaming signal. On the first call we drain any bytes that
-// were buffered before the handler decided to stream, flip into pass-through
-// mode, and then forward to the underlying writer's Flush.
+// Flush switches to streaming mode and forwards the flush to the underlying writer.
 func (w *customResponseWriter) Flush() {
 	if !w.streaming {
 		w.streaming = true
@@ -111,7 +101,7 @@ func cleanResponseMiddleware() gin.HandlerFunc {
 	}
 }
 
-// removeFieldRecursively removes all occurrences of the given field from a (possibly nested) JSON structure represented as map[string]interface{} or []interface{}.
+// removeFieldsRecursively removes fields from nested JSON objects and arrays.
 func removeFieldsRecursively(data interface{}, fields ...string) {
 	switch val := data.(type) {
 	case map[string]interface{}:

--- a/server/routes/clean_response_middleware.go
+++ b/server/routes/clean_response_middleware.go
@@ -29,42 +29,65 @@ var (
 	cleanupFields = []string{"managedFields"}
 )
 
-// customResponseWriter wraps gin.ResponseWriter to capture the response body.
+// customResponseWriter wraps gin.ResponseWriter to buffer the response body for
+// post-processing. A handler that calls Flush() is treated as streaming: the
+// writer drains any buffered bytes, flips into pass-through mode, and forwards
+// every subsequent Write directly to the underlying ResponseWriter. Handlers
+// that never call Flush() remain fully buffered so the middleware can rewrite
+// the response (e.g. stripping managedFields).
+//
+// Note: a handler that streams without ever calling Flush() would still be
+// buffered. All current streaming endpoints (pod logs follow, c.Stream-based
+// handlers) call Flush(), so this is sufficient in practice. Hijacked
+// connections (e.g. websockets) bypass Write entirely and are unaffected.
 type customResponseWriter struct {
 	gin.ResponseWriter
-	body *bytes.Buffer
+	body      *bytes.Buffer
+	streaming bool
 }
 
-// cleanResponseSkipper reports whether cleanResponseMiddleware should leave the response writer untouched.
-type cleanResponseSkipper func(*gin.Context) bool
-
-func (w customResponseWriter) Write(b []byte) (int, error) {
+func (w *customResponseWriter) Write(b []byte) (int, error) {
+	if w.streaming {
+		return w.ResponseWriter.Write(b)
+	}
 	return w.body.Write(b)
 }
 
-func (w customResponseWriter) WriteString(s string) (int, error) {
+func (w *customResponseWriter) WriteString(s string) (int, error) {
+	if w.streaming {
+		return w.ResponseWriter.Write([]byte(s))
+	}
 	return w.body.WriteString(s)
 }
 
-// cleanResponseMiddleware is a Gin middleware to clean up data in the response body.
-func cleanResponseMiddleware(skippers ...cleanResponseSkipper) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// Skip buffering for streaming endpoints (e.g. pod logs with follow=true),
-		// otherwise the response would never be written to the client.
-		for _, skip := range skippers {
-			if skip != nil && skip(c) {
-				c.Next()
-				return
-			}
+// Flush is the streaming signal. On the first call we drain any bytes that
+// were buffered before the handler decided to stream, flip into pass-through
+// mode, and then forward to the underlying writer's Flush.
+func (w *customResponseWriter) Flush() {
+	if !w.streaming {
+		w.streaming = true
+		if w.body.Len() > 0 {
+			_, _ = w.ResponseWriter.Write(w.body.Bytes())
+			w.body.Reset()
 		}
-		// Replace the original response writer with our custom one
+	}
+	w.ResponseWriter.Flush()
+}
+
+// cleanResponseMiddleware is a Gin middleware to clean up data in the response body.
+func cleanResponseMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
 		w := &customResponseWriter{body: bytes.NewBufferString(""), ResponseWriter: c.Writer}
 		c.Writer = w
 
 		c.Next()
 
-		// At this point, the original handler has written to our customResponseWriter's body buffer.
-		// We can now access and modify the response data.
+		// If the handler streamed (called Flush at any point), bytes have
+		// already been sent to the client and no cleanup is possible.
+		if w.streaming {
+			return
+		}
+
 		originalBody := w.body.Bytes()
 
 		// Only process JSON responses
@@ -85,18 +108,6 @@ func cleanResponseMiddleware(skippers ...cleanResponseSkipper) gin.HandlerFunc {
 			}
 		}
 		_, _ = w.ResponseWriter.Write(originalBody)
-	}
-}
-
-// skipCleanResponseForRoutes matches Gin route patterns returned by c.FullPath().
-func skipCleanResponseForRoutes(routes ...string) cleanResponseSkipper {
-	routeSet := make(map[string]struct{}, len(routes))
-	for _, route := range routes {
-		routeSet[route] = struct{}{}
-	}
-	return func(c *gin.Context) bool {
-		_, ok := routeSet[c.FullPath()]
-		return ok
 	}
 }
 

--- a/server/routes/clean_response_middleware.go
+++ b/server/routes/clean_response_middleware.go
@@ -35,6 +35,9 @@ type customResponseWriter struct {
 	body *bytes.Buffer
 }
 
+// cleanResponseSkipper reports whether cleanResponseMiddleware should leave the response writer untouched.
+type cleanResponseSkipper func(*gin.Context) bool
+
 func (w customResponseWriter) Write(b []byte) (int, error) {
 	return w.body.Write(b)
 }
@@ -44,13 +47,15 @@ func (w customResponseWriter) WriteString(s string) (int, error) {
 }
 
 // cleanResponseMiddleware is a Gin middleware to clean up data in the response body.
-func cleanResponseMiddleware() gin.HandlerFunc {
+func cleanResponseMiddleware(skippers ...cleanResponseSkipper) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Skip buffering for streaming endpoints (e.g. pod logs with follow=true),
 		// otherwise the response would never be written to the client.
-		if strings.HasSuffix(c.FullPath(), "/pods/:pod/logs") {
-			c.Next()
-			return
+		for _, skip := range skippers {
+			if skip != nil && skip(c) {
+				c.Next()
+				return
+			}
 		}
 		// Replace the original response writer with our custom one
 		w := &customResponseWriter{body: bytes.NewBufferString(""), ResponseWriter: c.Writer}
@@ -80,6 +85,18 @@ func cleanResponseMiddleware() gin.HandlerFunc {
 			}
 		}
 		_, _ = w.ResponseWriter.Write(originalBody)
+	}
+}
+
+// skipCleanResponseForRoutes matches Gin route patterns returned by c.FullPath().
+func skipCleanResponseForRoutes(routes ...string) cleanResponseSkipper {
+	routeSet := make(map[string]struct{}, len(routes))
+	for _, route := range routes {
+		routeSet[route] = struct{}{}
+	}
+	return func(c *gin.Context) bool {
+		_, ok := routeSet[c.FullPath()]
+		return ok
 	}
 }
 

--- a/server/routes/clean_response_middleware.go
+++ b/server/routes/clean_response_middleware.go
@@ -46,6 +46,12 @@ func (w customResponseWriter) WriteString(s string) (int, error) {
 // cleanResponseMiddleware is a Gin middleware to clean up data in the response body.
 func cleanResponseMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Skip buffering for streaming endpoints (e.g. pod logs with follow=true),
+		// otherwise the response would never be written to the client.
+		if strings.HasSuffix(c.FullPath(), "/pods/:pod/logs") {
+			c.Next()
+			return
+		}
 		// Replace the original response writer with our custom one
 		w := &customResponseWriter{body: bytes.NewBufferString(""), ResponseWriter: c.Writer}
 		c.Writer = w

--- a/server/routes/clean_response_middleware_test.go
+++ b/server/routes/clean_response_middleware_test.go
@@ -397,16 +397,60 @@ func TestCustomResponseWriter_Write(t *testing.T) {
 	})
 }
 
-func TestCleanResponseMiddleware_SkipsPodLogsStreaming(t *testing.T) {
+func TestCleanResponseMiddleware_SkipsConfiguredStreamingRoutes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	t.Run("pod logs route bypasses response buffering", func(t *testing.T) {
+	t.Run("configured streaming route bypasses response buffering", func(t *testing.T) {
 		router := gin.New()
-		router.Use(cleanResponseMiddleware())
+		router.Use(cleanResponseMiddleware(skipCleanResponseForRoutes("/stream/:name")))
 
 		w := httptest.NewRecorder()
 		var bytesReceivedDuringHandler int
-		router.GET("/api/v1/namespaces/:namespace/pods/:pod/logs", func(c *gin.Context) {
+		router.GET("/stream/:name", func(c *gin.Context) {
+			_, _ = c.Writer.WriteString("log line 1\n")
+			c.Writer.Flush()
+			bytesReceivedDuringHandler = w.Body.Len()
+			_, _ = c.Writer.WriteString("log line 2\n")
+		})
+
+		req, _ := http.NewRequest(http.MethodGet, "/stream/test?follow=true", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Greater(t, bytesReceivedDuringHandler, 0, "configured streaming responses should reach the client while the handler is still streaming")
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "log line 1\nlog line 2\n", w.Body.String())
+	})
+
+	t.Run("unconfigured route still buffers response", func(t *testing.T) {
+		router := gin.New()
+		router.Use(cleanResponseMiddleware(skipCleanResponseForRoutes("/stream/:name")))
+
+		w := httptest.NewRecorder()
+		var bytesReceivedDuringHandler int
+		router.GET("/other-stream/:name", func(c *gin.Context) {
+			_, _ = c.Writer.WriteString("log line 1\n")
+			c.Writer.Flush()
+			bytesReceivedDuringHandler = w.Body.Len()
+			_, _ = c.Writer.WriteString("log line 2\n")
+		})
+
+		req, _ := http.NewRequest(http.MethodGet, "/other-stream/test?follow=true", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, 0, bytesReceivedDuringHandler, "unconfigured routes should keep using response buffering")
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "log line 1\nlog line 2\n", w.Body.String())
+	})
+
+	t.Run("pod logs route can be configured as streaming route", func(t *testing.T) {
+		router := gin.New()
+		apiV1Route := "/api/v1"
+		api := router.Group(apiV1Route)
+		api.Use(cleanResponseMiddleware(skipCleanResponseForRoutes(apiV1Route + podLogsRoute)))
+
+		w := httptest.NewRecorder()
+		var bytesReceivedDuringHandler int
+		api.GET(podLogsRoute, func(c *gin.Context) {
 			_, _ = c.Writer.WriteString("log line 1\n")
 			c.Writer.Flush()
 			bytesReceivedDuringHandler = w.Body.Len()
@@ -416,7 +460,7 @@ func TestCleanResponseMiddleware_SkipsPodLogsStreaming(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/ns/pods/my-pod/logs?container=numa&follow=true", nil)
 		router.ServeHTTP(w, req)
 
-		assert.Greater(t, bytesReceivedDuringHandler, 0, "logs should reach the client while the handler is still streaming")
+		assert.Greater(t, bytesReceivedDuringHandler, 0, "pod logs route should be configurable as a streaming route")
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, "log line 1\nlog line 2\n", w.Body.String())
 	})

--- a/server/routes/clean_response_middleware_test.go
+++ b/server/routes/clean_response_middleware_test.go
@@ -397,6 +397,31 @@ func TestCustomResponseWriter_Write(t *testing.T) {
 	})
 }
 
+func TestCleanResponseMiddleware_SkipsPodLogsStreaming(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("pod logs route bypasses response buffering", func(t *testing.T) {
+		router := gin.New()
+		router.Use(cleanResponseMiddleware())
+
+		w := httptest.NewRecorder()
+		var bytesReceivedDuringHandler int
+		router.GET("/api/v1/namespaces/:namespace/pods/:pod/logs", func(c *gin.Context) {
+			_, _ = c.Writer.WriteString("log line 1\n")
+			c.Writer.Flush()
+			bytesReceivedDuringHandler = w.Body.Len()
+			_, _ = c.Writer.WriteString("log line 2\n")
+		})
+
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/ns/pods/my-pod/logs?container=numa&follow=true", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Greater(t, bytesReceivedDuringHandler, 0, "logs should reach the client while the handler is still streaming")
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "log line 1\nlog line 2\n", w.Body.String())
+	})
+}
+
 func TestCleanResponseMiddleware_EdgeCases(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/server/routes/clean_response_middleware_test.go
+++ b/server/routes/clean_response_middleware_test.go
@@ -397,12 +397,12 @@ func TestCustomResponseWriter_Write(t *testing.T) {
 	})
 }
 
-func TestCleanResponseMiddleware_SkipsConfiguredStreamingRoutes(t *testing.T) {
+func TestCleanResponseMiddleware_StreamingViaFlush(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	t.Run("configured streaming route bypasses response buffering", func(t *testing.T) {
+	t.Run("flush mid-response bypasses buffering", func(t *testing.T) {
 		router := gin.New()
-		router.Use(cleanResponseMiddleware(skipCleanResponseForRoutes("/stream/:name")))
+		router.Use(cleanResponseMiddleware())
 
 		w := httptest.NewRecorder()
 		var bytesReceivedDuringHandler int
@@ -416,41 +416,82 @@ func TestCleanResponseMiddleware_SkipsConfiguredStreamingRoutes(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/stream/test?follow=true", nil)
 		router.ServeHTTP(w, req)
 
-		assert.Greater(t, bytesReceivedDuringHandler, 0, "configured streaming responses should reach the client while the handler is still streaming")
+		assert.Greater(t, bytesReceivedDuringHandler, 0, "flushing handlers should reach the client mid-response")
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, "log line 1\nlog line 2\n", w.Body.String())
 	})
 
-	t.Run("unconfigured route still buffers response", func(t *testing.T) {
+	t.Run("handler that never flushes still gets JSON cleanup", func(t *testing.T) {
 		router := gin.New()
-		router.Use(cleanResponseMiddleware(skipCleanResponseForRoutes("/stream/:name")))
+		router.Use(cleanResponseMiddleware())
 
-		w := httptest.NewRecorder()
-		var bytesReceivedDuringHandler int
-		router.GET("/other-stream/:name", func(c *gin.Context) {
-			_, _ = c.Writer.WriteString("log line 1\n")
-			c.Writer.Flush()
-			bytesReceivedDuringHandler = w.Body.Len()
-			_, _ = c.Writer.WriteString("log line 2\n")
+		router.GET("/test", func(c *gin.Context) {
+			c.JSON(http.StatusOK, map[string]interface{}{
+				"name":          "buffered",
+				"managedFields": "should be removed",
+			})
 		})
 
-		req, _ := http.NewRequest(http.MethodGet, "/other-stream/test?follow=true", nil)
+		req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		assert.Equal(t, 0, bytesReceivedDuringHandler, "unconfigured routes should keep using response buffering")
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, "log line 1\nlog line 2\n", w.Body.String())
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "buffered", response["name"])
+		assert.NotContains(t, response, "managedFields")
 	})
 
-	t.Run("pod logs route can be configured as streaming route", func(t *testing.T) {
+	t.Run("pre-flush bytes are preserved in order", func(t *testing.T) {
 		router := gin.New()
-		apiV1Route := "/api/v1"
-		api := router.Group(apiV1Route)
-		api.Use(cleanResponseMiddleware(skipCleanResponseForRoutes(apiV1Route + podLogsRoute)))
+		router.Use(cleanResponseMiddleware())
+
+		w := httptest.NewRecorder()
+		router.GET("/stream", func(c *gin.Context) {
+			_, _ = c.Writer.WriteString("first\n")
+			_, _ = c.Writer.Write([]byte("second\n"))
+			c.Writer.Flush()
+			_, _ = c.Writer.WriteString("third\n")
+			_, _ = c.Writer.Write([]byte("fourth\n"))
+		})
+
+		req, _ := http.NewRequest(http.MethodGet, "/stream", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "first\nsecond\nthird\nfourth\n", w.Body.String())
+	})
+
+	t.Run("flush with empty buffer does not write spurious bytes", func(t *testing.T) {
+		router := gin.New()
+		router.Use(cleanResponseMiddleware())
+
+		w := httptest.NewRecorder()
+		router.GET("/stream", func(c *gin.Context) {
+			c.Writer.Flush()
+			bytesAfterEmptyFlush := w.Body.Len()
+			assert.Equal(t, 0, bytesAfterEmptyFlush, "flushing an empty buffer should not write any bytes")
+			_, _ = c.Writer.WriteString("payload\n")
+		})
+
+		req, _ := http.NewRequest(http.MethodGet, "/stream", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "payload\n", w.Body.String())
+	})
+
+	t.Run("pod logs route streams when the handler flushes", func(t *testing.T) {
+		router := gin.New()
+		api := router.Group("/api/v1")
+		api.Use(cleanResponseMiddleware())
 
 		w := httptest.NewRecorder()
 		var bytesReceivedDuringHandler int
-		api.GET(podLogsRoute, func(c *gin.Context) {
+		api.GET("/namespaces/:namespace/pods/:pod/logs", func(c *gin.Context) {
 			_, _ = c.Writer.WriteString("log line 1\n")
 			c.Writer.Flush()
 			bytesReceivedDuringHandler = w.Body.Len()
@@ -460,7 +501,7 @@ func TestCleanResponseMiddleware_SkipsConfiguredStreamingRoutes(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespaces/ns/pods/my-pod/logs?container=numa&follow=true", nil)
 		router.ServeHTTP(w, req)
 
-		assert.Greater(t, bytesReceivedDuringHandler, 0, "pod logs route should be configurable as a streaming route")
+		assert.Greater(t, bytesReceivedDuringHandler, 0, "pod logs handler should stream as soon as it flushes")
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, "log line 1\nlog line 2\n", w.Body.String())
 	})

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -41,8 +41,6 @@ type AuthInfo struct {
 	ServerAddr    string `json:"serverAddr"`
 }
 
-const podLogsRoute = "/namespaces/:namespace/pods/:pod/logs"
-
 func Routes(ctx context.Context, r *gin.Engine, sysInfo SystemInfo, authInfo AuthInfo, baseHref string, authRouteMap authz.RouteMap) {
 	r.GET("/livez", func(c *gin.Context) {
 		c.Status(http.StatusOK)
@@ -72,9 +70,8 @@ func Routes(ctx context.Context, r *gin.Engine, sysInfo SystemInfo, authInfo Aut
 
 	// r1Group is a group of routes that require AuthN/AuthZ when auth is enabled.
 	// they share the AuthN/AuthZ middleware.
-	apiV1Route := baseHref + "api/v1"
-	r1Group := r.Group(apiV1Route)
-	r1Group.Use(cleanResponseMiddleware(skipCleanResponseForRoutes(apiV1Route + podLogsRoute)))
+	r1Group := r.Group(baseHref + "api/v1")
+	r1Group.Use(cleanResponseMiddleware())
 	if !authInfo.DisableAuth {
 		authorizer, err := authz.NewCasbinObject(ctx, authRouteMap)
 		if err != nil {
@@ -162,7 +159,7 @@ func v1Routes(ctx context.Context, r gin.IRouter, dexObj *v1.DexObject, localUse
 	// Get the metrics such as cpu, memory usage for a pod.
 	r.GET("/metrics/namespaces/:namespace/pods", handler.ListPodsMetrics)
 	// Get pod logs.
-	r.GET(podLogsRoute, handler.PodLogs)
+	r.GET("/namespaces/:namespace/pods/:pod/logs", handler.PodLogs)
 	// Get the pod metrics for a mono vertex.
 	r.GET("/namespaces/:namespace/mono-vertices/:mono-vertex/pods-info", handler.GetMonoVertexPodsInfo)
 	// Get the pod metrics for a pipeline vertex.

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -41,6 +41,8 @@ type AuthInfo struct {
 	ServerAddr    string `json:"serverAddr"`
 }
 
+const podLogsRoute = "/namespaces/:namespace/pods/:pod/logs"
+
 func Routes(ctx context.Context, r *gin.Engine, sysInfo SystemInfo, authInfo AuthInfo, baseHref string, authRouteMap authz.RouteMap) {
 	r.GET("/livez", func(c *gin.Context) {
 		c.Status(http.StatusOK)
@@ -70,8 +72,9 @@ func Routes(ctx context.Context, r *gin.Engine, sysInfo SystemInfo, authInfo Aut
 
 	// r1Group is a group of routes that require AuthN/AuthZ when auth is enabled.
 	// they share the AuthN/AuthZ middleware.
-	r1Group := r.Group(baseHref + "api/v1")
-	r1Group.Use(cleanResponseMiddleware())
+	apiV1Route := baseHref + "api/v1"
+	r1Group := r.Group(apiV1Route)
+	r1Group.Use(cleanResponseMiddleware(skipCleanResponseForRoutes(apiV1Route + podLogsRoute)))
 	if !authInfo.DisableAuth {
 		authorizer, err := authz.NewCasbinObject(ctx, authRouteMap)
 		if err != nil {
@@ -159,7 +162,7 @@ func v1Routes(ctx context.Context, r gin.IRouter, dexObj *v1.DexObject, localUse
 	// Get the metrics such as cpu, memory usage for a pod.
 	r.GET("/metrics/namespaces/:namespace/pods", handler.ListPodsMetrics)
 	// Get pod logs.
-	r.GET("/namespaces/:namespace/pods/:pod/logs", handler.PodLogs)
+	r.GET(podLogsRoute, handler.PodLogs)
 	// Get the pod metrics for a mono vertex.
 	r.GET("/namespaces/:namespace/mono-vertices/:mono-vertex/pods-info", handler.GetMonoVertexPodsInfo)
 	// Get the pod metrics for a pipeline vertex.


### PR DESCRIPTION
### What this PR does / why we need it

The UI logs panel gets stuck on "Loading logs..." and `follow=true` pod log requests return zero bytes.

`cleanResponseMiddleware` wraps the response writer in a buffer so it can strip `managedFields` from JSON, but only flushes after the handler returns. For streaming endpoints (pod logs with `follow=true`) the handler never returns while the client is connected, so no bytes reach the UI.

This PR makes the middleware detect streaming dynamically by overriding `Flush()` on the wrapped writer. When a handler calls `c.Writer.Flush()`, the writer drains its buffer, flips into pass-through mode, and forwards subsequent writes directly. JSON cleanup is skipped for streaming responses. 

### Related issues

Fixes #3470

### Testing

<img width="1115" height="671" alt="image" src="https://github.com/user-attachments/assets/e714a7bb-b5c1-4a0a-8a23-d3a05b4871e4" />

<img width="1331" height="729" alt="image" src="https://github.com/user-attachments/assets/3825f513-88c2-4535-9bd8-3883d1595f44" />


### Notes for reviewers

- Non-streaming endpoints are unchanged.
- A handler that streams without ever calling `Flush()` would still be buffered. All current streaming handlers flush.
- Thanks @adarsh0728 for the `Flush()`-detection suggestion.
