### PR TITLE
feat: surface OOM (and other) reasons as free-form text

### DIFF
--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -130,15 +130,7 @@ func formatContainerFailure(c corev1.ContainerStatus, reason, msg string) string
 // formatRecentRestart renders a container that recently OOM/Error-restarted but is no longer in a
 // failed state. The OOMKilled reason is inferred from exit code 137 when not explicitly set.
 func formatRecentRestart(c corev1.ContainerStatus, x *corev1.ContainerStateTerminated) string {
-	reason := x.Reason
-	if reason == "" {
-		if x.ExitCode == 137 {
-			reason = "OOMKilled"
-		} else {
-			reason = "Error"
-		}
-	}
-	return fmt.Sprintf("container %q restarted recently: %s (exit code %d)", c.Name, reason, x.ExitCode)
+	return fmt.Sprintf("container %q restarted recently: %s %s (exit code %d)", c.Name, x.Reason, x.Message, x.ExitCode)
 }
 
 func NumOfReadyPods(pods corev1.PodList) int {

--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -127,22 +127,15 @@ func formatContainerFailure(c corev1.ContainerStatus, reason, msg string) string
 	return detail
 }
 
-// formatRecentRestart renders a container that recently OOM/Error-restarted. The detail is normally
-// read from the last termination, but the current terminated state is preferred when it carries a
-// reason, and OOMKilled is given top preference wherever it appears: the runtime tags OOM
-// best-effort, so the current and last terminations can disagree (one "OOMKilled", one "Error").
+// formatRecentRestart renders a container that recently OOM/Error-restarted.
 // Reason, message and exit code are reported verbatim (no OOM is inferred); the message is included
 // only when present, since it is empty for a typical OOM kill.
 func formatRecentRestart(c corev1.ContainerStatus, x *corev1.ContainerStateTerminated) string {
-	t := x
-	if cur := c.State.Terminated; cur != nil && cur.Reason != "" && x.Reason != "OOMKilled" {
-		t = cur
+	detail := fmt.Sprintf("container %q restarted recently: %s", c.Name, x.Reason)
+	if x.Message != "" {
+		detail += " " + x.Message
 	}
-	detail := fmt.Sprintf("container %q restarted recently: %s", c.Name, t.Reason)
-	if t.Message != "" {
-		detail += " " + t.Message
-	}
-	return detail + fmt.Sprintf(" (exit code %d)", t.ExitCode)
+	return detail + fmt.Sprintf(" (exit code %d)", x.ExitCode)
 }
 
 func NumOfReadyPods(pods corev1.PodList) int {

--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -19,6 +19,7 @@ package reconciler
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	appv1 "k8s.io/api/apps/v1"
@@ -34,8 +35,8 @@ func CheckPodsStatus(pods *corev1.PodList) (healthy bool, reason string, message
 		return true, "NoPodsFound", "No Pods found", false
 	} else {
 		for _, pod := range pods.Items {
-			if podHealthy, msg, transient := isPodHealthy(&pod); !podHealthy {
-				return false, "Pod" + msg, fmt.Sprintf("Pod %s is unhealthy", pod.Name), transient
+			if podHealthy, podReason, details, transient := isPodHealthy(&pod); !podHealthy {
+				return false, "Pod" + podReason, fmt.Sprintf("Pod %s: %s", pod.Name, details), transient
 			}
 		}
 	}
@@ -46,50 +47,103 @@ func CheckPodsStatus(pods *corev1.PodList) (healthy bool, reason string, message
 // The reason of transient unhealthy status is because of the logic of checking RecentRestart,
 // which would not end up with another reconciliation when it reaches the time limit,
 // but we have to trigger it explicitly.
-func isPodHealthy(pod *corev1.Pod) (healthy bool, reason string, isTransientUnhealthy bool) {
+// When unhealthy, message carries the free-form per-container failure detail (e.g. OOMKilled,
+// ImagePullBackOff) so it can be surfaced in the PodsHealthy condition.
+func isPodHealthy(pod *corev1.Pod) (healthy bool, reason string, message string, isTransientUnhealthy bool) {
 	// Skip pods that are terminating or already completed
 	if pod.DeletionTimestamp != nil || pod.Status.Phase == corev1.PodSucceeded {
-		return true, "", false
+		return true, "", "", false
 	}
 
 	// check both container and initContainer statuses
-	healthy, reason, isTransientUnhealthy = checkContainerStatuses(pod.Status.ContainerStatuses)
+	healthy, reason, message, isTransientUnhealthy = checkContainerStatuses(pod.Status.ContainerStatuses)
 	if !healthy {
-		return healthy, reason, isTransientUnhealthy
+		return healthy, reason, message, isTransientUnhealthy
 	}
-	healthy, reason, isTransientUnhealthy = checkContainerStatuses(pod.Status.InitContainerStatuses)
+	healthy, reason, message, isTransientUnhealthy = checkContainerStatuses(pod.Status.InitContainerStatuses)
 	if !healthy {
-		return healthy, reason, isTransientUnhealthy
+		return healthy, reason, message, isTransientUnhealthy
 	}
 
-	return true, "", false
+	return true, "", "", false
 
 }
 
-func checkContainerStatuses(containers []corev1.ContainerStatus) (bool, string, bool) {
+// checkContainerStatuses inspects a set of container statuses and, when any are unhealthy,
+// returns a single short reason token (the first failing container's) plus a free-form message
+// aggregating the detail of every failed container in the set.
+func checkContainerStatuses(containers []corev1.ContainerStatus) (healthy bool, reason string, message string, transient bool) {
 	var lastRestartTime time.Time
+	var firstReason string
+	var details []string
 	for _, c := range containers {
-		if c.State.Waiting != nil && slices.Contains(dfv1.UnhealthyWaitingStatus, c.State.Waiting.Reason) {
-			return false, c.State.Waiting.Reason, false
-		}
-		if c.State.Terminated != nil && c.State.Terminated.Reason == "Error" {
-			return false, c.State.Terminated.Reason, false
-		}
-		if x := c.LastTerminationState.Terminated; x != nil && !x.FinishedAt.Time.IsZero() {
-			if lastRestartTime.IsZero() || x.FinishedAt.After(lastRestartTime) {
-				// Only check OOM or exit with Error
-				// TODO: revisit later if needed.
-				if x.ExitCode == 137 || (x.ExitCode == 143 && x.Reason == "Error") {
-					lastRestartTime = x.FinishedAt.Time
+		switch {
+		case c.State.Waiting != nil && slices.Contains(dfv1.UnhealthyWaitingStatus, c.State.Waiting.Reason):
+			if firstReason == "" {
+				firstReason = c.State.Waiting.Reason
+			}
+			details = append(details, formatContainerFailure(c, c.State.Waiting.Reason, c.State.Waiting.Message))
+		case c.State.Terminated != nil && c.State.Terminated.Reason == "Error":
+			if firstReason == "" {
+				firstReason = c.State.Terminated.Reason
+			}
+			details = append(details, formatContainerFailure(c, c.State.Terminated.Reason, c.State.Terminated.Message))
+		default:
+			if x := c.LastTerminationState.Terminated; x != nil && !x.FinishedAt.Time.IsZero() {
+				if lastRestartTime.IsZero() || x.FinishedAt.After(lastRestartTime) {
+					// Only check OOM or exit with Error
+					// TODO: revisit later if needed.
+					if x.ExitCode == 137 || (x.ExitCode == 143 && x.Reason == "Error") {
+						lastRestartTime = x.FinishedAt.Time
+					}
 				}
 			}
 		}
 	}
-	// Container restart happened in the last 2 mins
-	if !lastRestartTime.IsZero() && lastRestartTime.Add(2*time.Minute).After(time.Now()) {
-		return false, "RecentRestart", true
+	// Waiting/terminated failures take precedence and are not transient.
+	if len(details) > 0 {
+		return false, firstReason, strings.Join(details, "; "), false
 	}
-	return true, "", false
+	// Otherwise, a recent OOM/error restart on an otherwise-running container (within the last 2 mins).
+	if !lastRestartTime.IsZero() && lastRestartTime.Add(2*time.Minute).After(time.Now()) {
+		var restartDetails []string
+		for _, c := range containers {
+			if x := c.LastTerminationState.Terminated; x != nil &&
+				(x.ExitCode == 137 || (x.ExitCode == 143 && x.Reason == "Error")) {
+				restartDetails = append(restartDetails, formatRecentRestart(c, x))
+			}
+		}
+		return false, "RecentRestart", strings.Join(restartDetails, "; "), true
+	}
+	return true, "", "", false
+}
+
+// formatContainerFailure renders one failed container's detail. When the container has a previous
+// termination (e.g. a crash-looping container that was OOMKilled), that underlying cause is appended
+// so it isn't masked by the current waiting reason like CrashLoopBackOff.
+func formatContainerFailure(c corev1.ContainerStatus, reason, msg string) string {
+	detail := fmt.Sprintf("container %q %s", c.Name, reason)
+	if msg != "" {
+		detail += ": " + msg
+	}
+	if x := c.LastTerminationState.Terminated; x != nil && x.Reason != "" && x.Reason != reason {
+		detail += fmt.Sprintf(" (last termination: %s, exit code %d)", x.Reason, x.ExitCode)
+	}
+	return detail
+}
+
+// formatRecentRestart renders a container that recently OOM/Error-restarted but is no longer in a
+// failed state. The OOMKilled reason is inferred from exit code 137 when not explicitly set.
+func formatRecentRestart(c corev1.ContainerStatus, x *corev1.ContainerStateTerminated) string {
+	reason := x.Reason
+	if reason == "" {
+		if x.ExitCode == 137 {
+			reason = "OOMKilled"
+		} else {
+			reason = "Error"
+		}
+	}
+	return fmt.Sprintf("container %q restarted recently: %s (exit code %d)", c.Name, reason, x.ExitCode)
 }
 
 func NumOfReadyPods(pods corev1.PodList) int {

--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -76,6 +76,7 @@ func checkContainerStatuses(containers []corev1.ContainerStatus) (healthy bool, 
 	var lastRestartTime time.Time
 	var firstReason string
 	var details []string
+	var restartDetails []string
 	for _, c := range containers {
 		switch {
 		case c.State.Waiting != nil && slices.Contains(dfv1.UnhealthyWaitingStatus, c.State.Waiting.Reason):
@@ -90,12 +91,13 @@ func checkContainerStatuses(containers []corev1.ContainerStatus) (healthy bool, 
 			details = append(details, formatContainerFailure(c, c.State.Terminated.Reason, c.State.Terminated.Message))
 		default:
 			if x := c.LastTerminationState.Terminated; x != nil && !x.FinishedAt.Time.IsZero() {
-				if lastRestartTime.IsZero() || x.FinishedAt.After(lastRestartTime) {
-					// Only check OOM or exit with Error
-					// TODO: revisit later if needed.
-					if x.ExitCode == 137 || (x.ExitCode == 143 && x.Reason == "Error") {
+				// Only check OOM or exit with Error
+				// TODO: revisit later if needed.
+				if x.ExitCode == 137 || (x.ExitCode == 143 && x.Reason == "Error") {
+					if lastRestartTime.IsZero() || x.FinishedAt.After(lastRestartTime) {
 						lastRestartTime = x.FinishedAt.Time
 					}
+					restartDetails = append(restartDetails, formatRecentRestart(c, x))
 				}
 			}
 		}
@@ -106,13 +108,6 @@ func checkContainerStatuses(containers []corev1.ContainerStatus) (healthy bool, 
 	}
 	// Otherwise, a recent OOM/error restart on an otherwise-running container (within the last 2 mins).
 	if !lastRestartTime.IsZero() && lastRestartTime.Add(2*time.Minute).After(time.Now()) {
-		var restartDetails []string
-		for _, c := range containers {
-			if x := c.LastTerminationState.Terminated; x != nil &&
-				(x.ExitCode == 137 || (x.ExitCode == 143 && x.Reason == "Error")) {
-				restartDetails = append(restartDetails, formatRecentRestart(c, x))
-			}
-		}
 		return false, "RecentRestart", strings.Join(restartDetails, "; "), true
 	}
 	return true, "", "", false
@@ -135,15 +130,7 @@ func formatContainerFailure(c corev1.ContainerStatus, reason, msg string) string
 // formatRecentRestart renders a container that recently OOM/Error-restarted but is no longer in a
 // failed state. The OOMKilled reason is inferred from exit code 137 when not explicitly set.
 func formatRecentRestart(c corev1.ContainerStatus, x *corev1.ContainerStateTerminated) string {
-	reason := x.Reason
-	if reason == "" {
-		if x.ExitCode == 137 {
-			reason = "OOMKilled"
-		} else {
-			reason = "Error"
-		}
-	}
-	return fmt.Sprintf("container %q restarted recently: %s (exit code %d)", c.Name, reason, x.ExitCode)
+	return fmt.Sprintf("container %q restarted recently: %s (exit code %d)", c.Name, x.Message, x.ExitCode)
 }
 
 func NumOfReadyPods(pods corev1.PodList) int {

--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -127,10 +127,22 @@ func formatContainerFailure(c corev1.ContainerStatus, reason, msg string) string
 	return detail
 }
 
-// formatRecentRestart renders a container that recently OOM/Error-restarted but is no longer in a
-// failed state. The OOMKilled reason is inferred from exit code 137 when not explicitly set.
+// formatRecentRestart renders a container that recently OOM/Error-restarted. The detail is normally
+// read from the last termination, but the current terminated state is preferred when it carries a
+// reason, and OOMKilled is given top preference wherever it appears: the runtime tags OOM
+// best-effort, so the current and last terminations can disagree (one "OOMKilled", one "Error").
+// Reason, message and exit code are reported verbatim (no OOM is inferred); the message is included
+// only when present, since it is empty for a typical OOM kill.
 func formatRecentRestart(c corev1.ContainerStatus, x *corev1.ContainerStateTerminated) string {
-	return fmt.Sprintf("container %q restarted recently: %s %s (exit code %d)", c.Name, x.Reason, x.Message, x.ExitCode)
+	t := x
+	if cur := c.State.Terminated; cur != nil && cur.Reason != "" && x.Reason != "OOMKilled" {
+		t = cur
+	}
+	detail := fmt.Sprintf("container %q restarted recently: %s", c.Name, t.Reason)
+	if t.Message != "" {
+		detail += " " + t.Message
+	}
+	return detail + fmt.Sprintf(" (exit code %d)", t.ExitCode)
 }
 
 func NumOfReadyPods(pods corev1.PodList) int {

--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -130,7 +130,15 @@ func formatContainerFailure(c corev1.ContainerStatus, reason, msg string) string
 // formatRecentRestart renders a container that recently OOM/Error-restarted but is no longer in a
 // failed state. The OOMKilled reason is inferred from exit code 137 when not explicitly set.
 func formatRecentRestart(c corev1.ContainerStatus, x *corev1.ContainerStateTerminated) string {
-	return fmt.Sprintf("container %q restarted recently: %s (exit code %d)", c.Name, x.Message, x.ExitCode)
+	reason := x.Reason
+	if reason == "" {
+		if x.ExitCode == 137 {
+			reason = "OOMKilled"
+		} else {
+			reason = "Error"
+		}
+	}
+	return fmt.Sprintf("container %q restarted recently: %s (exit code %d)", c.Name, reason, x.ExitCode)
 }
 
 func NumOfReadyPods(pods corev1.PodList) int {

--- a/pkg/reconciler/util_test.go
+++ b/pkg/reconciler/util_test.go
@@ -109,6 +109,7 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 								FinishedAt: metav1.Time{
 									Time: time.Now().Add(-1 * time.Minute),
 								},
+								Reason:   "OOMKilled",
 								ExitCode: 137,
 							},
 						},
@@ -117,7 +118,7 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 			}},
 		}
 		done, reason, message, transient := CheckPodsStatus(&pods)
-		assert.Equal(t, `Pod test-pod: container "numa" restarted recently:   (exit code 137)`, message)
+		assert.Equal(t, `Pod test-pod: container "numa" restarted recently: OOMKilled (exit code 137)`, message)
 		assert.Equal(t, "PodRecentRestart", reason)
 		assert.False(t, done)
 		assert.True(t, transient)
@@ -313,9 +314,34 @@ func TestCheckPodsStatusFailureDetail(t *testing.T) {
 		assert.False(t, done)
 		assert.Equal(t, "PodRecentRestart", reason)
 		assert.True(t, transient)
-		assert.Contains(t, message, `container "numa" restarted recently: OOMKilled  (exit code 137)`)
-		assert.Contains(t, message, `container "udf" restarted recently: OOMKilled  (exit code 137)`)
+		assert.Contains(t, message, `container "numa" restarted recently: OOMKilled (exit code 137)`)
+		assert.Contains(t, message, `container "udf" restarted recently: OOMKilled (exit code 137)`)
 		assert.Contains(t, message, "; ")
+	})
+
+	t.Run("current OOMKilled termination is preferred over a generic last termination", func(t *testing.T) {
+		// Current state is OOMKilled but the last termination was tagged the generic "Error"
+		// (the runtime attributes OOM best-effort). The OOMKilled reason should win.
+		pods := corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "mvtx-0"}, Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "numa",
+						State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+							Reason: "OOMKilled", ExitCode: 137,
+						}},
+						LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+							Reason: "Error", ExitCode: 137, FinishedAt: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
+						}},
+					},
+				},
+			}},
+		}}
+		done, reason, message, transient := CheckPodsStatus(&pods)
+		assert.False(t, done)
+		assert.Equal(t, "PodRecentRestart", reason)
+		assert.True(t, transient)
+		assert.Equal(t, `Pod mvtx-0: container "numa" restarted recently: OOMKilled (exit code 137)`, message)
 	})
 }
 

--- a/pkg/reconciler/util_test.go
+++ b/pkg/reconciler/util_test.go
@@ -52,13 +52,13 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 			Items: []corev1.Pod{
 				{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}, Status: corev1.PodStatus{
 					ContainerStatuses: []corev1.ContainerStatus{
-						{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+						{Name: "numa", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
 					}},
 				},
 			},
 		}
 		done, reason, message, transient := CheckPodsStatus(&pods)
-		assert.Equal(t, "Pod test-pod is unhealthy", message)
+		assert.Equal(t, `Pod test-pod: container "numa" CrashLoopBackOff`, message)
 		assert.Equal(t, "PodCrashLoopBackOff", reason)
 		assert.False(t, done)
 		assert.False(t, transient)
@@ -102,6 +102,7 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 			{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}, Status: corev1.PodStatus{
 				ContainerStatuses: []corev1.ContainerStatus{
 					{
+						Name:  "numa",
 						State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "Running"}},
 						LastTerminationState: corev1.ContainerState{
 							Terminated: &corev1.ContainerStateTerminated{
@@ -116,7 +117,7 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 			}},
 		}
 		done, reason, message, transient := CheckPodsStatus(&pods)
-		assert.Equal(t, "Pod test-pod is unhealthy", message)
+		assert.Equal(t, `Pod test-pod: container "numa" restarted recently: OOMKilled (exit code 137)`, message)
 		assert.Equal(t, "PodRecentRestart", reason)
 		assert.False(t, done)
 		assert.True(t, transient)
@@ -157,14 +158,14 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 			{ObjectMeta: metav1.ObjectMeta{Name: "failed-pod"}, Status: corev1.PodStatus{
 				Phase: corev1.PodFailed,
 				ContainerStatuses: []corev1.ContainerStatus{
-					{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error"}}},
+					{Name: "numa", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error"}}},
 				}},
 			},
 		}}
 		done, reason, message, _ := CheckPodsStatus(&pods)
 		assert.False(t, done)
 		assert.Equal(t, "PodError", reason)
-		assert.Equal(t, "Pod failed-pod is unhealthy", message)
+		assert.Equal(t, `Pod failed-pod: container "numa" Error`, message)
 	})
 
 	t.Run("Test unhealthy pod is still detected among terminating pods", func(t *testing.T) {
@@ -177,14 +178,14 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 			},
 			{ObjectMeta: metav1.ObjectMeta{Name: "unhealthy-pod"}, Status: corev1.PodStatus{
 				ContainerStatuses: []corev1.ContainerStatus{
-					{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+					{Name: "numa", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
 				}},
 			},
 		}}
 		done, reason, message, _ := CheckPodsStatus(&pods)
 		assert.False(t, done)
 		assert.Equal(t, "PodCrashLoopBackOff", reason)
-		assert.Equal(t, "Pod unhealthy-pod is unhealthy", message)
+		assert.Equal(t, `Pod unhealthy-pod: container "numa" CrashLoopBackOff`, message)
 	})
 
 	t.Run("Test vertex status as false with failed initContainer", func(t *testing.T) {
@@ -192,20 +193,99 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 			Items: []corev1.Pod{
 				{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}, Status: corev1.PodStatus{
 					ContainerStatuses: []corev1.ContainerStatus{
-						{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "Running"}}},
+						{Name: "numa", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "Running"}}},
 					},
 					InitContainerStatuses: []corev1.ContainerStatus{
-						{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error"}}},
+						{Name: "init", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error"}}},
 					},
 				},
 				},
 			},
 		}
 		done, reason, message, transient := CheckPodsStatus(&pods)
-		assert.Equal(t, "Pod test-pod is unhealthy", message)
+		assert.Equal(t, `Pod test-pod: container "init" Error`, message)
 		assert.Equal(t, "PodError", reason)
 		assert.False(t, done)
 		assert.False(t, transient)
+	})
+}
+
+func TestCheckPodsStatusFailureDetail(t *testing.T) {
+	t.Run("OOMKilled surfaced for crash-looping container", func(t *testing.T) {
+		pods := corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "mvtx-0"}, Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "numa",
+						State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff", Message: "back-off restarting failed container"}},
+						LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+							Reason: "OOMKilled", ExitCode: 137, FinishedAt: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
+						}},
+					},
+				},
+			}},
+		}}
+		done, reason, message, transient := CheckPodsStatus(&pods)
+		assert.False(t, done)
+		assert.Equal(t, "PodCrashLoopBackOff", reason)
+		assert.Contains(t, message, `container "numa" CrashLoopBackOff`)
+		assert.Contains(t, message, "OOMKilled")
+		assert.Contains(t, message, "exit code 137")
+		assert.False(t, transient)
+	})
+
+	t.Run("ImagePullBackOff includes waiting message", func(t *testing.T) {
+		pods := corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "mvtx-0"}, Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: "udf", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff", Message: `Back-off pulling image "bad:img"`}}},
+				},
+			}},
+		}}
+		done, reason, message, _ := CheckPodsStatus(&pods)
+		assert.False(t, done)
+		assert.Equal(t, "PodImagePullBackOff", reason)
+		assert.Contains(t, message, "ImagePullBackOff")
+		assert.Contains(t, message, `Back-off pulling image "bad:img"`)
+	})
+
+	t.Run("aggregates all failed containers in a pod", func(t *testing.T) {
+		pods := corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "mvtx-0"}, Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: "udf", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}}},
+					{Name: "numa", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+				},
+			}},
+		}}
+		done, reason, message, _ := CheckPodsStatus(&pods)
+		assert.False(t, done)
+		assert.Equal(t, "PodImagePullBackOff", reason)
+		assert.Contains(t, message, `container "udf" ImagePullBackOff`)
+		assert.Contains(t, message, `container "numa" CrashLoopBackOff`)
+		assert.Contains(t, message, "; ")
+	})
+
+	t.Run("recent OOM restart surfaces OOM detail", func(t *testing.T) {
+		pods := corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "mvtx-0"}, Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "numa",
+						State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+							Reason: "OOMKilled", ExitCode: 137, FinishedAt: metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+						}},
+					},
+				},
+			}},
+		}}
+		done, reason, message, transient := CheckPodsStatus(&pods)
+		assert.False(t, done)
+		assert.Equal(t, "PodRecentRestart", reason)
+		assert.True(t, transient)
+		assert.Contains(t, message, "OOMKilled")
+		assert.Contains(t, message, "exit code 137")
 	})
 }
 

--- a/pkg/reconciler/util_test.go
+++ b/pkg/reconciler/util_test.go
@@ -117,7 +117,7 @@ func TestCheckVertexPodsStatus(t *testing.T) {
 			}},
 		}
 		done, reason, message, transient := CheckPodsStatus(&pods)
-		assert.Equal(t, `Pod test-pod: container "numa" restarted recently: OOMKilled (exit code 137)`, message)
+		assert.Equal(t, `Pod test-pod: container "numa" restarted recently:   (exit code 137)`, message)
 		assert.Equal(t, "PodRecentRestart", reason)
 		assert.False(t, done)
 		assert.True(t, transient)
@@ -313,8 +313,8 @@ func TestCheckPodsStatusFailureDetail(t *testing.T) {
 		assert.False(t, done)
 		assert.Equal(t, "PodRecentRestart", reason)
 		assert.True(t, transient)
-		assert.Contains(t, message, `container "numa" restarted recently: OOMKilled (exit code 137)`)
-		assert.Contains(t, message, `container "udf" restarted recently: OOMKilled (exit code 137)`)
+		assert.Contains(t, message, `container "numa" restarted recently: OOMKilled  (exit code 137)`)
+		assert.Contains(t, message, `container "udf" restarted recently: OOMKilled  (exit code 137)`)
 		assert.Contains(t, message, "; ")
 	})
 }

--- a/pkg/reconciler/util_test.go
+++ b/pkg/reconciler/util_test.go
@@ -318,31 +318,6 @@ func TestCheckPodsStatusFailureDetail(t *testing.T) {
 		assert.Contains(t, message, `container "udf" restarted recently: OOMKilled (exit code 137)`)
 		assert.Contains(t, message, "; ")
 	})
-
-	t.Run("current OOMKilled termination is preferred over a generic last termination", func(t *testing.T) {
-		// Current state is OOMKilled but the last termination was tagged the generic "Error"
-		// (the runtime attributes OOM best-effort). The OOMKilled reason should win.
-		pods := corev1.PodList{Items: []corev1.Pod{
-			{ObjectMeta: metav1.ObjectMeta{Name: "mvtx-0"}, Status: corev1.PodStatus{
-				ContainerStatuses: []corev1.ContainerStatus{
-					{
-						Name: "numa",
-						State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
-							Reason: "OOMKilled", ExitCode: 137,
-						}},
-						LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
-							Reason: "Error", ExitCode: 137, FinishedAt: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
-						}},
-					},
-				},
-			}},
-		}}
-		done, reason, message, transient := CheckPodsStatus(&pods)
-		assert.False(t, done)
-		assert.Equal(t, "PodRecentRestart", reason)
-		assert.True(t, transient)
-		assert.Equal(t, `Pod mvtx-0: container "numa" restarted recently: OOMKilled (exit code 137)`, message)
-	})
 }
 
 var (

--- a/pkg/reconciler/util_test.go
+++ b/pkg/reconciler/util_test.go
@@ -287,6 +287,36 @@ func TestCheckPodsStatusFailureDetail(t *testing.T) {
 		assert.Contains(t, message, "OOMKilled")
 		assert.Contains(t, message, "exit code 137")
 	})
+
+	t.Run("aggregates multiple recently-restarted containers", func(t *testing.T) {
+		pods := corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "mvtx-0"}, Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "numa",
+						State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+							Reason: "OOMKilled", ExitCode: 137, FinishedAt: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
+						}},
+					},
+					{
+						Name:  "udf",
+						State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+							Reason: "OOMKilled", ExitCode: 137, FinishedAt: metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+						}},
+					},
+				},
+			}},
+		}}
+		done, reason, message, transient := CheckPodsStatus(&pods)
+		assert.False(t, done)
+		assert.Equal(t, "PodRecentRestart", reason)
+		assert.True(t, transient)
+		assert.Contains(t, message, `container "numa" restarted recently: OOMKilled (exit code 137)`)
+		assert.Contains(t, message, `container "udf" restarted recently: OOMKilled (exit code 137)`)
+		assert.Contains(t, message, "; ")
+	})
 }
 
 var (


### PR DESCRIPTION
### What this PR does / why we need it

During Progressive Rollout when a Pipeline or MonoVertex fails, we capture its Status in the rollout’s Status so we can see later any information to why it failed. It would be very helpful to have information related to OOM, etc if that was the reason that it failed. (Also, maybe image pull failure would also be useful.)

At the Pod level, this is in the form of free-form text. If it’s not too long and we want to keep the logic simple, we could consider just taking all containers that are failed and appending the message string.

### Testing
Added unit tests for these. 

#### Testing for status change: 
Watching for status change in mvtx: [mvtxStatusCapture](https://gist.github.com/vaibhavtiwari33/72af64b8f2e29b26004e3d2b9d642edf)
Watching for status change in pod: [podStatusCapture](https://gist.github.com/vaibhavtiwari33/9a44b4a94e9b6b58a95599f646fcd51c)

### Special notes for reviewers
Anything notable for review (risk, rollout, follow-ups).

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
