### PR TITLE
fix(isbsvc): use quorum-aware health threshold for JetStream

### DIFF
--- a/pkg/reconciler/isbsvc/controller.go
+++ b/pkg/reconciler/isbsvc/controller.go
@@ -19,6 +19,7 @@ package isbsvc
 import (
 	"context"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -78,7 +79,7 @@ func (r *interStepBufferServiceReconciler) Reconcile(ctx context.Context, req ct
 	}
 	ctx = logging.WithLogger(ctx, log)
 	isbSvcCopy := isbSvc.DeepCopy()
-	reconcileErr := r.reconcile(ctx, isbSvcCopy)
+	result, reconcileErr := r.reconcile(ctx, isbSvcCopy)
 	if reconcileErr != nil {
 		log.Errorw("Reconcile error", zap.Error(reconcileErr))
 	}
@@ -104,11 +105,11 @@ func (r *interStepBufferServiceReconciler) Reconcile(ctx context.Context, req ct
 			return ctrl.Result{}, err
 		}
 	}
-	return ctrl.Result{}, reconcileErr
+	return result, reconcileErr
 }
 
 // reconcile does the real logic
-func (r *interStepBufferServiceReconciler) reconcile(ctx context.Context, isbSvc *dfv1.InterStepBufferService) error {
+func (r *interStepBufferServiceReconciler) reconcile(ctx context.Context, isbSvc *dfv1.InterStepBufferService) (ctrl.Result, error) {
 	log := logging.FromContext(ctx)
 	if !isbSvc.DeletionTimestamp.IsZero() {
 		log.Info("Deleting ISB Service")
@@ -117,14 +118,14 @@ func (r *interStepBufferServiceReconciler) reconcile(ctx context.Context, isbSvc
 			if err := installer.Uninstall(ctx, isbSvc, r.client, r.kubeClient, r.config, log, r.recorder); err != nil {
 				log.Errorw("Failed to uninstall", zap.Error(err))
 				isbSvc.Status.SetPhase(dfv1.ISBSvcPhaseDeleting, err.Error())
-				return err
+				return ctrl.Result{}, err
 			}
 			controllerutil.RemoveFinalizer(isbSvc, finalizerName)
 			controllerutil.RemoveFinalizer(isbSvc, deprecatedFinalizerName)
 			// Clean up metrics
 			_ = reconciler.ISBSvcHealth.DeleteLabelValues(isbSvc.Namespace, isbSvc.Name)
 		}
-		return nil
+		return ctrl.Result{}, nil
 	}
 	if controllerutil.ContainsFinalizer(isbSvc, deprecatedFinalizerName) { // Remove deprecated finalizer if exists
 		controllerutil.RemoveFinalizer(isbSvc, deprecatedFinalizerName)
@@ -144,9 +145,15 @@ func (r *interStepBufferServiceReconciler) reconcile(ctx context.Context, isbSvc
 	if err := validator.ValidateInterStepBufferService(isbSvc); err != nil {
 		log.Errorw("Validation failed", zap.Error(err))
 		isbSvc.Status.MarkNotConfigured("InvalidSpec", err.Error())
-		return err
+		return ctrl.Result{}, err
 	} else {
 		isbSvc.Status.MarkConfigured()
 	}
-	return installer.Install(ctx, isbSvc, r.client, r.kubeClient, r.config, log, r.recorder)
+	needsRequeue, err := installer.Install(ctx, isbSvc, r.client, r.kubeClient, r.config, log, r.recorder)
+	if needsRequeue {
+		// A pod had a recent restart; requeue to re-evaluate once the transient window expires,
+		// since no Kubernetes event will fire when the 2-minute restart window lapses.
+		return ctrl.Result{RequeueAfter: 1 * time.Minute}, err
+	}
+	return ctrl.Result{}, err
 }

--- a/pkg/reconciler/isbsvc/controller_test.go
+++ b/pkg/reconciler/isbsvc/controller_test.go
@@ -102,7 +102,7 @@ func TestReconcileJetStream(t *testing.T) {
 			logger:     zaptest.NewLogger(t).Sugar(),
 			recorder:   record.NewFakeRecorder(64),
 		}
-		err := r.reconcile(ctx, testIsb)
+		_, err := r.reconcile(ctx, testIsb)
 		assert.NoError(t, err)
 		testIsb.Status.MarkChildrenResourceHealthy("RolloutFinished", "All service healthy")
 		assert.True(t, testIsb.Status.IsHealthy())

--- a/pkg/reconciler/isbsvc/installer/installer.go
+++ b/pkg/reconciler/isbsvc/installer/installer.go
@@ -35,29 +35,35 @@ type Installer interface {
 	// Uninstall only needs to handle those resources not cascade deleted.
 	// For example, undeleted PVCs not automatically deleted when deleting a StatefulSet
 	Uninstall(ctx context.Context) error
-	// CheckChildrenResourceStatus checks the status of the resources created by the ISB Service
-	CheckChildrenResourceStatus(ctx context.Context) error
+	// CheckChildrenResourceStatus checks the status of the resources created by the ISB Service.
+	// Returns (needsRequeue, error): needsRequeue is true when the unhealthy state is transient
+	// (e.g. a pod had a recent restart) and the controller must explicitly requeue to re-evaluate
+	// once the transient window expires, since no Kubernetes event will trigger it.
+	CheckChildrenResourceStatus(ctx context.Context) (bool, error)
 }
 
-// Install function installs the ISB Service
-func Install(ctx context.Context, isbSvc *dfv1.InterStepBufferService, client client.Client, kubeClient kubernetes.Interface, config *reconciler.GlobalConfig, logger *zap.SugaredLogger, recorder record.EventRecorder) error {
+// Install installs the ISB Service and checks child resource status.
+// Returns (needsRequeue, error): needsRequeue mirrors CheckChildrenResourceStatus's signal
+// for transient pod failures that require an explicit requeue.
+func Install(ctx context.Context, isbSvc *dfv1.InterStepBufferService, client client.Client, kubeClient kubernetes.Interface, config *reconciler.GlobalConfig, logger *zap.SugaredLogger, recorder record.EventRecorder) (bool, error) {
 	installer, err := getInstaller(isbSvc, client, kubeClient, config, logger, recorder)
 	if err != nil {
 		logger.Errorw("failed to get an installer", zap.Error(err))
-		return err
+		return false, err
 	}
 	bufferConfig, err := installer.Install(ctx)
 	if err != nil {
 		logger.Errorw("installation error", zap.Error(err))
-		return err
+		return false, err
 	}
-	if err := installer.CheckChildrenResourceStatus(ctx); err != nil {
+	needsRequeue, err := installer.CheckChildrenResourceStatus(ctx)
+	if err != nil {
 		logger.Errorw("failed to check children resource status", zap.Error(err))
-		return err
+		return false, err
 	}
 	isbSvc.Status.Config = *bufferConfig
 
-	return nil
+	return needsRequeue, nil
 }
 
 // GetInstaller returns Installer implementation

--- a/pkg/reconciler/isbsvc/installer/installer_test.go
+++ b/pkg/reconciler/isbsvc/installer/installer_test.go
@@ -106,14 +106,14 @@ func TestInstall(t *testing.T) {
 	t.Run("test jetstream error", func(t *testing.T) {
 		testObj := testJetStreamIsbSvc.DeepCopy()
 		testObj.Spec.JetStream = nil
-		err := Install(ctx, testObj, cl, kubeClient, fakeConfig, zaptest.NewLogger(t).Sugar(), record.NewFakeRecorder(64))
+		_, err := Install(ctx, testObj, cl, kubeClient, fakeConfig, zaptest.NewLogger(t).Sugar(), record.NewFakeRecorder(64))
 		assert.Error(t, err)
 		assert.Equal(t, "invalid isb service spec", err.Error())
 	})
 
 	t.Run("test jetstream install ok", func(t *testing.T) {
 		testObj := testJetStreamIsbSvc.DeepCopy()
-		err := Install(ctx, testObj, cl, kubeClient, fakeConfig, zaptest.NewLogger(t).Sugar(), record.NewFakeRecorder(64))
+		_, err := Install(ctx, testObj, cl, kubeClient, fakeConfig, zaptest.NewLogger(t).Sugar(), record.NewFakeRecorder(64))
 		assert.NoError(t, err)
 		testObj.Status.MarkChildrenResourceHealthy("RolloutFinished", "partitioned roll out complete: 3 new pods have been updated...")
 		assert.True(t, testObj.Status.IsReady())
@@ -130,7 +130,7 @@ func TestInstall(t *testing.T) {
 	t.Run("test child resource not ready", func(t *testing.T) {
 		testObj := testJetStreamIsbSvc.DeepCopy()
 		testObj.Name = "fake-isb"
-		err := Install(ctx, testObj, cl, kubeClient, fakeConfig, zaptest.NewLogger(t).Sugar(), record.NewFakeRecorder(64))
+		_, err := Install(ctx, testObj, cl, kubeClient, fakeConfig, zaptest.NewLogger(t).Sugar(), record.NewFakeRecorder(64))
 		assert.NoError(t, err)
 		testObj.Status.MarkChildrenResourceUnHealthy("reason", "message")
 		assert.False(t, testObj.Status.IsReady())

--- a/pkg/reconciler/isbsvc/installer/jetstream.go
+++ b/pkg/reconciler/isbsvc/installer/jetstream.go
@@ -557,6 +557,10 @@ func (r *jetStreamInstaller) getPVCs(ctx context.Context) ([]corev1.PersistentVo
 	return pvcl.Items, nil
 }
 
+// CheckChildrenResourceStatus evaluates the JetStream StatefulSet and pod health.
+// Returns (needsRequeue, error): needsRequeue is true when the failure is transient
+// (a pod had a recent OOM or error restart) and the controller must explicitly requeue,
+// since no Kubernetes event fires when the 2-minute transient window expires.
 func (r *jetStreamInstaller) CheckChildrenResourceStatus(ctx context.Context) (bool, error) {
 	var isbStatefulSet appv1.StatefulSet
 	if err := r.client.Get(ctx, client.ObjectKey{

--- a/pkg/reconciler/isbsvc/installer/jetstream.go
+++ b/pkg/reconciler/isbsvc/installer/jetstream.go
@@ -575,11 +575,29 @@ func (r *jetStreamInstaller) CheckChildrenResourceStatus(ctx context.Context) er
 	// the ISBSvc unhealthy when the cluster can still serve writes (e.g. during a rolling node upgrade).
 	// Single-replica ISBSvc (replicas==1) keeps all-or-nothing semantics: quorum evaluates to 1.
 	quorum := int32(r.isbSvc.Spec.JetStream.GetReplicas()/2 + 1)
-	if status, reason, msg := reconciler.CheckStatefulSetStatus(&isbStatefulSet, quorum); status {
-		r.isbSvc.Status.MarkChildrenResourceHealthy(reason, msg)
-	} else {
+	if status, reason, msg := reconciler.CheckStatefulSetStatus(&isbStatefulSet, quorum); !status {
 		r.isbSvc.Status.MarkChildrenResourceUnHealthy(reason, msg)
+		return nil
 	}
+	// Quorum is met, but individual pods may be in a persistent failure state
+	// (CrashLoopBackOff, ImagePullBackOff, OOMKill) that will never self-resolve.
+	// Terminating pods from a node eviction are skipped by CheckPodsStatus, so this
+	// check distinguishes transient unavailability from permanent pod failures.
+	// Limitation: a pod stuck in Pending (e.g. unschedulable) is not detected here;
+	// a follow-up time-based escalation would be needed to catch that case.
+	podList := &corev1.PodList{}
+	if err := r.client.List(ctx, podList, &client.ListOptions{
+		Namespace:     r.isbSvc.Namespace,
+		LabelSelector: labels.SelectorFromSet(r.labels),
+	}); err != nil {
+		r.isbSvc.Status.MarkChildrenResourceUnHealthy("ListPodsFailed", err.Error())
+		return err
+	}
+	if healthy, reason, msg, _ := reconciler.CheckPodsStatus(podList); !healthy {
+		r.isbSvc.Status.MarkChildrenResourceUnHealthy(reason, msg)
+		return nil
+	}
+	r.isbSvc.Status.MarkChildrenResourceHealthy("Healthy", "JetStream cluster is healthy")
 	return nil
 }
 

--- a/pkg/reconciler/isbsvc/installer/jetstream.go
+++ b/pkg/reconciler/isbsvc/installer/jetstream.go
@@ -557,7 +557,7 @@ func (r *jetStreamInstaller) getPVCs(ctx context.Context) ([]corev1.PersistentVo
 	return pvcl.Items, nil
 }
 
-func (r *jetStreamInstaller) CheckChildrenResourceStatus(ctx context.Context) error {
+func (r *jetStreamInstaller) CheckChildrenResourceStatus(ctx context.Context) (bool, error) {
 	var isbStatefulSet appv1.StatefulSet
 	if err := r.client.Get(ctx, client.ObjectKey{
 		Namespace: r.isbSvc.Namespace,
@@ -566,10 +566,10 @@ func (r *jetStreamInstaller) CheckChildrenResourceStatus(ctx context.Context) er
 		if apierrors.IsNotFound(err) {
 			r.isbSvc.Status.MarkChildrenResourceUnHealthy("GetStatefulSetFailed",
 				"StatefulSet not found, might be still under creation")
-			return nil
+			return false, nil
 		}
 		r.isbSvc.Status.MarkChildrenResourceUnHealthy("GetStatefulSetFailed", err.Error())
-		return err
+		return false, err
 	}
 	// NATS JetStream maintains quorum at ⌊replicas/2⌋+1. A single missing pod must not mark
 	// the ISBSvc unhealthy when the cluster can still serve writes (e.g. during a rolling node upgrade).
@@ -577,7 +577,7 @@ func (r *jetStreamInstaller) CheckChildrenResourceStatus(ctx context.Context) er
 	quorum := int32(r.isbSvc.Spec.JetStream.GetReplicas()/2 + 1)
 	if status, reason, msg := reconciler.CheckStatefulSetStatus(&isbStatefulSet, quorum); !status {
 		r.isbSvc.Status.MarkChildrenResourceUnHealthy(reason, msg)
-		return nil
+		return false, nil
 	}
 	// Quorum is met, but individual pods may be in a persistent failure state
 	// (CrashLoopBackOff, ImagePullBackOff, OOMKill) that will never self-resolve.
@@ -591,14 +591,16 @@ func (r *jetStreamInstaller) CheckChildrenResourceStatus(ctx context.Context) er
 		LabelSelector: labels.SelectorFromSet(r.labels),
 	}); err != nil {
 		r.isbSvc.Status.MarkChildrenResourceUnHealthy("ListPodsFailed", err.Error())
-		return err
+		return false, err
 	}
-	if healthy, reason, msg, _ := reconciler.CheckPodsStatus(podList); !healthy {
+	if healthy, reason, msg, transientUnhealthy := reconciler.CheckPodsStatus(podList); !healthy {
 		r.isbSvc.Status.MarkChildrenResourceUnHealthy(reason, msg)
-		return nil
+		// transientUnhealthy means the pod had a recent restart (OOM/error exit within 2 minutes)
+		// and may stabilise without a Kubernetes event to trigger re-reconciliation.
+		return transientUnhealthy, nil
 	}
 	r.isbSvc.Status.MarkChildrenResourceHealthy("Healthy", "JetStream cluster is healthy")
-	return nil
+	return false, nil
 }
 
 func generateJetStreamServerSecretName(isbSvc *dfv1.InterStepBufferService) string {

--- a/pkg/reconciler/isbsvc/installer/jetstream.go
+++ b/pkg/reconciler/isbsvc/installer/jetstream.go
@@ -571,8 +571,11 @@ func (r *jetStreamInstaller) CheckChildrenResourceStatus(ctx context.Context) er
 		r.isbSvc.Status.MarkChildrenResourceUnHealthy("GetStatefulSetFailed", err.Error())
 		return err
 	}
-	// calculate the status of the InterStepBufferService by statefulset status and update the status of isbSvc
-	if status, reason, msg := reconciler.CheckStatefulSetStatus(&isbStatefulSet); status {
+	// NATS JetStream maintains quorum at ⌊replicas/2⌋+1. A single missing pod must not mark
+	// the ISBSvc unhealthy when the cluster can still serve writes (e.g. during a rolling node upgrade).
+	// Single-replica ISBSvc (replicas==1) keeps all-or-nothing semantics: quorum evaluates to 1.
+	quorum := int32(r.isbSvc.Spec.JetStream.GetReplicas()/2 + 1)
+	if status, reason, msg := reconciler.CheckStatefulSetStatus(&isbStatefulSet, quorum); status {
 		r.isbSvc.Status.MarkChildrenResourceHealthy(reason, msg)
 	} else {
 		r.isbSvc.Status.MarkChildrenResourceUnHealthy(reason, msg)

--- a/pkg/reconciler/isbsvc/installer/jetstream_test.go
+++ b/pkg/reconciler/isbsvc/installer/jetstream_test.go
@@ -260,8 +260,9 @@ func TestCheckChildrenResourceStatusQuorum(t *testing.T) {
 			logger:     zaptest.NewLogger(t).Sugar(),
 			recorder:   record.NewFakeRecorder(64),
 		}
-		err := i.CheckChildrenResourceStatus(ctx)
+		needsRequeue, err := i.CheckChildrenResourceStatus(ctx)
 		assert.NoError(t, err)
+		assert.False(t, needsRequeue)
 		assert.True(t, childrenHealthy(isbSvc), "2/3 ready with no pod errors should be healthy at quorum=2")
 	})
 
@@ -279,8 +280,9 @@ func TestCheckChildrenResourceStatusQuorum(t *testing.T) {
 			logger:     zaptest.NewLogger(t).Sugar(),
 			recorder:   record.NewFakeRecorder(64),
 		}
-		err := i.CheckChildrenResourceStatus(ctx)
+		needsRequeue, err := i.CheckChildrenResourceStatus(ctx)
 		assert.NoError(t, err)
+		assert.False(t, needsRequeue)
 		assert.False(t, childrenHealthy(isbSvc), "1/3 ready should be unhealthy below quorum=2")
 	})
 
@@ -298,9 +300,49 @@ func TestCheckChildrenResourceStatusQuorum(t *testing.T) {
 			logger:     zaptest.NewLogger(t).Sugar(),
 			recorder:   record.NewFakeRecorder(64),
 		}
-		err := i.CheckChildrenResourceStatus(ctx)
+		needsRequeue, err := i.CheckChildrenResourceStatus(ctx)
 		assert.NoError(t, err)
+		assert.False(t, needsRequeue, "CrashLoopBackOff is not transient — no requeue needed")
 		assert.False(t, childrenHealthy(isbSvc), "quorum met but CrashLoopBackOff pod should be unhealthy")
+	})
+
+	t.Run("unhealthy with recent-restart pod (transient — needs requeue)", func(t *testing.T) {
+		sts := baseSts.DeepCopy()
+		sts.Status.ReadyReplicas = 3
+		isbSvc := testJetStreamIsbSvc.DeepCopy()
+		recentRestart := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-2-restarting",
+				Namespace: testJetStreamIsbSvc.Namespace,
+				Labels:    testLabels,
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						LastTerminationState: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode:   137,
+								FinishedAt: metav1.Now(),
+							},
+						},
+					},
+				},
+			},
+		}
+		cl := fake.NewClientBuilder().WithObjects(sts, healthyPod("pod-0"), healthyPod("pod-1"), recentRestart).Build()
+		i := &jetStreamInstaller{
+			client:     cl,
+			kubeClient: k8sfake.NewSimpleClientset(),
+			isbSvc:     isbSvc,
+			config:     reconciler.FakeGlobalConfig(t, fakeGlobalISBSvcConfig),
+			labels:     testLabels,
+			logger:     zaptest.NewLogger(t).Sugar(),
+			recorder:   record.NewFakeRecorder(64),
+		}
+		needsRequeue, err := i.CheckChildrenResourceStatus(ctx)
+		assert.NoError(t, err)
+		assert.True(t, needsRequeue, "recent OOM restart is transient — controller must requeue")
+		assert.False(t, childrenHealthy(isbSvc), "recent OOM restart should still be unhealthy")
 	})
 }
 

--- a/pkg/reconciler/isbsvc/installer/jetstream_test.go
+++ b/pkg/reconciler/isbsvc/installer/jetstream_test.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap/zaptest"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -212,16 +213,44 @@ func TestCheckChildrenResourceStatusQuorum(t *testing.T) {
 	}
 	baseSts.Name = stsName
 
+	healthyPod := func(name string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testJetStreamIsbSvc.Namespace,
+				Labels:    testLabels,
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		}
+	}
+
+	crashingPod := func(name string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testJetStreamIsbSvc.Namespace,
+				Labels:    testLabels,
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+					}},
+				},
+			},
+		}
+	}
+
 	childrenHealthy := func(isbSvc *dfv1.InterStepBufferService) bool {
 		c := isbSvc.Status.GetCondition(dfv1.ISBSvcConditionChildrenResourcesHealthy)
 		return c != nil && c.Status == "True"
 	}
 
-	t.Run("healthy at quorum (2/3 ready)", func(t *testing.T) {
+	t.Run("healthy at quorum (2/3 ready, no pod errors)", func(t *testing.T) {
 		sts := baseSts.DeepCopy()
 		sts.Status.ReadyReplicas = 2
 		isbSvc := testJetStreamIsbSvc.DeepCopy()
-		cl := fake.NewClientBuilder().WithObjects(sts).Build()
+		cl := fake.NewClientBuilder().WithObjects(sts, healthyPod("pod-0"), healthyPod("pod-1")).Build()
 		i := &jetStreamInstaller{
 			client:     cl,
 			kubeClient: k8sfake.NewSimpleClientset(),
@@ -233,7 +262,7 @@ func TestCheckChildrenResourceStatusQuorum(t *testing.T) {
 		}
 		err := i.CheckChildrenResourceStatus(ctx)
 		assert.NoError(t, err)
-		assert.True(t, childrenHealthy(isbSvc), "2/3 ready should be healthy at quorum=2")
+		assert.True(t, childrenHealthy(isbSvc), "2/3 ready with no pod errors should be healthy at quorum=2")
 	})
 
 	t.Run("unhealthy below quorum (1/3 ready)", func(t *testing.T) {
@@ -253,6 +282,25 @@ func TestCheckChildrenResourceStatusQuorum(t *testing.T) {
 		err := i.CheckChildrenResourceStatus(ctx)
 		assert.NoError(t, err)
 		assert.False(t, childrenHealthy(isbSvc), "1/3 ready should be unhealthy below quorum=2")
+	})
+
+	t.Run("unhealthy at quorum with CrashLoopBackOff pod (persistent failure)", func(t *testing.T) {
+		sts := baseSts.DeepCopy()
+		sts.Status.ReadyReplicas = 2
+		isbSvc := testJetStreamIsbSvc.DeepCopy()
+		cl := fake.NewClientBuilder().WithObjects(sts, healthyPod("pod-0"), healthyPod("pod-1"), crashingPod("pod-2")).Build()
+		i := &jetStreamInstaller{
+			client:     cl,
+			kubeClient: k8sfake.NewSimpleClientset(),
+			isbSvc:     isbSvc,
+			config:     reconciler.FakeGlobalConfig(t, fakeGlobalISBSvcConfig),
+			labels:     testLabels,
+			logger:     zaptest.NewLogger(t).Sugar(),
+			recorder:   record.NewFakeRecorder(64),
+		}
+		err := i.CheckChildrenResourceStatus(ctx)
+		assert.NoError(t, err)
+		assert.False(t, childrenHealthy(isbSvc), "quorum met but CrashLoopBackOff pod should be unhealthy")
 	})
 }
 

--- a/pkg/reconciler/isbsvc/installer/jetstream_test.go
+++ b/pkg/reconciler/isbsvc/installer/jetstream_test.go
@@ -193,6 +193,69 @@ func Test_JetStreamInstall_Uninstall(t *testing.T) {
 	})
 }
 
+func TestCheckChildrenResourceStatusQuorum(t *testing.T) {
+	ctx := context.TODO()
+	stsName := generateJetStreamStatefulSetName(testJetStreamIsbSvc)
+	replicas := int32(3)
+	baseSts := &appv1.StatefulSet{
+		ObjectMeta: testJetStreamIsbSvc.ObjectMeta,
+		Spec: appv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appv1.StatefulSetStatus{
+			ObservedGeneration: 1,
+			CurrentRevision:    "rev-1",
+			UpdateRevision:     "rev-1",
+			CurrentReplicas:    3,
+			Replicas:           3,
+		},
+	}
+	baseSts.Name = stsName
+
+	childrenHealthy := func(isbSvc *dfv1.InterStepBufferService) bool {
+		c := isbSvc.Status.GetCondition(dfv1.ISBSvcConditionChildrenResourcesHealthy)
+		return c != nil && c.Status == "True"
+	}
+
+	t.Run("healthy at quorum (2/3 ready)", func(t *testing.T) {
+		sts := baseSts.DeepCopy()
+		sts.Status.ReadyReplicas = 2
+		isbSvc := testJetStreamIsbSvc.DeepCopy()
+		cl := fake.NewClientBuilder().WithObjects(sts).Build()
+		i := &jetStreamInstaller{
+			client:     cl,
+			kubeClient: k8sfake.NewSimpleClientset(),
+			isbSvc:     isbSvc,
+			config:     reconciler.FakeGlobalConfig(t, fakeGlobalISBSvcConfig),
+			labels:     testLabels,
+			logger:     zaptest.NewLogger(t).Sugar(),
+			recorder:   record.NewFakeRecorder(64),
+		}
+		err := i.CheckChildrenResourceStatus(ctx)
+		assert.NoError(t, err)
+		assert.True(t, childrenHealthy(isbSvc), "2/3 ready should be healthy at quorum=2")
+	})
+
+	t.Run("unhealthy below quorum (1/3 ready)", func(t *testing.T) {
+		sts := baseSts.DeepCopy()
+		sts.Status.ReadyReplicas = 1
+		isbSvc := testJetStreamIsbSvc.DeepCopy()
+		cl := fake.NewClientBuilder().WithObjects(sts).Build()
+		i := &jetStreamInstaller{
+			client:     cl,
+			kubeClient: k8sfake.NewSimpleClientset(),
+			isbSvc:     isbSvc,
+			config:     reconciler.FakeGlobalConfig(t, fakeGlobalISBSvcConfig),
+			labels:     testLabels,
+			logger:     zaptest.NewLogger(t).Sugar(),
+			recorder:   record.NewFakeRecorder(64),
+		}
+		err := i.CheckChildrenResourceStatus(ctx)
+		assert.NoError(t, err)
+		assert.False(t, childrenHealthy(isbSvc), "1/3 ready should be unhealthy below quorum=2")
+	})
+}
+
 func getEvents(recorder record.EventRecorder) []string {
 	c := recorder.(*record.FakeRecorder).Events
 	close(c)

--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -183,7 +183,7 @@ func CheckStatefulSetStatus(sts *appv1.StatefulSet, minReadyReplicas int32) (don
 		return false, "Progressing", fmt.Sprintf("waiting for statefulset rolling update to complete %d pods at revision %s...",
 			sts.Status.UpdatedReplicas, sts.Status.UpdateRevision)
 	}
-	if sts.Spec.Replicas != nil && sts.Status.ReadyReplicas < minReadyReplicas {
+	if sts.Status.ReadyReplicas < minReadyReplicas {
 		return false, "Unavailable", fmt.Sprintf("Waiting for %d pods to be ready...\n", minReadyReplicas-sts.Status.ReadyReplicas)
 	}
 	if sts.Spec.UpdateStrategy.Type == appv1.RollingUpdateStatefulSetStrategyType && sts.Spec.UpdateStrategy.RollingUpdate != nil {

--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -173,8 +173,9 @@ func getDeploymentCondition(status appv1.DeploymentStatus, condType appv1.Deploy
 }
 
 // CheckStatefulSetStatus returns a message describing statefulset status, and a bool value indicating if the status is considered done.
+// minReadyReplicas controls the readiness threshold: pass the desired replica count for all-or-nothing semantics, or ⌊replicas/2⌋+1 for quorum-based semantics (e.g. NATS JetStream).
 // Borrowed at kubernetes/kubectl/rollout_status.go https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollout_status.go#L130
-func CheckStatefulSetStatus(sts *appv1.StatefulSet) (done bool, reason string, message string) {
+func CheckStatefulSetStatus(sts *appv1.StatefulSet, minReadyReplicas int32) (done bool, reason string, message string) {
 	if sts.Status.ObservedGeneration == 0 || sts.Generation > sts.Status.ObservedGeneration {
 		return false, "Progressing", "Waiting for statefulset spec update to be observed..."
 	}
@@ -182,8 +183,8 @@ func CheckStatefulSetStatus(sts *appv1.StatefulSet) (done bool, reason string, m
 		return false, "Progressing", fmt.Sprintf("waiting for statefulset rolling update to complete %d pods at revision %s...",
 			sts.Status.UpdatedReplicas, sts.Status.UpdateRevision)
 	}
-	if sts.Spec.Replicas != nil && sts.Status.ReadyReplicas < *sts.Spec.Replicas {
-		return false, "Unavailable", fmt.Sprintf("Waiting for %d pods to be ready...\n", *sts.Spec.Replicas-sts.Status.ReadyReplicas)
+	if sts.Spec.Replicas != nil && sts.Status.ReadyReplicas < minReadyReplicas {
+		return false, "Unavailable", fmt.Sprintf("Waiting for %d pods to be ready...\n", minReadyReplicas-sts.Status.ReadyReplicas)
 	}
 	if sts.Spec.UpdateStrategy.Type == appv1.RollingUpdateStatefulSetStrategyType && sts.Spec.UpdateStrategy.RollingUpdate != nil {
 		if sts.Spec.Replicas != nil && sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {

--- a/pkg/reconciler/util_test.go
+++ b/pkg/reconciler/util_test.go
@@ -370,7 +370,7 @@ var (
 func TestGetStatefulSetStatus(t *testing.T) {
 	t.Run("Test statefulset status as true", func(t *testing.T) {
 		testSts := statefulSet.DeepCopy()
-		status, reason, msg := CheckStatefulSetStatus(testSts)
+		status, reason, msg := CheckStatefulSetStatus(testSts, 3)
 		assert.Equal(t, "Healthy", reason)
 		assert.True(t, status)
 		assert.Equal(t, "statefulset rolling update complete 3 pods at revision isbsvc-default-js-597b7f74d7...\n", msg)
@@ -379,7 +379,7 @@ func TestGetStatefulSetStatus(t *testing.T) {
 	t.Run("Test statefulset status as false", func(t *testing.T) {
 		testSts := statefulSet.DeepCopy()
 		testSts.Status.UpdateRevision = "isbsvc-default-js-597b7f73a1"
-		status, reason, msg := CheckStatefulSetStatus(testSts)
+		status, reason, msg := CheckStatefulSetStatus(testSts, 3)
 		assert.Equal(t, "Progressing", reason)
 		assert.False(t, status)
 		assert.Equal(t, "waiting for statefulset rolling update to complete 3 pods at revision isbsvc-default-js-597b7f73a1...", msg)
@@ -388,10 +388,46 @@ func TestGetStatefulSetStatus(t *testing.T) {
 	t.Run("Test statefulset with ObservedGeneration as zero", func(t *testing.T) {
 		testSts := statefulSet.DeepCopy()
 		testSts.Status.ObservedGeneration = 0
-		status, reason, msg := CheckStatefulSetStatus(testSts)
+		status, reason, msg := CheckStatefulSetStatus(testSts, 3)
 		assert.Equal(t, "Progressing", reason)
 		assert.False(t, status)
 		assert.Equal(t, "Waiting for statefulset spec update to be observed...", msg)
+	})
+
+	t.Run("Test 3-replica statefulset healthy at quorum (2/3 ready)", func(t *testing.T) {
+		replicas := int32(3)
+		testSts := statefulSet.DeepCopy()
+		testSts.Spec.Replicas = &replicas
+		testSts.Status.ReadyReplicas = 2
+		// quorum = ⌊3/2⌋+1 = 2
+		status, reason, msg := CheckStatefulSetStatus(testSts, 2)
+		assert.True(t, status)
+		assert.Equal(t, "Healthy", reason)
+		assert.Contains(t, msg, "statefulset rolling update complete")
+	})
+
+	t.Run("Test 3-replica statefulset unhealthy below quorum (1/3 ready)", func(t *testing.T) {
+		replicas := int32(3)
+		testSts := statefulSet.DeepCopy()
+		testSts.Spec.Replicas = &replicas
+		testSts.Status.ReadyReplicas = 1
+		// quorum = ⌊3/2⌋+1 = 2; 1 ready < 2 quorum → unhealthy
+		status, reason, msg := CheckStatefulSetStatus(testSts, 2)
+		assert.False(t, status)
+		assert.Equal(t, "Unavailable", reason)
+		assert.Contains(t, msg, "Waiting for 1 pods to be ready")
+	})
+
+	t.Run("Test 1-replica statefulset all-or-nothing (0/1 ready)", func(t *testing.T) {
+		replicas := int32(1)
+		testSts := statefulSet.DeepCopy()
+		testSts.Spec.Replicas = &replicas
+		testSts.Status.ReadyReplicas = 0
+		// quorum = ⌊1/2⌋+1 = 1; single replica must be ready
+		status, reason, msg := CheckStatefulSetStatus(testSts, 1)
+		assert.False(t, status)
+		assert.Equal(t, "Unavailable", reason)
+		assert.Contains(t, msg, "Waiting for 1 pods to be ready")
 	})
 }
 


### PR DESCRIPTION
### What this PR does / why we need it

ISBSvc health reporting was comparing ready pod count against the full replica count, so a 3-replica JetStream cluster would be marked unhealthy whenever a single pod was temporarily unavailable (e.g. during a GKE rolling node upgrade). NATS JetStream only needs ⌊replicas/2⌋+1 pods for write quorum, so this caused spurious `ReconcileFixedResourcesFailed` conditions on all dependent pipelines. This PR makes the health threshold quorum-aware: a cluster is healthy as long as enough pods are up to maintain quorum. Single-replica ISBSvc instances retain all-or-nothing semantics since their quorum evaluates to 1.

### Related issues

Fixes #

### Testing

- Unit tests added for `CheckStatefulSetStatus` covering 3-replica quorum boundary (2/3 healthy, 1/3 unhealthy) and 1-replica all-or-nothing semantics.
- Integration tests added for `CheckChildrenResourceStatus` on the `jetStreamInstaller` verifying the full reconciler path marks the ISBSvc healthy at quorum and unhealthy below quorum.

### Special notes for reviewers

`CheckStatefulSetStatus` now takes a `minReadyReplicas int32` parameter. The existing call sites that needed all-or-nothing semantics (passing the full replica count) retain that behaviour unchanged. Only the JetStream ISBSvc installer passes a quorum value. If other StatefulSet-backed components warrant quorum-aware checks in future, the same parameter is available.