### PR TITLE
fix: return detailed vertex status message when unhealthy

### DIFF
--- a/pkg/reconciler/util.go
+++ b/pkg/reconciler/util.go
@@ -172,6 +172,9 @@ func CheckVertexStatus(vertices *dfv1.VertexList) (healthy bool, reason string, 
 			return false, "Progressing", `Vertex "` + vertex.Spec.Name + `" Waiting for reconciliation`
 		}
 		if !vertex.Status.IsHealthy() {
+			if vertex.Status.Message != "" {
+				return false, "Unavailable", `Vertex "` + vertex.Spec.Name + `" error: ` + vertex.Status.Message
+			}
 			return false, "Unavailable", `Vertex "` + vertex.Spec.Name + `" is not healthy`
 		}
 	}

--- a/pkg/reconciler/util_test.go
+++ b/pkg/reconciler/util_test.go
@@ -457,6 +457,40 @@ func TestGetVertexStatus(t *testing.T) {
 		assert.Equal(t, "Unavailable", reason)
 		assert.Equal(t, `Vertex "test-vertex" is not healthy`, message)
 	})
+	t.Run("Test Vertex status returns detailed message", func(t *testing.T) {
+		vertices := dfv1.VertexList{
+			Items: []dfv1.Vertex{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 2,
+					},
+					Spec: dfv1.VertexSpec{
+						AbstractVertex: dfv1.AbstractVertex{
+							Name: "test-vertex",
+						},
+					},
+					Status: dfv1.VertexStatus{
+						Phase:              "Pending",
+						ObservedGeneration: 2,
+						Message:            "failed to connect to source",
+					},
+				},
+			},
+		}
+
+		vertices.Items[0].Status.Conditions = []metav1.Condition{
+			{
+				Type:   string(dfv1.VertexConditionPodsHealthy),
+				Status: metav1.ConditionTrue,
+			},
+		}
+
+		status, reason, message := CheckVertexStatus(&vertices)
+
+		assert.False(t, status)
+		assert.Equal(t, "Unavailable", reason)
+		assert.Equal(t, `Vertex "test-vertex" error: failed to connect to source`, message)
+	})
 }
 
 var (


### PR DESCRIPTION
### What this PR does / why we need it

When a vertex is unhealthy, `CheckVertexStatus` currently returns a generic message:

> `Vertex "<name>" is not healthy`

This hides the more detailed diagnostic information already available in `vertex.Status.Message`.

This PR updates `CheckVertexStatus` to return `vertex.Status.Message` when it is available, while preserving the existing generic fallback message when no detailed status message exists.

Additionally, a unit test has been added to verify the new behavior without changing the existing fallback behavior.

### Related issues

Fixes #3496

### Testing

- Added a unit test covering the detailed status message behavior.
- Existing fallback behavior remains covered by the current tests.
- Ran:

```bash
gofmt -w pkg/reconciler/util.go pkg/reconciler/util_test.go
go test ./pkg/reconciler/...