### PR TITLE
fix(UI): dynamic monovertex dimension for cleaner UI

### DIFF
--- a/ui/src/components/pages/Pipeline/partials/Graph/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/index.tsx
@@ -85,12 +85,17 @@ const nodeWidth = 252;
 const nodeHeight = 72;
 const nodeHeightTall = 112;
 const graphDirection = "LR";
+const NODE_DATA_TYPES = {
+  MONO_VERTEX: "monoVertex",
+  MONO_VERTEX_INTERNAL: "monoVertexInternal",
+} as const;
 
 const getNodeLayoutWidth = (node: Node): number => {
   const d = node?.data as Record<string, any> | undefined;
-  if (d?.type === "monoVertex")
+  if (d?.type === NODE_DATA_TYPES.MONO_VERTEX)
     return d.containerWidth ?? MONO_VERTEX_MAX_CONTAINER_WIDTH;
-  if (d?.type === "monoVertexInternal") return MONO_VERTEX_INTERNAL_NODE_WIDTH;
+  if (d?.type === NODE_DATA_TYPES.MONO_VERTEX_INTERNAL)
+    return MONO_VERTEX_INTERNAL_NODE_WIDTH;
   return nodeWidth;
 };
 
@@ -98,9 +103,10 @@ const getNodeLayoutHeight = (node: Node): number => {
   const d = node?.data as Record<string, any> | undefined;
   if (!d) return nodeHeight;
   const nodeInfo = d.nodeInfo as Record<string, any> | undefined;
-  if (d.type === "monoVertex")
+  if (d.type === NODE_DATA_TYPES.MONO_VERTEX)
     return d.containerHeight ?? MONO_VERTEX_MAX_CONTAINER_HEIGHT;
-  if (d.type === "monoVertexInternal") return MONO_VERTEX_INTERNAL_NODE_WIDTH;
+  if (d.type === NODE_DATA_TYPES.MONO_VERTEX_INTERNAL)
+    return MONO_VERTEX_INTERNAL_NODE_WIDTH;
   if (d.type === "source" && nodeInfo?.source?.transformer) return nodeHeightTall;
   if (d.type === "sink" && (nodeInfo?.sink?.onSuccess || nodeInfo?.sink?.fallback)) return nodeHeightTall;
   return nodeHeight;
@@ -130,7 +136,7 @@ const getLayoutedElements = (
   dagreGraph.setGraph({ rankdir: direction, ranksep: 240, edgesep: 180 });
 
   nodes.forEach((node) => {
-    if (node?.data?.type === "monoVertexInternal") return;
+    if (node?.data?.type === NODE_DATA_TYPES.MONO_VERTEX_INTERNAL) return;
     const w = getNodeLayoutWidth(node);
     const h = getNodeLayoutHeight(node);
     dagreGraph.setNode(node.id, { width: w, height: h });
@@ -153,7 +159,7 @@ const getLayoutedElements = (
     if (
       node?.data?.type !== "sideInput" &&
       node?.data?.type !== "generator" &&
-      node?.data?.type !== "monoVertexInternal"
+      node?.data?.type !== NODE_DATA_TYPES.MONO_VERTEX_INTERNAL
     ) {
       const nodeWithPosition = dagreGraph.node(node.id);
       max_pos = Math.max(max_pos, nodeWithPosition.y);
@@ -161,7 +167,7 @@ const getLayoutedElements = (
   });
   let cnt = 2;
   nodes.forEach((node) => {
-    if (node?.data?.type === "monoVertexInternal") {
+    if (node?.data?.type === NODE_DATA_TYPES.MONO_VERTEX_INTERNAL) {
       node.targetPosition = isHorizontal ? Position.Left : Position.Top;
       node.sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
       return;
@@ -878,7 +884,7 @@ export default function Graph(props: GraphProps) {
 
   const handleNodeClick = useCallback(
     (event: MouseEvent | undefined, node: Node) => {
-      if (node?.data?.type === "monoVertexInternal") {
+      if (node?.data?.type === NODE_DATA_TYPES.MONO_VERTEX_INTERNAL) {
         return;
       }
       setNodeId(node.id);

--- a/ui/src/components/pages/Pipeline/partials/Graph/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/index.tsx
@@ -52,6 +52,11 @@ import {
   timeAgo,
   getBaseHref,
 } from "../../../../../utils";
+import {
+  MONO_VERTEX_INTERNAL_NODE_WIDTH,
+  MONO_VERTEX_MAX_CONTAINER_HEIGHT,
+  MONO_VERTEX_MAX_CONTAINER_WIDTH,
+} from "../../../../../utils/monoVertexGraphLayout";
 import { ErrorIndicator } from "../../../../common/ErrorIndicator";
 import { CollapseContext } from "../../../../common/SummaryPageLayout";
 import lock from "../../../../../images/lock.svg";
@@ -79,14 +84,13 @@ import "./style.css";
 const nodeWidth = 252;
 const nodeHeight = 72;
 const nodeHeightTall = 112;
-const monoVertexNodeWidth = 420;
-const monoVertexNodeHeight = 170;
 const graphDirection = "LR";
 
 const getNodeLayoutWidth = (node: Node): number => {
   const d = node?.data as Record<string, any> | undefined;
-  if (d?.type === "monoVertex") return monoVertexNodeWidth;
-  if (d?.type === "monoVertexInternal") return 32;
+  if (d?.type === "monoVertex")
+    return d.containerWidth ?? MONO_VERTEX_MAX_CONTAINER_WIDTH;
+  if (d?.type === "monoVertexInternal") return MONO_VERTEX_INTERNAL_NODE_WIDTH;
   return nodeWidth;
 };
 
@@ -94,8 +98,9 @@ const getNodeLayoutHeight = (node: Node): number => {
   const d = node?.data as Record<string, any> | undefined;
   if (!d) return nodeHeight;
   const nodeInfo = d.nodeInfo as Record<string, any> | undefined;
-  if (d.type === "monoVertex") return monoVertexNodeHeight;
-  if (d.type === "monoVertexInternal") return 32;
+  if (d.type === "monoVertex")
+    return d.containerHeight ?? MONO_VERTEX_MAX_CONTAINER_HEIGHT;
+  if (d.type === "monoVertexInternal") return MONO_VERTEX_INTERNAL_NODE_WIDTH;
   if (d.type === "source" && nodeInfo?.source?.transformer) return nodeHeightTall;
   if (d.type === "sink" && (nodeInfo?.sink?.onSuccess || nodeInfo?.sink?.fallback)) return nodeHeightTall;
   return nodeHeight;
@@ -207,7 +212,7 @@ const Flow = (props: FlowProps) => {
     type,
   } = props;
   const fitViewOptions = useMemo(
-    () => (type === "monoVertex" ? { padding: 0.25, maxZoom: 2.5 } : undefined),
+    () => (type === "monoVertex" ? { padding: 0.35, maxZoom: 1.60 } : undefined),
     [type]
   );
 

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomEdge/index.test.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomEdge/index.test.tsx
@@ -447,7 +447,7 @@ describe("Custom Edge", () => {
       );
       expect(edge).toBeInTheDocument();
       expect(edge).toHaveStyle("stroke: #8D9096");
-      expect(edge).toHaveStyle("stroke-width: 1.2");
+      expect(edge).toHaveStyle("stroke-width: 2");
       expect(edge.getAttribute("style")).not.toContain("stroke-dasharray");
     });
   });
@@ -497,12 +497,12 @@ describe("Custom Edge", () => {
       );
       expect(edge).toBeInTheDocument();
       expect(edge).toHaveStyle("stroke: var(--mono-vertex-bypass-color)");
-      expect(edge).toHaveStyle("stroke-width: 1.2");
+      expect(edge).toHaveStyle("stroke-width: 2");
       expect(edge).toHaveStyle(
         "animation: monoVertexBypassFlow 0.8s linear infinite"
       );
       expect(edge).toHaveStyle("pointer-events: none");
-      expect(edge).toHaveStyle("stroke-dasharray: 4 4");
+      expect(edge).toHaveStyle("stroke-dasharray: 5 5");
       expect(edge).toHaveStyle("stroke-dashoffset: 0");
       expect(edge).toHaveAttribute(
         "d",

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomEdge/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomEdge/index.tsx
@@ -221,15 +221,15 @@ const CustomEdge: FC<EdgeProps<Edge<Record<string, any>>>> = ({
         : getColor,
       strokeWidth:
         data?.monoVertexBypassEdge
-          ? 1.2
+          ? 2
           : isMonoVertexEdge
-          ? 1.2
+          ? 2
           : 2,
       ...(data?.monoVertexBypassEdge
         ? {
             animation: "monoVertexBypassFlow 0.8s linear infinite",
             pointerEvents: "none",
-            strokeDasharray: "4 4",
+            strokeDasharray: "5 5",
             strokeDashoffset: 0,
           }
         : {}),

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomNode/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomNode/index.tsx
@@ -7,6 +7,10 @@ import Box from "@mui/material/Box";
 import { HighlightContext } from "../../index";
 import { GeneratorColorContext } from "../../../../index";
 import { HighlightContextProps } from "../../../../../../../types/declarations/graph";
+import {
+  MONO_VERTEX_MAX_CONTAINER_HEIGHT,
+  MONO_VERTEX_MAX_CONTAINER_WIDTH,
+} from "../../../../../../../utils/monoVertexGraphLayout";
 // import healthy from "../../../../../../../images/heart-fill.svg";
 import source from "../../../../../../../images/source.png";
 import map from "../../../../../../../images/map.png";
@@ -458,6 +462,16 @@ const CustomNode: FC<NodeProps> = ({
       ...commonStyle,
     };
   }, [highlightValues, data, hasBothSinks]);
+  const monoVertexNodeStyle = isMonoVertex
+    ? {
+        ...nodeStyle,
+        border: `${
+          highlightValues[data?.name] ? "0.3rem" : "0.15rem"
+        } solid ${getBorderColor(data?.type)}`,
+        width: data?.containerWidth ?? MONO_VERTEX_MAX_CONTAINER_WIDTH,
+        height: data?.containerHeight ?? MONO_VERTEX_MAX_CONTAINER_HEIGHT,
+      }
+    : nodeStyle;
 
   // arrow for containers in monoVertex
   const arrowSvg = useMemo(() => {
@@ -521,7 +535,7 @@ const CustomNode: FC<NodeProps> = ({
       <Box
         className={nodeInputClass}
         onClick={handleClick}
-        style={nodeStyle}
+        style={monoVertexNodeStyle}
       >
         {data?.type !== "monoVertex" && (
           <Box className="node-info">{data?.name}</Box>

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomNode/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomNode/index.tsx
@@ -462,7 +462,7 @@ const CustomNode: FC<NodeProps> = ({
       ...commonStyle,
     };
   }, [highlightValues, data, hasBothSinks]);
-  const monoVertexNodeStyle = isMonoVertex
+  const resolvedNodeStyle = isMonoVertex
     ? {
         ...nodeStyle,
         border: `${
@@ -535,7 +535,7 @@ const CustomNode: FC<NodeProps> = ({
       <Box
         className={nodeInputClass}
         onClick={handleClick}
-        style={monoVertexNodeStyle}
+        style={resolvedNodeStyle}
       >
         {data?.type !== "monoVertex" && (
           <Box className="node-info">{data?.name}</Box>

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomNode/style.css
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/CustomNode/style.css
@@ -144,8 +144,10 @@
 }
 
 .react-flow__node-input--mono-vertex {
-  width: 42rem;
-  height: 17rem;
+  width: auto;
+  height: auto;
+  min-width: 30rem;
+  min-height: 15rem;
   display: flex;
   flex-direction: column;
   position: relative;
@@ -178,9 +180,10 @@
 .node-info-mono {
   display: flex;
   position: relative;
-  top: -1.2rem;
+  top: -0.6rem;
   width: 100%;
-  height: 4.8rem;
+  height: 4rem;
+  padding: 0 1.2rem;
   flex-direction: column;
   justify-content: center;
   color: var(--node-text);
@@ -307,7 +310,7 @@
   fill: none;
   stroke: var(--mono-vertex-bypass-color);
   stroke-width: 2;
-  stroke-dasharray: 4 4;
+  stroke-dasharray: 5 5;
 }
 
 .mono-vertex-img-wrapper {
@@ -341,11 +344,14 @@
 }
 
 .mono-vertex-internal-node {
-  height: 3.2rem;
-  width: 3.2rem;
+  height: 4rem;
+  width: 4rem;
   border-radius: 50%;
   border: 1px solid var(--border-secondary);
   background: var(--bg-secondary);
+  box-shadow:
+    0 0 0 0.12rem rgba(141, 144, 150, 0.16),
+    0 0.1rem 0.35rem rgba(39, 76, 119, 0.12);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -360,16 +366,16 @@
 }
 
 .mono-vertex-internal-node-icon > img {
-  height: 1.4rem;
-  width: 1.4rem;
+  height: 2.2rem;
+  width: 2.2rem;
 }
 
 .mono-vertex-bypass-handle {
   position: absolute;
-  bottom: -1rem;
+  bottom: -1.2rem;
   left: 50%;
-  width: 1.1rem;
-  height: 1.1rem;
+  width: 1.4rem;
+  height: 1.4rem;
   cursor: pointer;
   opacity: 0.85;
   z-index: 2;

--- a/ui/src/utils/fetcherHooks/monoVertexViewFetch.test.tsx
+++ b/ui/src/utils/fetcherHooks/monoVertexViewFetch.test.tsx
@@ -182,8 +182,10 @@ describe("getMonoVertexInternalStages", () => {
     const stages = getMonoVertexInternalStages(createSourceOnlySpec());
 
     expect(stages).toHaveLength(2);
-    expect(getStage(stages, "source").x).toBe(154);
-    expect(getStage(stages, "sink").x).toBe(234);
+    expect(getStage(stages, "source").x).toBe(86);
+    expect(getStage(stages, "sink").x).toBe(174);
+    expect(getStage(stages, "source").y).toBe(67);
+    expect(getStage(stages, "sink").y).toBe(67);
   });
 
   it("aligns fallback horizontally when it is the only optional sink output", () => {
@@ -202,8 +204,8 @@ describe("getMonoVertexInternalStages", () => {
     const sink = getStage(stages, "sink");
     const fallback = getStage(stages, "fallback");
 
-    expect(sink.x).toBe(274);
-    expect(fallback.x).toBe(354);
+    expect(sink.x).toBe(280.5);
+    expect(fallback.x).toBe(366);
     expect(fallback.y).toBe(sink.y);
     expect(fallback.x).toBeGreaterThan(sink.x);
     expect(stages.find((s) => s.key === "onSuccess")).toBeUndefined();
@@ -225,8 +227,8 @@ describe("getMonoVertexInternalStages", () => {
     const sink = getStage(stages, "sink");
     const onSuccess = getStage(stages, "onSuccess");
 
-    expect(sink.x).toBe(274);
-    expect(onSuccess.x).toBe(354);
+    expect(sink.x).toBe(280.5);
+    expect(onSuccess.x).toBe(366);
     expect(onSuccess.y).toBe(sink.y);
     expect(onSuccess.x).toBeGreaterThan(sink.x);
     expect(stages.find((s) => s.key === "fallback")).toBeUndefined();
@@ -246,11 +248,11 @@ describe("getMonoVertexInternalStages", () => {
     );
 
     expect(stages).toHaveLength(4);
-    expect(getStage(stages, "source").x).toBe(74);
-    expect(getStage(stages, "udf").x).toBe(154);
-    expect(getStage(stages, "sink").x).toBe(234);
-    expect(getStage(stages, "fallback").x).toBe(314);
-    expect(getStage(stages, "fallback").y).toBe(76);
+    expect(getStage(stages, "source").x).toBe(63);
+    expect(getStage(stages, "udf").x).toBe(151);
+    expect(getStage(stages, "sink").x).toBe(239);
+    expect(getStage(stages, "fallback").x).toBe(327);
+    expect(getStage(stages, "fallback").y).toBe(80);
   });
 
   it("fans out onSuccess and fallback when both optional sink outputs exist", () => {
@@ -277,12 +279,12 @@ describe("getMonoVertexInternalStages", () => {
     const onSuccess = getStage(stages, "onSuccess");
     const fallback = getStage(stages, "fallback");
 
-    expect(sink.y).toBe(76);
-    expect(sink.x).toBe(274);
-    expect(onSuccess.x).toBe(354);
-    expect(fallback.x).toBe(354);
-    expect(onSuccess.y).toBe(44);
-    expect(fallback.y).toBe(106);
+    expect(sink.y).toBe(90);
+    expect(sink.x).toBe(298);
+    expect(onSuccess.x).toBe(386);
+    expect(fallback.x).toBe(386);
+    expect(onSuccess.y).toBe(54);
+    expect(fallback.y).toBe(126);
     expect(onSuccess.y).toBeLessThan(sink.y);
     expect(fallback.y).toBeGreaterThan(sink.y);
   });
@@ -324,6 +326,14 @@ describe("useMonoVertexViewFetch", () => {
           ?.data?.podnum
       ).toBe(1);
     });
+    expect(
+      result.current.vertices.find((node) => node.id === MONO_VERTEX_NAME)
+        ?.data?.containerWidth
+    ).toBe(300);
+    expect(
+      result.current.vertices.find((node) => node.id === MONO_VERTEX_NAME)
+        ?.data?.containerHeight
+    ).toBe(150);
 
     monoVertexName.current = nextMonoVertexName;
     rerender({ pipelineId: nextMonoVertexName });

--- a/ui/src/utils/fetcherHooks/monoVertexViewFetch.ts
+++ b/ui/src/utils/fetcherHooks/monoVertexViewFetch.ts
@@ -6,166 +6,25 @@ import { AppContextProps } from "../../types/declarations/app";
 import { AppContext } from "../../App";
 import {
   MonoVertex,
-  MonoVertexBypass,
   MonoVertexSpec,
   MonoVertexMetrics,
 } from "../../types/declarations/pipeline";
+import {
+  MONO_VERTEX_BYPASS_TARGETS,
+  getMonoVertexBypassSourceStages,
+  getMonoVertexContainerDimensions,
+  getMonoVertexDirectInternalEdges,
+  getMonoVertexInternalEdgeKey,
+  getMonoVertexInternalStages,
+  getMonoVertexMainStages,
+  getMonoVertexStageNodeName,
+  shouldFanOutMonoVertexSinkTargets,
+} from "../monoVertexGraphLayout";
 
-type MonoVertexBypassTarget = keyof MonoVertexBypass;
-const MONO_VERTEX_BYPASS_TARGETS: MonoVertexBypassTarget[] = [
-  "sink",
-  "onSuccess",
-  "fallback",
-];
-
-const MONO_VERTEX_CONTAINER_WIDTH = 420;
-const MONO_VERTEX_INTERNAL_NODE_WIDTH = 32;
-const MONO_VERTEX_MAX_STAGE_STEP_X = 80;
-const MONO_VERTEX_MIN_SIDE_PADDING = 24;
-const MONO_VERTEX_STAGE_Y = 76;
-const MONO_VERTEX_ONSUCCESS_FAN_OUT_Y = 44;
-const MONO_VERTEX_FALLBACK_FAN_OUT_Y = 106;
-
-const getMonoVertexStageNodeName = (name: string, stage: string) =>
-  `${name}-${stage}`;
-
-const getMonoVertexInternalEdgeKey = (source: string, target: string) =>
-  `${source}->${target}`;
-
-const getMonoVertexMainStages = (spec: MonoVertexSpec) => [
-  "source",
-  ...(spec?.source?.transformer ? ["transformer"] : []),
-  ...(spec?.udf ? ["udf"] : []),
-  "sink",
-];
-
-const getMonoVertexBypassSourceStages = (spec: MonoVertexSpec) => {
-  const bypassSourceStages = [
-    ...(spec?.source?.transformer ? ["transformer"] : []),
-    ...(spec?.udf ? ["udf"] : []),
-  ];
-  if (bypassSourceStages.length === 0) {
-    bypassSourceStages.push("source");
-  }
-  return bypassSourceStages;
-};
-
-const getMonoVertexDirectInternalEdges = (
-  spec: MonoVertexSpec,
-  name: string
-) => {
-  const directInternalEdges = new Set<string>();
-  const addDirectInternalEdge = (sourceStage: string, targetStage: string) => {
-    directInternalEdges.add(
-      getMonoVertexInternalEdgeKey(
-        getMonoVertexStageNodeName(name, sourceStage),
-        getMonoVertexStageNodeName(name, targetStage)
-      )
-    );
-  };
-  const mainStages = getMonoVertexMainStages(spec);
-  mainStages.forEach((stage, idx) => {
-    const targetStage = mainStages[idx + 1];
-    if (!targetStage) return;
-    addDirectInternalEdge(stage, targetStage);
-  });
-  if (spec?.sink?.onSuccess) {
-    addDirectInternalEdge("sink", "onSuccess");
-  }
-  if (spec?.sink?.fallback) {
-    addDirectInternalEdge("sink", "fallback");
-  }
-  return directInternalEdges;
-};
-
-const shouldFanOutMonoVertexSinkTargets = (spec: MonoVertexSpec) =>
-  !!spec?.sink?.onSuccess && !!spec?.sink?.fallback;
-
-export const getMonoVertexInternalStages = (spec: MonoVertexSpec) => {
-  const hasOnSuccess = !!spec?.sink?.onSuccess;
-  const hasFallback = !!spec?.sink?.fallback;
-  const hasOptionalSinkOutput = hasOnSuccess || hasFallback;
-  const shouldFanOutSinkTargets = shouldFanOutMonoVertexSinkTargets(spec);
-  const columns = [
-    {
-      key: "source",
-      spec: spec.source,
-    },
-    ...(spec?.source?.transformer
-      ? [
-          {
-            key: "transformer",
-            spec: spec.source.transformer,
-          },
-        ]
-      : []),
-    ...(spec?.udf
-      ? [
-          {
-            key: "udf",
-            spec: spec.udf,
-          },
-        ]
-      : []),
-    {
-      key: "sink",
-      spec: spec.sink,
-    },
-    ...(hasOptionalSinkOutput
-      ? [
-          {
-            key: "optionalOutputs",
-            spec: undefined,
-          },
-        ]
-      : []),
-  ];
-  const usableWidth =
-    MONO_VERTEX_CONTAINER_WIDTH -
-    2 * MONO_VERTEX_MIN_SIDE_PADDING -
-    MONO_VERTEX_INTERNAL_NODE_WIDTH;
-  const idealStep =
-    columns.length > 1 ? usableWidth / (columns.length - 1) : 0;
-  const stepX = Math.min(idealStep, MONO_VERTEX_MAX_STAGE_STEP_X);
-  const totalSpan = (columns.length - 1) * stepX;
-  const startX =
-    (MONO_VERTEX_CONTAINER_WIDTH -
-      totalSpan -
-      MONO_VERTEX_INTERNAL_NODE_WIDTH) /
-    2;
-  const stageXByKey = columns.reduce((positions, column, index) => {
-    positions[column.key] = startX + index * stepX;
-    return positions;
-  }, {} as Record<string, number>);
-  const internalStages = columns
-    .filter((column) => column.key !== "optionalOutputs")
-    .map((column) => ({
-      ...column,
-      x: stageXByKey[column.key],
-      y: MONO_VERTEX_STAGE_Y,
-    }));
-  if (hasOnSuccess) {
-    internalStages.push({
-      key: "onSuccess",
-      spec: spec.sink.onSuccess,
-      x: stageXByKey.optionalOutputs,
-      y: shouldFanOutSinkTargets
-        ? MONO_VERTEX_ONSUCCESS_FAN_OUT_Y
-        : MONO_VERTEX_STAGE_Y,
-    });
-  }
-  if (hasFallback) {
-    internalStages.push({
-      key: "fallback",
-      spec: spec.sink.fallback,
-      x: stageXByKey.optionalOutputs,
-      y: shouldFanOutSinkTargets
-        ? MONO_VERTEX_FALLBACK_FAN_OUT_Y
-        : MONO_VERTEX_STAGE_Y,
-    });
-  }
-  return internalStages;
-};
+export {
+  getMonoVertexContainerDimensions,
+  getMonoVertexInternalStages,
+} from "../monoVertexGraphLayout";
 
 export const useMonoVertexViewFetch = (
   namespaceId: string | undefined,
@@ -404,6 +263,7 @@ export const useMonoVertexViewFetch = (
     const newVertices: Node[] = [];
     if (spec?.source && spec?.sink && monoVertexMetrics) {
       const name = pipelineId ?? "";
+      const { width, height } = getMonoVertexContainerDimensions(spec);
       const newNode = {} as Node;
       newNode.id = name;
       newNode.data = { name: name };
@@ -413,6 +273,8 @@ export const useMonoVertexViewFetch = (
       newNode.type = "custom";
       newNode.data.nodeInfo = spec;
       newNode.data.type = "monoVertex";
+      newNode.data.containerWidth = width;
+      newNode.data.containerHeight = height;
       newNode.data.vertexMetrics = monoVertexMetrics.has(name)
         ? monoVertexMetrics.get(name)
         : null;
@@ -491,14 +353,14 @@ export const useMonoVertexViewFetch = (
       const name = pipelineId ?? "";
       const internalMarkerEnd = {
         type: MarkerType.Arrow,
-        width: 8,
-        height: 8,
+        width: 10,
+        height: 10,
         color: "#8D9096",
       };
       const bypassMarkerEnd = {
         type: MarkerType.Arrow,
-        width: 6,
-        height: 6,
+        width: 8,
+        height: 8,
         color: "var(--mono-vertex-bypass-color)",
       };
       const mainStages = getMonoVertexMainStages(spec);

--- a/ui/src/utils/monoVertexGraphLayout.test.ts
+++ b/ui/src/utils/monoVertexGraphLayout.test.ts
@@ -1,0 +1,256 @@
+import { MonoVertexSpec } from "../types/declarations/pipeline";
+import {
+  getMonoVertexContainerDimensions,
+  getMonoVertexInternalStages,
+} from "./monoVertexGraphLayout";
+
+const baseSpec = {
+  source: {
+    udsource: {
+      container: {
+        image: "source-image",
+      },
+    },
+    transformer: {
+      container: {
+        image: "transformer-image",
+      },
+    },
+  },
+  udf: {
+    container: {
+      image: "udf-image",
+    },
+  },
+  sink: {
+    udsink: {
+      container: {
+        image: "sink-image",
+      },
+    },
+  },
+  scale: {},
+} as MonoVertexSpec;
+
+const createSpec = (
+  sinkOverrides: Record<string, any> = {},
+  specOverrides: Partial<MonoVertexSpec> = {}
+): MonoVertexSpec =>
+  ({
+    ...baseSpec,
+    ...specOverrides,
+    sink: {
+      ...baseSpec.sink,
+      ...sinkOverrides,
+    },
+  } as MonoVertexSpec);
+
+const createSourceOnlySpec = (
+  sinkOverrides: Record<string, any> = {}
+): MonoVertexSpec =>
+  ({
+    source: {
+      udsource: {
+        container: {
+          image: "source-image",
+        },
+      },
+    },
+    sink: {
+      udsink: {
+        container: {
+          image: "sink-image",
+        },
+      },
+      ...sinkOverrides,
+    },
+    scale: {},
+  } as MonoVertexSpec);
+
+const createUdfOnlySpec = (
+  sinkOverrides: Record<string, any> = {}
+): MonoVertexSpec =>
+  ({
+    ...createSourceOnlySpec(sinkOverrides),
+    udf: baseSpec.udf,
+  } as MonoVertexSpec);
+
+const getStage = (
+  stages: ReturnType<typeof getMonoVertexInternalStages>,
+  key: string
+) => {
+  const stage = stages.find((s) => s.key === key);
+  if (!stage) {
+    throw new Error(`Expected stage ${key} to be defined`);
+  }
+  return stage;
+};
+
+describe("getMonoVertexContainerDimensions", () => {
+  it("uses compact dimensions for source and sink only", () => {
+    expect(getMonoVertexContainerDimensions(createSourceOnlySpec())).toEqual({
+      width: 300,
+      height: 150,
+    });
+  });
+
+  it("uses balanced dimensions for linear multi-stage mono vertices", () => {
+    expect(getMonoVertexContainerDimensions(createUdfOnlySpec())).toEqual({
+      width: 390,
+      height: 165,
+    });
+  });
+
+  it("widens for optional outputs", () => {
+    expect(
+      getMonoVertexContainerDimensions(
+        createUdfOnlySpec({
+          onSuccess: {
+            udsink: {
+              container: {
+                image: "on-success-image",
+              },
+            },
+          },
+        })
+      )
+    ).toEqual({
+      width: 430,
+      height: 175,
+    });
+  });
+
+  it("widens for bypass-capable layouts", () => {
+    expect(
+      getMonoVertexContainerDimensions({
+        ...createSourceOnlySpec(),
+        bypass: {
+          sink: {
+            tags: {
+              values: ["route-sink"],
+            },
+          },
+        },
+      } as MonoVertexSpec)
+    ).toEqual({
+      width: 430,
+      height: 175,
+    });
+  });
+
+  it("keeps full height for fan-out sink outputs", () => {
+    expect(
+      getMonoVertexContainerDimensions(
+        createSourceOnlySpec({
+          onSuccess: {
+            udsink: {
+              container: {
+                image: "on-success-image",
+              },
+            },
+          },
+          fallback: {
+            udsink: {
+              container: {
+                image: "fallback-image",
+              },
+            },
+          },
+        })
+      )
+    ).toEqual({
+      width: 460,
+      height: 195,
+    });
+  });
+
+  it("uses full dimensions for complex fan-out layouts", () => {
+    expect(
+      getMonoVertexContainerDimensions(
+        createSpec({
+          onSuccess: {
+            udsink: {
+              container: {
+                image: "on-success-image",
+              },
+            },
+          },
+          fallback: {
+            udsink: {
+              container: {
+                image: "fallback-image",
+              },
+            },
+          },
+        })
+      )
+    ).toEqual({
+      width: 460,
+      height: 195,
+    });
+  });
+});
+
+describe("getMonoVertexInternalStages", () => {
+  it("packs source and sink into the compact container", () => {
+    const stages = getMonoVertexInternalStages(createSourceOnlySpec());
+
+    expect(getStage(stages, "source").x).toBe(86);
+    expect(getStage(stages, "sink").x).toBe(174);
+    expect(getStage(stages, "source").y).toBe(67);
+    expect(getStage(stages, "sink").y).toBe(67);
+  });
+
+  it("balances the main row for linear multi-stage layouts", () => {
+    const stages = getMonoVertexInternalStages(createUdfOnlySpec());
+
+    expect(getStage(stages, "source").y).toBe(75);
+    expect(getStage(stages, "udf").y).toBe(75);
+    expect(getStage(stages, "sink").y).toBe(75);
+  });
+
+  it("balances the main row for optional output layouts", () => {
+    const stages = getMonoVertexInternalStages(
+      createUdfOnlySpec({
+        fallback: {
+          udsink: {
+            container: {
+              image: "fallback-image",
+            },
+          },
+        },
+      })
+    );
+
+    expect(getStage(stages, "sink").y).toBe(80);
+    expect(getStage(stages, "fallback").y).toBe(80);
+  });
+
+  it("preserves fan-out Y positions for complex sink outputs", () => {
+    const stages = getMonoVertexInternalStages(
+      createSpec({
+        onSuccess: {
+          udsink: {
+            container: {
+              image: "on-success-image",
+            },
+          },
+        },
+        fallback: {
+          udsink: {
+            container: {
+              image: "fallback-image",
+            },
+          },
+        },
+      })
+    );
+
+    expect(getStage(stages, "sink").x).toBe(298);
+    expect(getStage(stages, "onSuccess").x).toBe(386);
+    expect(getStage(stages, "fallback").x).toBe(386);
+    expect(getStage(stages, "sink").y).toBe(90);
+    expect(getStage(stages, "onSuccess").y).toBe(54);
+    expect(getStage(stages, "fallback").y).toBe(126);
+  });
+});

--- a/ui/src/utils/monoVertexGraphLayout.ts
+++ b/ui/src/utils/monoVertexGraphLayout.ts
@@ -1,0 +1,225 @@
+import {
+  MonoVertexBypass,
+  MonoVertexSpec,
+} from "../types/declarations/pipeline";
+
+export type MonoVertexBypassTarget = keyof MonoVertexBypass;
+
+export const MONO_VERTEX_BYPASS_TARGETS: MonoVertexBypassTarget[] = [
+  "sink",
+  "onSuccess",
+  "fallback",
+];
+
+export const MONO_VERTEX_INTERNAL_NODE_WIDTH = 40;
+export const MONO_VERTEX_MAX_STAGE_STEP_X = 88;
+export const MONO_VERTEX_MIN_SIDE_PADDING = 24;
+export const MONO_VERTEX_STAGE_Y = 76;
+export const MONO_VERTEX_ONSUCCESS_FAN_OUT_Y = 42;
+export const MONO_VERTEX_FALLBACK_FAN_OUT_Y = 112;
+export const MONO_VERTEX_MAX_CONTAINER_WIDTH = 460;
+export const MONO_VERTEX_MAX_CONTAINER_HEIGHT = 195;
+export const MONO_VERTEX_SIMPLE_CONTAINER_WIDTH = 300;
+export const MONO_VERTEX_SIMPLE_CONTAINER_HEIGHT = 150;
+export const MONO_VERTEX_LINEAR_CONTAINER_WIDTH = 390;
+export const MONO_VERTEX_LINEAR_CONTAINER_HEIGHT = 165;
+export const MONO_VERTEX_OPTIONAL_OUTPUT_CONTAINER_WIDTH = 430;
+export const MONO_VERTEX_OPTIONAL_OUTPUT_CONTAINER_HEIGHT = 175;
+export const MONO_VERTEX_STAGE_TOP_RESERVED = 44;
+export const MONO_VERTEX_STAGE_BOTTOM_RESERVED = 20;
+export const MONO_VERTEX_FAN_OUT_UP_OFFSET = 36;
+export const MONO_VERTEX_FAN_OUT_DOWN_OFFSET = 36;
+
+type MonoVertexColumn = {
+  key: string;
+  spec: any;
+};
+
+export const getMonoVertexStageY = (containerHeight: number) =>
+  Math.round(
+    (MONO_VERTEX_STAGE_TOP_RESERVED +
+      (containerHeight - MONO_VERTEX_STAGE_BOTTOM_RESERVED) -
+      MONO_VERTEX_INTERNAL_NODE_WIDTH) /
+      2
+  );
+
+export const getMonoVertexFanOutY = (containerHeight: number) => {
+  const stageY = getMonoVertexStageY(containerHeight);
+  return {
+    onSuccessY: stageY - MONO_VERTEX_FAN_OUT_UP_OFFSET,
+    fallbackY: stageY + MONO_VERTEX_FAN_OUT_DOWN_OFFSET,
+  };
+};
+
+export const getMonoVertexStageNodeName = (name: string, stage: string) =>
+  `${name}-${stage}`;
+
+export const getMonoVertexInternalEdgeKey = (
+  source: string,
+  target: string
+) => `${source}->${target}`;
+
+export const getMonoVertexMainStages = (spec: MonoVertexSpec) => [
+  "source",
+  ...(spec?.source?.transformer ? ["transformer"] : []),
+  ...(spec?.udf ? ["udf"] : []),
+  "sink",
+];
+
+export const getMonoVertexBypassSourceStages = (spec: MonoVertexSpec) => {
+  const bypassSourceStages = [
+    ...(spec?.source?.transformer ? ["transformer"] : []),
+    ...(spec?.udf ? ["udf"] : []),
+  ];
+  if (bypassSourceStages.length === 0) {
+    bypassSourceStages.push("source");
+  }
+  return bypassSourceStages;
+};
+
+export const shouldFanOutMonoVertexSinkTargets = (spec: MonoVertexSpec) =>
+  !!spec?.sink?.onSuccess && !!spec?.sink?.fallback;
+
+const getMonoVertexColumns = (spec: MonoVertexSpec): MonoVertexColumn[] => {
+  const hasOptionalSinkOutput = !!spec?.sink?.onSuccess || !!spec?.sink?.fallback;
+  return [
+    {
+      key: "source",
+      spec: spec.source,
+    },
+    ...(spec?.source?.transformer
+      ? [
+          {
+            key: "transformer",
+            spec: spec.source.transformer,
+          },
+        ]
+      : []),
+    ...(spec?.udf
+      ? [
+          {
+            key: "udf",
+            spec: spec.udf,
+          },
+        ]
+      : []),
+    {
+      key: "sink",
+      spec: spec.sink,
+    },
+    ...(hasOptionalSinkOutput
+      ? [
+          {
+            key: "optionalOutputs",
+            spec: undefined,
+          },
+        ]
+      : []),
+  ];
+};
+
+export const getMonoVertexColumnKeys = (spec: MonoVertexSpec) =>
+  getMonoVertexColumns(spec).map((column) => column.key);
+
+const hasMonoVertexBypass = (spec: MonoVertexSpec) =>
+  Object.values(spec?.bypass || {}).some((rule) => !!rule?.tags);
+
+export const getMonoVertexContainerDimensions = (spec: MonoVertexSpec) => {
+  const columns = getMonoVertexColumnKeys(spec);
+  if (shouldFanOutMonoVertexSinkTargets(spec)) {
+    return {
+      width: MONO_VERTEX_MAX_CONTAINER_WIDTH,
+      height: MONO_VERTEX_MAX_CONTAINER_HEIGHT,
+    };
+  }
+  if (spec?.sink?.onSuccess || spec?.sink?.fallback || hasMonoVertexBypass(spec)) {
+    return {
+      width: MONO_VERTEX_OPTIONAL_OUTPUT_CONTAINER_WIDTH,
+      height: MONO_VERTEX_OPTIONAL_OUTPUT_CONTAINER_HEIGHT,
+    };
+  }
+  if (columns.length > 2) {
+    return {
+      width: MONO_VERTEX_LINEAR_CONTAINER_WIDTH,
+      height: MONO_VERTEX_LINEAR_CONTAINER_HEIGHT,
+    };
+  }
+  return {
+    width: MONO_VERTEX_SIMPLE_CONTAINER_WIDTH,
+    height: MONO_VERTEX_SIMPLE_CONTAINER_HEIGHT,
+  };
+};
+
+export const getMonoVertexDirectInternalEdges = (
+  spec: MonoVertexSpec,
+  name: string
+) => {
+  const directInternalEdges = new Set<string>();
+  const addDirectInternalEdge = (sourceStage: string, targetStage: string) => {
+    directInternalEdges.add(
+      getMonoVertexInternalEdgeKey(
+        getMonoVertexStageNodeName(name, sourceStage),
+        getMonoVertexStageNodeName(name, targetStage)
+      )
+    );
+  };
+  const mainStages = getMonoVertexMainStages(spec);
+  mainStages.forEach((stage, idx) => {
+    const targetStage = mainStages[idx + 1];
+    if (!targetStage) return;
+    addDirectInternalEdge(stage, targetStage);
+  });
+  if (spec?.sink?.onSuccess) {
+    addDirectInternalEdge("sink", "onSuccess");
+  }
+  if (spec?.sink?.fallback) {
+    addDirectInternalEdge("sink", "fallback");
+  }
+  return directInternalEdges;
+};
+
+export const getMonoVertexInternalStages = (spec: MonoVertexSpec) => {
+  const hasOnSuccess = !!spec?.sink?.onSuccess;
+  const hasFallback = !!spec?.sink?.fallback;
+  const shouldFanOutSinkTargets = shouldFanOutMonoVertexSinkTargets(spec);
+  const columns = getMonoVertexColumns(spec);
+  const { width, height } = getMonoVertexContainerDimensions(spec);
+  const stageY = getMonoVertexStageY(height);
+  const { onSuccessY, fallbackY } = getMonoVertexFanOutY(height);
+  const usableWidth =
+    width - 2 * MONO_VERTEX_MIN_SIDE_PADDING - MONO_VERTEX_INTERNAL_NODE_WIDTH;
+  const idealStep =
+    columns.length > 1 ? usableWidth / (columns.length - 1) : 0;
+  const stepX = Math.min(idealStep, MONO_VERTEX_MAX_STAGE_STEP_X);
+  const totalSpan = (columns.length - 1) * stepX;
+  const startX =
+    (width - totalSpan - MONO_VERTEX_INTERNAL_NODE_WIDTH) / 2;
+  const stageXByKey = columns.reduce((positions, column, index) => {
+    positions[column.key] = startX + index * stepX;
+    return positions;
+  }, {} as Record<string, number>);
+  const internalStages = columns
+    .filter((column) => column.key !== "optionalOutputs")
+    .map((column) => ({
+      ...column,
+      x: stageXByKey[column.key],
+      y: stageY,
+    }));
+  if (hasOnSuccess) {
+    internalStages.push({
+      key: "onSuccess",
+      spec: spec.sink.onSuccess,
+      x: stageXByKey.optionalOutputs,
+      y: shouldFanOutSinkTargets ? onSuccessY : stageY,
+    });
+  }
+  if (hasFallback) {
+    internalStages.push({
+      key: "fallback",
+      spec: spec.sink.fallback,
+      x: stageXByKey.optionalOutputs,
+      y: shouldFanOutSinkTargets ? fallbackY : stageY,
+    });
+  }
+  return internalStages;
+};


### PR DESCRIPTION
### What this PR does / why we need it

MonoVertex cards in the UI graph were always shown at the same large size, even for simple setups like source → sink. That made the graph feel unnecessarily big.

This PR makes the card size depend on what's actually in the MonoVertex, a simple layout gets a smaller card, and it only grows when needed (e.g. extra stages, optional outputs, or bypass paths).

### Related issues

Fixes #3468

### Testing
```bash
yarn test
```

- Unit tests added and updated for the new sizing logic.
- All related UI tests pass (32 tests).

### Notes for reviewers

- Larger dimensions are only used when the spec needs them — not for every MonoVertex.
- Small visual tweaks to internal icons and bypass edges so things stay readable at the smaller sizes.
<img width="1728" height="1045" alt="Screenshot 2026-07-03 at 10 05 30 PM" src="https://github.com/user-attachments/assets/b40fcc69-41e8-4e62-876a-1f755571d89b" />
<img width="1728" height="964" alt="Screenshot 2026-07-03 at 10 05 45 PM" src="https://github.com/user-attachments/assets/b3244926-ad99-4880-9d8c-3e1608a2d791" />
<img width="1727" height="1045" alt="Screenshot 2026-07-03 at 10 05 51 PM" src="https://github.com/user-attachments/assets/8dd06d34-7c36-471c-8b58-a94297059d54" />
