### PR TITLE
chore: upgrade mkdocs and its dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ ifdef IMAGE_IMPORT_CMD
 endif
 
 /usr/local/bin/mkdocs:
-	$(PYTHON) -m pip install mkdocs==1.3.0 mkdocs_material==8.3.9 mkdocs-embed-external-markdown==2.3.0
+	$(PYTHON) -m pip install mkdocs==1.6.1 mkdocs_material==9.7.6 mkdocs-embed-external-markdown==3.0.2
 
 /usr/local/bin/lychee:
 ifeq (, $(shell which lychee))


### PR DESCRIPTION
  - Security: v9.5.32 fixed a reflected-XSS vulnerability in the search results page (search is enabled by default), and v9.7.1 patched a requests dependency CVE. The old 8.3.9 pin doesn't have either fix.
  - Mermaid diagrams: numaflow's mkdocs.yml defines a custom mermaid fence via pymdownx.superfences — Material bundled Mermaid.js was bumped repeatedly and is at v11 by 9.5.34, vs. whatever much older Mermaid shipped alongside 8.3.9. Better diagram support/rendering, fewer rendering bugs.
  - Content tabs deep-linking: numaflow already enables content.tabs.link in the theme config; anchor-linkable tab support for it only landed in v8.5.0/v9.5.0, so the old 8.3.9 pin predates or barely has this.
  - Future-proofing: newer Python version support (3.14 added in 9.6.19) keeps make docs working on current dev machines/CI images going forward.