### PR TITLE
chore: introduce additional unhealthy waiting statuses

### DIFF
--- a/pkg/apis/numaflow/v1alpha1/const.go
+++ b/pkg/apis/numaflow/v1alpha1/const.go
@@ -271,5 +271,7 @@ const (
 var (
 	// unhealthyWaitingStatus contains the status messages for a pod in waiting state
 	// which should be considered as unhealthy
-	UnhealthyWaitingStatus = []string{"CrashLoopBackOff", "ImagePullBackOff"}
+	UnhealthyWaitingStatus = []string{"CrashLoopBackOff", "ImagePullBackOff", "InvalidImageName",
+		"ErrImageNeverPull", "CreateContainerConfigError", "CreateContainerError", "ErrImagePull",
+		"ImageInspectError", "RunContainerError"}
 )


### PR DESCRIPTION
### What this PR does / why we need it
Following are captured statuses for a vertex and the pod it comprises of where the udf image used does not exist:
* [Vertex status capture](https://gist.github.com/vaibhavtiwari33/898388b232dccda4848971f0bfe6262c)
* [Pod status capture](https://gist.github.com/vaibhavtiwari33/58fb2a7b5f2f92dad40294bba4bd7c75)

The reason in pod status oscillates between `ErrImagePull` and `ImagePullBackOff` while the vertex status flips between `PodImagePullBackOff` and `Running`. 

So this change aims to introduce additional unhealthy statuses that the controller recognizes as unhealthy states for a vertex/mvtx. 

### Testing
Status capture after the changes:
* [mvtx status capture](https://gist.github.com/vaibhavtiwari33/eb2c59f1f15528485660bafdeb842f6a)
* [pod status capture](https://gist.github.com/vaibhavtiwari33/12d0059f53677b94f44e986eac07af27)

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
