### PR TITLE
fix: remove streaming gate for monovertex metrics in source

### DIFF
--- a/rust/numaflow-core/src/source.rs
+++ b/rust/numaflow-core/src/source.rs
@@ -846,12 +846,7 @@ impl<C: crate::typ::NumaflowTypeConfig> Source<C> {
 
             let read_time = read_start_time.elapsed().as_micros() as f64;
 
-            Self::record_batch_read_metrics(
-                &pipeline_labels,
-                mvtx_labels,
-                read_time,
-                msgs_len,
-            );
+            Self::record_batch_read_metrics(&pipeline_labels, mvtx_labels, read_time, msgs_len);
 
             for mut message in messages.drain(..) {
                 // Pre-compute per-source-offset trace context (same as non-streaming).

--- a/rust/numaflow-core/src/source.rs
+++ b/rust/numaflow-core/src/source.rs
@@ -577,7 +577,6 @@ impl<C: crate::typ::NumaflowTypeConfig> Source<C> {
                         mvtx_labels,
                         read_time,
                         msgs_len,
-                        false,
                     );
 
                     let mut msg_handles = vec![];
@@ -846,15 +845,12 @@ impl<C: crate::typ::NumaflowTypeConfig> Source<C> {
             let msgs_len = messages.len();
 
             let read_time = read_start_time.elapsed().as_micros() as f64;
-            // streaming=true: read_time and read_batch_size are skipped on the mvtx
-            // path (batch semantics are meaningless per-message). Pipeline path unchanged.
-            // TODO: track per message metrics
+
             Self::record_batch_read_metrics(
                 &pipeline_labels,
                 mvtx_labels,
                 read_time,
                 msgs_len,
-                true,
             );
 
             for mut message in messages.drain(..) {
@@ -1117,7 +1113,7 @@ impl<C: crate::typ::NumaflowTypeConfig> Source<C> {
         let start = Instant::now();
         let ack_result = if disposition {
             let result = Self::ack_with_retry(source_handle, vec![offset], &cancel_token).await;
-            Self::send_ack_metrics(1, start, true);
+            Self::send_ack_metrics(1, start);
             result
         } else {
             let result = Self::nack_with_retry(
@@ -1129,11 +1125,11 @@ impl<C: crate::typ::NumaflowTypeConfig> Source<C> {
                 &cancel_token,
             )
             .await;
-            Self::send_nack_metrics(1, start, true);
+            Self::send_nack_metrics(1, start);
             result
         };
 
-        Self::send_e2e_metrics(e2e_start_time, true);
+        Self::send_e2e_metrics(e2e_start_time);
 
         // Drop the permit here so the drain barrier sees one fewer in-flight message.
         // The drop happens after ack_with_retry so we never signal "done" before the
@@ -1182,17 +1178,15 @@ impl<C: crate::typ::NumaflowTypeConfig> Source<C> {
         if !offsets_to_ack.is_empty() {
             let acked_offset_count = offsets_to_ack.len();
             Self::ack_with_retry(source_handle.clone(), offsets_to_ack, &cancel_token).await?;
-            // Non-streaming path: record all batch-granular metrics (streaming=false).
-            Self::send_ack_metrics(acked_offset_count, ack_start, false);
+            Self::send_ack_metrics(acked_offset_count, ack_start);
         }
         let nack_start = Instant::now();
         if !offsets_to_nack.is_empty() {
             let nacked_offset_count = offsets_to_nack.len();
             Self::nack_with_retry(source_handle.clone(), offsets_to_nack, &cancel_token).await?;
-            // Non-streaming path: record all batch-granular metrics (streaming=false).
-            Self::send_nack_metrics(nacked_offset_count, nack_start, false);
+            Self::send_nack_metrics(nacked_offset_count, nack_start);
         }
-        Self::send_e2e_metrics(e2e_start_time, false);
+        Self::send_e2e_metrics(e2e_start_time);
 
         Ok(())
     }
@@ -1262,32 +1256,21 @@ impl<C: crate::typ::NumaflowTypeConfig> Source<C> {
 
     /// Record per-batch read metrics (read_time, read_batch_size).
     /// These metrics are recorded once per batch read operation.
-    ///
-    /// `streaming`: when `true` and `is_mono_vertex()`, the batch-granular `read_time` and
-    /// `read_batch_size` metrics are skipped — their batch semantics are meaningless for
-    /// per-message streaming. The pipeline label path is always recorded unchanged.
     fn record_batch_read_metrics(
         pipeline_labels: &Vec<(String, String)>,
         mvtx_labels: &Vec<(String, String)>,
         read_time: f64,
         batch_size: usize,
-        streaming: bool,
     ) {
         if is_mono_vertex() {
-            // Gate batch-granular metrics off under streaming. read_time would measure
-            // the duration of a read that returns a full batch regardless of how many
-            // messages are actually in flight, and read_batch_size would pin to ~1
-            // (meaningless for per-message throughput monitoring).
-            if !streaming {
-                monovertex_metrics()
-                    .read_time
-                    .get_or_create(mvtx_labels)
-                    .observe(read_time);
-                monovertex_metrics()
-                    .read_batch_size
-                    .get_or_create(mvtx_labels)
-                    .set(batch_size as i64);
-            }
+            monovertex_metrics()
+                .read_time
+                .get_or_create(mvtx_labels)
+                .observe(read_time);
+            monovertex_metrics()
+                .read_batch_size
+                .get_or_create(mvtx_labels)
+                .set(batch_size as i64);
         } else {
             pipeline_metrics()
                 .forwarder
@@ -1345,6 +1328,7 @@ impl<C: crate::typ::NumaflowTypeConfig> Source<C> {
                 .inc_by(bytes as u64);
         }
     }
+
     /// Records a duplicate drop on the source read path. The source forwarder runs in
     /// both monovertex and pipeline modes, so increment whichever counter family
     /// matches the current mode. Monovertex has a single `dropped_total` without a
@@ -1371,22 +1355,14 @@ impl<C: crate::typ::NumaflowTypeConfig> Source<C> {
         }
     }
 
-    /// `streaming`: when `true` and `is_mono_vertex()`, `ack_time` observes
-    /// are skipped — these batch-granular histograms are meaningless per-message (one sample
-    /// per ack call would misrepresent the aggregate). `ack_total` always increments (n=1
-    /// per message in the streaming path) since it is a valid per-message counter. The
-    /// pipeline label path is always recorded unchanged.
-    fn send_ack_metrics(n: usize, start: Instant, streaming: bool) {
+    fn send_ack_metrics(n: usize, start: Instant) {
         if is_mono_vertex() {
             let mvtx_labels = mvtx_forward_metric_labels();
 
-            // Gate batch-granular timing histograms off under streaming.
-            if !streaming {
-                monovertex_metrics()
-                    .ack_time
-                    .get_or_create(mvtx_labels)
-                    .observe(start.elapsed().as_micros() as f64);
-            }
+            monovertex_metrics()
+                .ack_time
+                .get_or_create(mvtx_labels)
+                .observe(start.elapsed().as_micros() as f64);
 
             // ack_total is a per-message counter — always valid, never gated.
             monovertex_metrics()
@@ -1413,17 +1389,14 @@ impl<C: crate::typ::NumaflowTypeConfig> Source<C> {
         }
     }
 
-    fn send_nack_metrics(n: usize, start: Instant, streaming: bool) {
+    fn send_nack_metrics(n: usize, start: Instant) {
         if is_mono_vertex() {
             let mvtx_labels = mvtx_forward_metric_labels();
 
-            // Gate batch-granular timing histograms off under streaming.
-            if !streaming {
-                monovertex_metrics()
-                    .nack_time
-                    .get_or_create(mvtx_labels)
-                    .observe(start.elapsed().as_micros() as f64);
-            }
+            monovertex_metrics()
+                .nack_time
+                .get_or_create(mvtx_labels)
+                .observe(start.elapsed().as_micros() as f64);
 
             // nack_total is a per-message counter — always valid, never gated.
             monovertex_metrics()
@@ -1450,17 +1423,14 @@ impl<C: crate::typ::NumaflowTypeConfig> Source<C> {
         }
     }
 
-    fn send_e2e_metrics(e2e_start_time: Instant, streaming: bool) {
+    fn send_e2e_metrics(e2e_start_time: Instant) {
         if is_mono_vertex() {
             let mvtx_labels = mvtx_forward_metric_labels();
 
-            // Gate batch-granular timing histograms off under streaming.
-            if !streaming {
-                monovertex_metrics()
-                    .e2e_time
-                    .get_or_create(mvtx_labels)
-                    .observe(e2e_start_time.elapsed().as_micros() as f64);
-            }
+            monovertex_metrics()
+                .e2e_time
+                .get_or_create(mvtx_labels)
+                .observe(e2e_start_time.elapsed().as_micros() as f64);
         } else {
             let mut pipeline_labels = pipeline_metric_labels(VERTEX_TYPE_SOURCE).clone();
             pipeline_labels.push((


### PR DESCRIPTION
### What this PR does / why we need it
I believe, the metrics gated behind `streaming` gate still do make sense on a per message level and should not be omitted during monovertex streaming. 

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
