### PR TITLE
chore: Rust 1.97, faster local image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,25 @@
+# Rust build artifacts (compiled on host or via BuildKit cache mounts)
 rust/target
+
+# Not used by Dockerfile COPY (only ui/build is needed)
+ui/node_modules
+
+# VCS / docs
+.git
+docs
+
+# Go sources and tooling (Go binary is host-built into dist/)
+pkg
+cmd
+config
+hack
+test
+examples
+vendor
+
+# Markdown and other non-build inputs
+*.md
+
+# Intermediate extract / cargo cache under dist/
+dist/rust-out
+dist/cargo

--- a/.dockerignore
+++ b/.dockerignore
@@ -19,7 +19,3 @@ vendor
 
 # Markdown and other non-build inputs
 *.md
-
-# Intermediate extract / cargo cache under dist/
-dist/rust-out
-dist/cargo

--- a/.github/workflows/memprofile-image.yml
+++ b/.github/workflows/memprofile-image.yml
@@ -1,0 +1,178 @@
+name: memprofile-image
+
+# Builds and pushes a multi-arch memory-profiling numaflow image.
+# Specify the branch to build via the workflow_dispatch input.
+# Final tag: quay.io/<org>/numaflow:<branch>-<sha7>-memprofile
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Git branch to build"
+        required: true
+        default: "main"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prepare:
+    name: Compute image tag
+    runs-on: ubuntu-24.04
+    if: github.repository == 'numaproj/numaflow'
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+      git_sha: ${{ steps.tag.outputs.git_sha }}
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Compute short tag from branch + commit
+        id: tag
+        run: |
+          # Sanitize branch for Docker tags: lowercase, / -> -, drop other invalid chars, cap length.
+          BRANCH=$(echo "${{ inputs.branch }}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's|/|-|g; s/[^a-z0-9._-]/-/g; s/--*/-/g; s/^-//; s/-$//' \
+            | cut -c1-50)
+          SHA=$(git rev-parse --short=7 HEAD)
+          TAG="${BRANCH}-${SHA}-memprofile"
+          echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "git_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Building branch=${{ inputs.branch }} sha=${SHA} tag=${TAG}"
+
+  build-go-binaries:
+    name: Build Go binaries
+    needs: [prepare]
+    runs-on: ubuntu-24.04
+    if: github.repository == 'numaproj/numaflow'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Build binaries
+        run: |
+          make build
+          chmod -R +x dist
+
+      - name: Store artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries
+          path: dist
+          if-no-files-found: error
+
+  build-push:
+    name: Build & push (${{ matrix.arch }})
+    needs: [prepare, build-go-binaries]
+    if: github.repository == 'numaproj/numaflow'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup Node-Cache
+        uses: actions/cache@v4
+        with:
+          path: ui/node_modules
+          key: ${{ runner.os }}-${{ matrix.arch }}-node-dep-v1-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Download Go binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries
+          path: dist/
+
+      - name: Registry Login
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAYIO_USERNAME }}
+          password: ${{ secrets.QUAYIO_PASSWORD }}
+
+      # Builds Rust numaflow (dynamic glibc), libbytehound.so, UI, and the final image.
+      # Rust is compiled in-Docker on this native runner (not via build-rust-docker-ghactions,
+      # which always links +crt-static and cannot be LD_PRELOAD'd).
+      - name: Build numaflow + bytehound image
+        env:
+          IMAGE_NAMESPACE: ${{ secrets.QUAYIO_ORG }}
+          VERSION: ${{ needs.prepare.outputs.git_sha }}
+          MEMPROFILE_IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}-${{ matrix.arch }}
+          DOCKER_PUSH: "false"
+          SKIP_CLEAN: "true"
+        run: make image-memprofile
+
+      - name: Verify dynamic linking and libbytehound.so
+        env:
+          IMAGE_NAMESPACE: ${{ secrets.QUAYIO_ORG }}
+          MEMPROFILE_IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}-${{ matrix.arch }}
+        run: |
+          IMAGE="${IMAGE_NAMESPACE}/numaflow:${MEMPROFILE_IMAGE_TAG}"
+          docker run --rm --entrypoint /bin/sh "${IMAGE}" -c '
+            set -e
+            ldd /bin/numaflow-rs | grep -q libc.so.6
+            ldd /bin/entrypoint | grep -q libc.so.6
+            test -f /usr/share/libbytehound.so
+            echo "ok: dynamic binaries + libbytehound.so present"
+          '
+
+      - name: Push arch-specific image
+        env:
+          IMAGE_NAMESPACE: ${{ secrets.QUAYIO_ORG }}
+          MEMPROFILE_IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}-${{ matrix.arch }}
+        run: docker push "${IMAGE_NAMESPACE}/numaflow:${MEMPROFILE_IMAGE_TAG}"
+
+  create-manifest:
+    name: Create multi-arch manifest
+    needs: [prepare, build-push]
+    if: github.repository == 'numaproj/numaflow'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Registry Login
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAYIO_USERNAME }}
+          password: ${{ secrets.QUAYIO_PASSWORD }}
+
+      - name: Create and push manifest
+        env:
+          IMAGE_NAMESPACE: ${{ secrets.QUAYIO_ORG }}
+          IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}
+        run: |
+          FINAL="${IMAGE_NAMESPACE}/numaflow:${IMAGE_TAG}"
+          AMD64="${IMAGE_NAMESPACE}/numaflow:${IMAGE_TAG}-amd64"
+          ARM64="${IMAGE_NAMESPACE}/numaflow:${IMAGE_TAG}-arm64"
+          docker buildx imagetools create -t "${FINAL}" "${AMD64}" "${ARM64}"
+          echo "Published ${FINAL}"
+          docker buildx imagetools inspect "${FINAL}"

--- a/.github/workflows/memprofile-image.yml
+++ b/.github/workflows/memprofile-image.yml
@@ -10,6 +10,7 @@ on:
         description: "Git branch to build"
         required: true
         default: "main"
+  pull_request:
 
 permissions:
   contents: read
@@ -30,13 +31,15 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
 
       - name: Compute short tag from branch + commit
         id: tag
+        env:
+          BRANCH_NAME: ${{ inputs.branch || github.head_ref || github.ref_name }}
         run: |
           # Sanitize branch for Docker tags: lowercase, / -> -, drop other invalid chars, cap length.
-          BRANCH=$(echo "${{ inputs.branch }}" \
+          BRANCH=$(echo "${BRANCH_NAME}" \
             | tr '[:upper:]' '[:lower:]' \
             | sed 's|/|-|g; s/[^a-z0-9._-]/-/g; s/--*/-/g; s/^-//; s/-$//' \
             | cut -c1-50)
@@ -44,7 +47,7 @@ jobs:
           TAG="${BRANCH}-${SHA}-memprofile"
           echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "git_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "Building branch=${{ inputs.branch }} sha=${SHA} tag=${TAG}"
+          echo "Building branch=${BRANCH_NAME} sha=${SHA} tag=${TAG}"
 
   build-go-binaries:
     name: Build Go binaries
@@ -55,7 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -91,7 +94,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/memprofile-image.yml
+++ b/.github/workflows/memprofile-image.yml
@@ -10,7 +10,6 @@ on:
         description: "Git branch to build"
         required: true
         default: "main"
-  pull_request:
 
 permissions:
   contents: read
@@ -31,15 +30,13 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          ref: ${{ inputs.branch }}
 
       - name: Compute short tag from branch + commit
         id: tag
-        env:
-          BRANCH_NAME: ${{ inputs.branch || github.head_ref || github.ref_name }}
         run: |
           # Sanitize branch for Docker tags: lowercase, / -> -, drop other invalid chars, cap length.
-          BRANCH=$(echo "${BRANCH_NAME}" \
+          BRANCH=$(echo "${{ inputs.branch }}" \
             | tr '[:upper:]' '[:lower:]' \
             | sed 's|/|-|g; s/[^a-z0-9._-]/-/g; s/--*/-/g; s/^-//; s/-$//' \
             | cut -c1-50)
@@ -47,7 +44,7 @@ jobs:
           TAG="${BRANCH}-${SHA}-memprofile"
           echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "git_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "Building branch=${BRANCH_NAME} sha=${SHA} tag=${TAG}"
+          echo "Building branch=${{ inputs.branch }} sha=${SHA} tag=${TAG}"
 
   build-go-binaries:
     name: Build Go binaries
@@ -58,7 +55,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          ref: ${{ inputs.branch }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -94,7 +91,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
+          ref: ${{ inputs.branch }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ RUN chmod +x /bin/numaflow
 # Rust binary
 ####################################################################################################
 # Dependency reuse relies on BuildKit cache mounts below (not cargo-chef layer caching).
+# ENABLE_MEMORY_PROFILING=true builds a dynamically linked glibc binary (required for LD_PRELOAD).
 FROM rust:1.97.1-trixie AS rust-builder
 ARG TARGETPLATFORM
+ARG ENABLE_MEMORY_PROFILING=false
 WORKDIR /numaflow
 RUN apt-get update && apt-get install -y --no-install-recommends \
     protobuf-compiler cmake clang \
@@ -53,13 +55,34 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
         "linux/arm64") TARGET="aarch64-unknown-linux-gnu" ;; \
     *) echo "Unsupported platform: ${TARGETPLATFORM}" && exit 1 ;; \
     esac && \
-    RUSTFLAGS='-C target-feature=+crt-static' cargo build -p numaflow --profile ${CARGO_PROFILE} --target ${TARGET} && \
+    if [ "${ENABLE_MEMORY_PROFILING}" = "true" ]; then \
+        RUSTFLAGS_VAL=""; \
+    else \
+        RUSTFLAGS_VAL="-C target-feature=+crt-static"; \
+    fi && \
+    RUSTFLAGS="${RUSTFLAGS_VAL}" cargo build -p numaflow --profile ${CARGO_PROFILE} --target ${TARGET} && \
     case ${CARGO_PROFILE} in \
         "dev") OUT_DIR="debug" ;; \
         *) OUT_DIR="${CARGO_PROFILE}" ;; \
     esac && \
     cp -pv target/${TARGET}/${OUT_DIR}/numaflow /root/numaflow && \
     cp -pv target/${TARGET}/${OUT_DIR}/entrypoint /root/entrypoint
+
+####################################################################################################
+# bytehound (libbytehound.so) — built from source for amd64 and arm64
+####################################################################################################
+FROM rust:1.97.1-trixie AS bytehound-builder
+ARG BYTEHOUND_REF=0.11.0
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates build-essential pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+# Clone first so cargo picks up bytehound's rust-toolchain (pinned nightly).
+RUN git clone --depth 1 --branch "${BYTEHOUND_REF}" https://github.com/koute/bytehound.git .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build --release -p bytehound-preload \
+    && cp -pv target/release/libbytehound.so /libbytehound.so
 
 ####################################################################################################
 # numaflow
@@ -76,6 +99,23 @@ COPY ui/build /ui/build
 
 # TODO: remove this when we are ported everything to Rust
 COPY --from=rust-builder /root/entrypoint /bin/entrypoint
+ENTRYPOINT ["/bin/entrypoint"]
+
+####################################################################################################
+# numaflow-memprofile (dynamic glibc + libbytehound.so for LD_PRELOAD profiling)
+# Build with: --target numaflow-memprofile --build-arg ENABLE_MEMORY_PROFILING=true
+####################################################################################################
+FROM debian:trixie-slim AS numaflow-memprofile
+ARG ARCH
+
+COPY --from=base /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=base /bin/numaflow /bin/numaflow
+COPY --from=rust-builder /root/numaflow /bin/numaflow-rs
+COPY --from=rust-builder /root/entrypoint /bin/entrypoint
+COPY --from=bytehound-builder /libbytehound.so /usr/share/libbytehound.so
+COPY ui/build /ui/build
+
 ENTRYPOINT ["/bin/entrypoint"]
 
 ####################################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     && cp -pv target/release/libbytehound.so /libbytehound.so
 
 ####################################################################################################
-# numaflow
+# numaflow (local / image-dev — Rust from rust-builder)
 ####################################################################################################
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} AS numaflow
@@ -99,6 +99,29 @@ COPY ui/build /ui/build
 
 # TODO: remove this when we are ported everything to Rust
 COPY --from=rust-builder /root/entrypoint /bin/entrypoint
+ENTRYPOINT ["/bin/entrypoint"]
+
+####################################################################################################
+# numaflow-ci (GitHub Actions — host-built Rust binaries from dist/, skips rust-builder)
+####################################################################################################
+FROM base AS base-ci
+ARG ARCH
+COPY dist/numaflow-rs-linux-${ARCH} /bin/numaflow-rs
+COPY dist/entrypoint-linux-${ARCH} /bin/entrypoint
+RUN chmod +x /bin/numaflow-rs /bin/entrypoint
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS numaflow-ci
+ARG ARCH
+
+COPY --from=base-ci /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=base-ci /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=base-ci /bin/numaflow /bin/numaflow
+COPY --from=base-ci /bin/numaflow-rs /bin/numaflow-rs
+COPY ui/build /ui/build
+
+# TODO: remove this when we are ported everything to Rust
+COPY --from=base-ci /bin/entrypoint /bin/entrypoint
 ENTRYPOINT ["/bin/entrypoint"]
 
 ####################################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=scratch
 ARG ARCH=$TARGETARCH
 ####################################################################################################
-# base
+# base (host-built Go binary + CA/tz data)
 ####################################################################################################
 FROM alpine:3.17 AS base
 ARG ARCH
@@ -10,14 +10,7 @@ RUN apk update && apk upgrade && \
     apk --no-cache add tzdata
 
 COPY dist/numaflow-linux-${ARCH} /bin/numaflow
-COPY dist/numaflow-rs-linux-${ARCH} /bin/numaflow-rs
-
 RUN chmod +x /bin/numaflow
-RUN chmod +x /bin/numaflow-rs
-
-# TODO: remove this when we are ported everything to Rust
-COPY dist/entrypoint-linux-${ARCH} /bin/entrypoint
-RUN chmod +x /bin/entrypoint
 
 ####################################################################################################
 # Rust binary
@@ -69,13 +62,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp -pv target/${TARGET}/${OUT_DIR}/entrypoint /root/entrypoint
 
 ####################################################################################################
-# Thin export of Rust binaries (avoids --load of the full rust-builder image)
-####################################################################################################
-FROM scratch AS rust-artifacts
-COPY --from=rust-builder /root/numaflow /numaflow-rs
-COPY --from=rust-builder /root/entrypoint /entrypoint
-
-####################################################################################################
 # numaflow
 ####################################################################################################
 ARG BASE_IMAGE
@@ -85,11 +71,11 @@ ARG ARCH
 COPY --from=base /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=base /bin/numaflow /bin/numaflow
-COPY --from=base /bin/numaflow-rs /bin/numaflow-rs
+COPY --from=rust-builder /root/numaflow /bin/numaflow-rs
 COPY ui/build /ui/build
 
 # TODO: remove this when we are ported everything to Rust
-COPY --from=base /bin/entrypoint /bin/entrypoint
+COPY --from=rust-builder /root/entrypoint /bin/entrypoint
 ENTRYPOINT ["/bin/entrypoint"]
 
 ####################################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,15 @@ RUN chmod +x /bin/entrypoint
 ####################################################################################################
 # Rust binary
 ####################################################################################################
-FROM lukemathwalker/cargo-chef:latest-rust-1.95 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.97 AS chef
 ARG TARGETPLATFORM
 WORKDIR /numaflow
 RUN apt-get update && apt-get install -y protobuf-compiler cmake clang
+
+# Install the pinned toolchain once; inherited by planner and rust-builder.
+# Kept in chef so source-only changes do not re-download the toolchain.
+COPY rust/rust-toolchain.toml ./rust-toolchain.toml
+RUN rustup show
 
 FROM chef AS planner
 COPY ./rust/ .
@@ -35,15 +40,19 @@ FROM chef AS rust-builder
 
 COPY --from=planner /numaflow/recipe.json recipe.json
 
+# Cargo profile: "release" (default, fat LTO) or "image-dev" (faster local builds).
+ARG CARGO_PROFILE=release
+
 # Build to cache dependencies
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/numaflow/target \
     case ${TARGETPLATFORM} in \
         "linux/amd64") TARGET="x86_64-unknown-linux-gnu" ;; \
         "linux/arm64") TARGET="aarch64-unknown-linux-gnu" ;; \
     *) echo "Unsupported platform: ${TARGETPLATFORM}" && exit 1 ;; \
     esac && \
-    RUSTFLAGS='-C target-feature=+crt-static' cargo chef cook --workspace --release --target ${TARGET} --recipe-path recipe.json
+    RUSTFLAGS='-C target-feature=+crt-static' cargo chef cook -p numaflow --profile ${CARGO_PROFILE} --target ${TARGET} --recipe-path recipe.json
 
 # Copy the actual source code files of the main project and the subprojects
 COPY ./rust/ .
@@ -64,18 +73,32 @@ ARG GIT_TREE_STATE
 ENV GIT_TREE_STATE=$GIT_TREE_STATE
 ARG GIT_TAG
 ENV GIT_TAG=$GIT_TAG
+# Re-declare so the value is available after COPY (Docker ARG scope)
+ARG CARGO_PROFILE=release
 
 # Build the real binaries
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/numaflow/target \
     case ${TARGETPLATFORM} in \
         "linux/amd64") TARGET="x86_64-unknown-linux-gnu" ;; \
         "linux/arm64") TARGET="aarch64-unknown-linux-gnu" ;; \
     *) echo "Unsupported platform: ${TARGETPLATFORM}" && exit 1 ;; \
     esac && \
-    RUSTFLAGS='-C target-feature=+crt-static' cargo build --workspace --all --release --target ${TARGET} && \
-    cp -pv target/${TARGET}/release/numaflow /root/numaflow && \
-    cp -pv target/${TARGET}/release/entrypoint /root/entrypoint
+    RUSTFLAGS='-C target-feature=+crt-static' cargo build -p numaflow --profile ${CARGO_PROFILE} --target ${TARGET} && \
+    case ${CARGO_PROFILE} in \
+        "dev") OUT_DIR="debug" ;; \
+        *) OUT_DIR="${CARGO_PROFILE}" ;; \
+    esac && \
+    cp -pv target/${TARGET}/${OUT_DIR}/numaflow /root/numaflow && \
+    cp -pv target/${TARGET}/${OUT_DIR}/entrypoint /root/entrypoint
+
+####################################################################################################
+# Thin export of Rust binaries (avoids --load of the full rust-builder image)
+####################################################################################################
+FROM scratch AS rust-artifacts
+COPY --from=rust-builder /root/numaflow /numaflow-rs
+COPY --from=rust-builder /root/entrypoint /entrypoint
 
 ####################################################################################################
 # numaflow

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,42 +22,20 @@ RUN chmod +x /bin/entrypoint
 ####################################################################################################
 # Rust binary
 ####################################################################################################
-FROM lukemathwalker/cargo-chef:latest-rust-1.97 AS chef
+# Dependency reuse relies on BuildKit cache mounts below (not cargo-chef layer caching).
+FROM rust:1.97.1-trixie AS rust-builder
 ARG TARGETPLATFORM
 WORKDIR /numaflow
-RUN apt-get update && apt-get install -y protobuf-compiler cmake clang
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    protobuf-compiler cmake clang \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install the pinned toolchain once; inherited by planner and rust-builder.
-# Kept in chef so source-only changes do not re-download the toolchain.
+# Install the pinned toolchain so source-only changes do not re-download it.
 COPY rust/rust-toolchain.toml ./rust-toolchain.toml
 RUN rustup show
 
-FROM chef AS planner
-COPY ./rust/ .
-RUN cargo chef prepare --recipe-path recipe.json
-
-FROM chef AS rust-builder
-
-COPY --from=planner /numaflow/recipe.json recipe.json
-
-# Cargo profile: "release" (default, fat LTO) or "image-dev" (faster local builds).
-ARG CARGO_PROFILE=release
-
-# Build to cache dependencies
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/numaflow/target \
-    case ${TARGETPLATFORM} in \
-        "linux/amd64") TARGET="x86_64-unknown-linux-gnu" ;; \
-        "linux/arm64") TARGET="aarch64-unknown-linux-gnu" ;; \
-    *) echo "Unsupported platform: ${TARGETPLATFORM}" && exit 1 ;; \
-    esac && \
-    RUSTFLAGS='-C target-feature=+crt-static' cargo chef cook -p numaflow --profile ${CARGO_PROFILE} --target ${TARGET} --recipe-path recipe.json
-
-# Copy the actual source code files of the main project and the subprojects
 COPY ./rust/ .
 
-ARG TARGETPLATFORM
 ARG ARCH
 ARG VERSION=latest
 ENV VERSION=$VERSION
@@ -71,12 +49,9 @@ ARG GIT_TAG
 ENV GIT_TAG=$GIT_TAG
 ARG GIT_TREE_STATE
 ENV GIT_TREE_STATE=$GIT_TREE_STATE
-ARG GIT_TAG
-ENV GIT_TAG=$GIT_TAG
-# Re-declare so the value is available after COPY (Docker ARG scope)
+# Cargo profile: "release" (default, fat LTO) or "image-dev" (faster local builds).
 ARG CARGO_PROFILE=release
 
-# Build the real binaries
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/numaflow/target \

--- a/Makefile
+++ b/Makefile
@@ -193,14 +193,8 @@ ifneq ($(SKIP_UI_BUILD),true)
 	$(MAKE) ui-build
 endif
 	# Always rebuild the host Go binary (pattern rule has no source deps; -B forces it).
+	# Rust is built inside the Dockerfile rust-builder stage (single docker build).
 	$(MAKE) -B dist/$(BINARY_NAME)-linux-$(HOST_ARCH)
-ifdef GITHUB_ACTIONS
-	# The binary will be built in a separate Github Actions job
-	cp -pv numaflow-rs-linux-amd64 dist/numaflow-rs-linux-amd64
-	cp -pv entrypoint-linux-amd64 dist/entrypoint-linux-amd64
-else
-	$(MAKE) build-rust-in-docker
-endif
 	DOCKER_BUILDKIT=1 $(DOCKER) build --build-arg "BASE_IMAGE=$(DEV_BASE_IMAGE)" $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION) --target $(BINARY_NAME) -f $(DOCKERFILE) .
 	@if [[ "$(DOCKER_PUSH)" = "true" ]]; then $(DOCKER) push $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION); fi
 ifdef IMAGE_IMPORT_CMD
@@ -219,42 +213,13 @@ image-dev:
 	fi; \
 	$(MAKE) image CARGO_PROFILE=image-dev SKIP_CLEAN=true SKIP_UI_BUILD=$$skip_ui
 
-.PHONY: build-rust-in-docker
-build-rust-in-docker:
-	mkdir -p dist
-	# Export only the thin rust-artifacts stage (two binaries). Do not --load rust-builder
-	# (toolchain + sources + fat binary) or --output the full builder rootfs.
-	DOCKER_BUILDKIT=1 $(DOCKER) build --build-arg "BASE_IMAGE=$(DEV_BASE_IMAGE)" $(DOCKER_BUILD_ARGS) \
-		--target rust-artifacts -f $(DOCKERFILE) \
-		--output type=local,dest=dist/rust-out .
-	cp -pv dist/rust-out/numaflow-rs dist/numaflow-rs-linux-$(HOST_ARCH)
-	cp -pv dist/rust-out/entrypoint dist/entrypoint-linux-$(HOST_ARCH)
-
-.PHONY: build-rust-in-docker-multi
-build-rust-in-docker-multi:
-	mkdir -p dist
-	docker run $(DOCKER_ENV_ARGS) -v ./dist/cargo:/root/.cargo -v ./rust/:/app/ -w /app --rm ubuntu:24.04 bash build.sh all
-	cp -pv rust/target/aarch64-unknown-linux-gnu/release/numaflow dist/numaflow-rs-linux-arm64
-	cp -pv rust/target/x86_64-unknown-linux-gnu/release/numaflow dist/numaflow-rs-linux-amd64
-	cp -pv rust/target/aarch64-unknown-linux-gnu/release/entrypoint dist/entrypoint-linux-arm64
-	cp -pv rust/target/x86_64-unknown-linux-gnu/release/entrypoint dist/entrypoint-linux-amd64
-
-# Set Rust target triplet based on host architecture
-RUST_TARGET_TRIPLET := x86_64-unknown-linux-gnu
-ifeq ($(HOST_ARCH),arm64)
-	RUST_TARGET_TRIPLET := aarch64-unknown-linux-gnu
-endif
-
-
 .PHONY: build-rust-docker-ghactions
 build-rust-docker-ghactions:
 	mkdir -p dist
 	docker run $(DOCKER_ENV_ARGS) -v ./dist/cargo:/root/.cargo -v ./rust/:/app/ -w /app --rm ubuntu:24.04 bash build.sh $(HOST_ARCH)
 
+# Rust is built per-platform in the Dockerfile rust-builder stage.
 image-multi: ui-build set-qemu dist/$(BINARY_NAME)-linux-arm64.gz dist/$(BINARY_NAME)-linux-amd64.gz
-ifndef GITHUB_ACTIONS
-	$(MAKE) build-rust-in-docker-multi
-endif
 	$(DOCKER) buildx build --sbom=false --provenance=false --build-arg "BASE_IMAGE=$(RELEASE_BASE_IMAGE)" $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION) --target $(BINARY_NAME) --platform linux/amd64,linux/arm64 --file $(DOCKERFILE) ${PUSH_OPTION} .
 
 set-qemu:

--- a/Makefile
+++ b/Makefile
@@ -313,12 +313,20 @@ lint: $(GOPATH)/bin/golangci-lint
 	$(GOPATH)/bin/golangci-lint run --fix --verbose --concurrency 4 --timeout 5m
 	cd rust && cargo fmt -- --check || (echo "Run 'cd rust && cargo fmt' to fix formatting issues" && exit 1)
 
+# Image target used by `start`. Default `image` preserves CI/release behavior.
+# Local fast path: make start IMAGE_TARGET=image-dev  (or: make start-dev)
+IMAGE_TARGET ?= image
+
 .PHONY: start
-start: image
+start: $(IMAGE_TARGET)
 	kubectl apply -f test/manifests/numaflow-ns.yaml
 	kubectl -n numaflow-system delete cm numaflow-cmd-params-config --ignore-not-found=true
 	kubectl kustomize test/manifests | sed 's@quay.io/numaproj/@$(IMAGE_NAMESPACE)/@' | sed 's/:$(BASE_VERSION)/:$(VERSION)/' | kubectl -n numaflow-system apply -l app.kubernetes.io/part-of=numaflow --prune=false --force -f -
 	kubectl -n numaflow-system wait deployment -lapp.kubernetes.io/part-of=numaflow --for=condition=Available --timeout 60s
+
+.PHONY: start-dev
+start-dev:
+	$(MAKE) start IMAGE_TARGET=image-dev
 
 .PHONY: e2eapi-image
 e2eapi-image: clean dist/e2eapi

--- a/Makefile
+++ b/Makefile
@@ -196,9 +196,17 @@ ifneq ($(SKIP_UI_BUILD),true)
 	$(MAKE) ui-build
 endif
 	# Always rebuild the host Go binary (pattern rule has no source deps; -B forces it).
-	# Rust is built inside the Dockerfile rust-builder stage (single docker build).
 	$(MAKE) -B dist/$(BINARY_NAME)-linux-$(HOST_ARCH)
+ifdef GITHUB_ACTIONS
+	# Rust is built in a separate job (build-rust-amd64); package only — skip rust-builder.
+	mkdir -p dist
+	cp -pv numaflow-rs-linux-amd64 dist/numaflow-rs-linux-amd64
+	cp -pv entrypoint-linux-amd64 dist/entrypoint-linux-amd64
+	DOCKER_BUILDKIT=1 $(DOCKER) build --build-arg "BASE_IMAGE=$(DEV_BASE_IMAGE)" $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION) --target $(BINARY_NAME)-ci -f $(DOCKERFILE) .
+else
+	# Local: Rust is built inside the Dockerfile rust-builder stage (single docker build).
 	DOCKER_BUILDKIT=1 $(DOCKER) build --build-arg "BASE_IMAGE=$(DEV_BASE_IMAGE)" $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION) --target $(BINARY_NAME) -f $(DOCKERFILE) .
+endif
 	@if [[ "$(DOCKER_PUSH)" = "true" ]]; then $(DOCKER) push $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION); fi
 ifdef IMAGE_IMPORT_CMD
 	$(IMAGE_IMPORT_CMD) $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION)
@@ -249,9 +257,13 @@ build-rust-docker-ghactions:
 	mkdir -p dist
 	docker run $(DOCKER_ENV_ARGS) -v ./dist/cargo:/root/.cargo -v ./rust/:/app/ -w /app --rm ubuntu:24.04 bash build.sh $(HOST_ARCH)
 
-# Rust is built per-platform in the Dockerfile rust-builder stage.
+# CI: prebuilt Rust binaries are already in dist/ (download-artifact). Local: rust-builder in Docker.
 image-multi: ui-build set-qemu dist/$(BINARY_NAME)-linux-arm64.gz dist/$(BINARY_NAME)-linux-amd64.gz
+ifdef GITHUB_ACTIONS
+	$(DOCKER) buildx build --sbom=false --provenance=false --build-arg "BASE_IMAGE=$(RELEASE_BASE_IMAGE)" $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION) --target $(BINARY_NAME)-ci --platform linux/amd64,linux/arm64 --file $(DOCKERFILE) ${PUSH_OPTION} .
+else
 	$(DOCKER) buildx build --sbom=false --provenance=false --build-arg "BASE_IMAGE=$(RELEASE_BASE_IMAGE)" $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION) --target $(BINARY_NAME) --platform linux/amd64,linux/arm64 --file $(DOCKERFILE) ${PUSH_OPTION} .
+endif
 
 set-qemu:
 	$(DOCKER) pull tonistiigi/binfmt:latest

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ VERSION=$(GIT_TAG)
 override LDFLAGS += -X ${PACKAGE}.gitTag=${GIT_TAG}
 endif
 
-DOCKER_BUILD_ARGS=--build-arg "VERSION=$(VERSION)" --build-arg "BUILD_DATE=$(BUILD_DATE)" --build-arg "GIT_COMMIT=$(GIT_COMMIT)" --build-arg "GIT_BRANCH=$(GIT_BRANCH)" --build-arg "GIT_TAG=$(GIT_TAG)" --build-arg "GIT_TREE_STATE=$(GIT_TREE_STATE)"
+# Cargo profile for the Rust image build. Use "image-dev" for faster local rebuilds (see make image-dev).
+CARGO_PROFILE?=release
+DOCKER_BUILD_ARGS=--build-arg "VERSION=$(VERSION)" --build-arg "BUILD_DATE=$(BUILD_DATE)" --build-arg "GIT_COMMIT=$(GIT_COMMIT)" --build-arg "GIT_BRANCH=$(GIT_BRANCH)" --build-arg "GIT_TAG=$(GIT_TAG)" --build-arg "GIT_TREE_STATE=$(GIT_TREE_STATE)" --build-arg "CARGO_PROFILE=$(CARGO_PROFILE)"
 DOCKER_ENV_ARGS=--env "VERSION=$(VERSION)" --env "BUILD_DATE=$(BUILD_DATE)" --env "GIT_COMMIT=$(GIT_COMMIT)" --env "GIT_BRANCH=$(GIT_BRANCH)" --env "GIT_TAG=$(GIT_TAG)" --env "GIT_TREE_STATE=$(GIT_TREE_STATE)"
 
 # Check Python
@@ -176,8 +178,22 @@ ui-build:
 ui-test: ui-build
 	./hack/test-ui.sh
 
+# Optional knobs for `image` / `image-dev` (defaults preserve CI / release behavior).
+SKIP_CLEAN ?= false
+SKIP_UI_BUILD ?= false
+# Force a UI rebuild on image-dev: make image-dev UI_BUILD=true
+UI_BUILD ?= false
+
 .PHONY: image
-image: clean ui-build dist/$(BINARY_NAME)-linux-$(HOST_ARCH)
+image:
+ifneq ($(SKIP_CLEAN),true)
+	$(MAKE) clean
+endif
+ifneq ($(SKIP_UI_BUILD),true)
+	$(MAKE) ui-build
+endif
+	# Always rebuild the host Go binary (pattern rule has no source deps; -B forces it).
+	$(MAKE) -B dist/$(BINARY_NAME)-linux-$(HOST_ARCH)
 ifdef GITHUB_ACTIONS
 	# The binary will be built in a separate Github Actions job
 	cp -pv numaflow-rs-linux-amd64 dist/numaflow-rs-linux-amd64
@@ -191,11 +207,28 @@ ifdef IMAGE_IMPORT_CMD
 	$(IMAGE_IMPORT_CMD) $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION)
 endif
 
+# Faster local image build using the slim `image-dev` Cargo profile (still statically linked).
+# Skips `clean` and skips UI when ui/node_modules (and ui/build) already exist.
+# Force UI rebuild: make image-dev UI_BUILD=true
+.PHONY: image-dev
+image-dev:
+	@skip_ui=false; \
+	if [[ "$(UI_BUILD)" != "true" && "$(UI_BUILD)" != "1" && -d ui/node_modules && -d ui/build ]]; then \
+		skip_ui=true; \
+		echo "Skipping ui-build (ui/node_modules present). Force with: make image-dev UI_BUILD=true"; \
+	fi; \
+	$(MAKE) image CARGO_PROFILE=image-dev SKIP_CLEAN=true SKIP_UI_BUILD=$$skip_ui
+
 .PHONY: build-rust-in-docker
 build-rust-in-docker:
 	mkdir -p dist
-	DOCKER_BUILDKIT=1 $(DOCKER) build --build-arg "BASE_IMAGE=$(DEV_BASE_IMAGE)" $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAMESPACE)/$(BINARY_NAME)-rust-builder:$(VERSION) --target rust-builder -f $(DOCKERFILE) . --load
-	export CTR=$$($(DOCKER) create $(IMAGE_NAMESPACE)/$(BINARY_NAME)-rust-builder:$(VERSION)) && $(DOCKER) cp $$CTR:/root/numaflow dist/numaflow-rs-linux-$(HOST_ARCH) && $(DOCKER) cp $$CTR:/root/entrypoint dist/entrypoint-linux-$(HOST_ARCH)
+	# Export only the thin rust-artifacts stage (two binaries). Do not --load rust-builder
+	# (toolchain + sources + fat binary) or --output the full builder rootfs.
+	DOCKER_BUILDKIT=1 $(DOCKER) build --build-arg "BASE_IMAGE=$(DEV_BASE_IMAGE)" $(DOCKER_BUILD_ARGS) \
+		--target rust-artifacts -f $(DOCKERFILE) \
+		--output type=local,dest=dist/rust-out .
+	cp -pv dist/rust-out/numaflow-rs dist/numaflow-rs-linux-$(HOST_ARCH)
+	cp -pv dist/rust-out/entrypoint dist/entrypoint-linux-$(HOST_ARCH)
 
 .PHONY: build-rust-in-docker-multi
 build-rust-in-docker-multi:

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ endif
 CARGO_PROFILE?=release
 DOCKER_BUILD_ARGS=--build-arg "VERSION=$(VERSION)" --build-arg "BUILD_DATE=$(BUILD_DATE)" --build-arg "GIT_COMMIT=$(GIT_COMMIT)" --build-arg "GIT_BRANCH=$(GIT_BRANCH)" --build-arg "GIT_TAG=$(GIT_TAG)" --build-arg "GIT_TREE_STATE=$(GIT_TREE_STATE)" --build-arg "CARGO_PROFILE=$(CARGO_PROFILE)"
 DOCKER_ENV_ARGS=--env "VERSION=$(VERSION)" --env "BUILD_DATE=$(BUILD_DATE)" --env "GIT_COMMIT=$(GIT_COMMIT)" --env "GIT_BRANCH=$(GIT_BRANCH)" --env "GIT_TAG=$(GIT_TAG)" --env "GIT_TREE_STATE=$(GIT_TREE_STATE)"
+# Tag for memory-profiling image builds (single-arch; see make image-memprofile).
+MEMPROFILE_IMAGE_TAG?=$(VERSION)-memprofile
+BYTEHOUND_REF?=0.11.0
 
 # Check Python
 PYTHON:=$(shell command -v python 2> /dev/null)
@@ -212,6 +215,34 @@ image-dev:
 		echo "Skipping ui-build (ui/node_modules present). Force with: make image-dev UI_BUILD=true"; \
 	fi; \
 	$(MAKE) image CARGO_PROFILE=image-dev SKIP_CLEAN=true SKIP_UI_BUILD=$$skip_ui
+
+# Single-arch memory-profiling image (dynamic glibc + libbytehound.so).
+# Native only — do not use buildx/QEMU (rdkafka). For multi-arch, build per-arch on
+# native runners and join with docker buildx imagetools (see memprofile-image workflow).
+# Override tag: make image-memprofile MEMPROFILE_IMAGE_TAG=my-tag
+# CI: pass SKIP_CLEAN=true and pre-populate dist/numaflow-linux-$(HOST_ARCH).
+.PHONY: image-memprofile
+image-memprofile:
+ifneq ($(SKIP_CLEAN),true)
+	$(MAKE) clean
+endif
+ifneq ($(SKIP_UI_BUILD),true)
+	$(MAKE) ui-build
+endif
+	@if [[ ! -f dist/$(BINARY_NAME)-linux-$(HOST_ARCH) ]]; then \
+		$(MAKE) dist/$(BINARY_NAME)-linux-$(HOST_ARCH); \
+	fi
+	DOCKER_BUILDKIT=1 $(DOCKER) build \
+		--build-arg "ENABLE_MEMORY_PROFILING=true" \
+		--build-arg "BYTEHOUND_REF=$(BYTEHOUND_REF)" \
+		$(DOCKER_BUILD_ARGS) \
+		-t $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(MEMPROFILE_IMAGE_TAG) \
+		--target $(BINARY_NAME)-memprofile \
+		-f $(DOCKERFILE) .
+	@if [[ "$(DOCKER_PUSH)" = "true" ]]; then $(DOCKER) push $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(MEMPROFILE_IMAGE_TAG); fi
+ifdef IMAGE_IMPORT_CMD
+	$(IMAGE_IMPORT_CMD) $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(MEMPROFILE_IMAGE_TAG)
+endif
 
 .PHONY: build-rust-docker-ghactions
 build-rust-docker-ghactions:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 DIST_DIR=${CURRENT_DIR}/dist
 BINARY_NAME:=numaflow
 DOCKERFILE:=Dockerfile
-DEV_BASE_IMAGE:=debian:bookworm
+DEV_BASE_IMAGE:=debian:trixie-slim
 RELEASE_BASE_IMAGE:=scratch
 
 BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')

--- a/docs/user-guide/reference/memory-profiling.md
+++ b/docs/user-guide/reference/memory-profiling.md
@@ -3,62 +3,63 @@
 ## Numa container memory profiling
 
 This section explores attaching [bytehound](https://github.com/koute/bytehound) (heap profiler via `LD_PRELOAD`)
-mem profiler to the numaflow-core process in the **`numa` main container** and captures a `.dat` for analysis offline
+mem profiler to the numaflow-core process in the **`numa` main container** and captures a `.dat` for analysis offline.
 
-The stock numaflow image **cannot** be profiled as-is since the rust binary is built with `-C target-feature=+crt-static`
+The stock numaflow image **cannot** be profiled as-is since the Rust binary is built with `-C target-feature=+crt-static`
 (fully static -> no dynamic loader) and the release image is `FROM scratch` (no `ld.so`/libc).
 Both make `LD_PRELOAD` silently do nothing. We need a *dynamic glibc* binary on a *glibc* base.
 
+Use `make image-memprofile` for that: it builds a dynamically linked `numaflow-rs`, compiles
+`libbytehound.so` from source (amd64 and arm64), and packages them on `debian:trixie-slim`.
+
 ### Prerequisites
 
-- bytehound prebuilt is **x86_64 only** (v0.11.0). Cluster nodes must be x86_64, or build bytehound from source for arm64.
 - kubectl + permission to edit the numaflow controller Deployment (`numaflow-system`).
-- docker/buildx to build & push the numaflow image.
+- Docker (BuildKit) to build & push a single-arch image locally, **or** use the
+  [`memprofile-image`](https://github.com/numaproj/numaflow/actions/workflows/memprofile-image.yml)
+  GitHub Actions workflow for a multi-arch image.
 
-### Step 1 - Get `libbytehound.so`
+### Step 1 - Build a *profilable* numaflow image
 
-Download `bytehound-x86_64-unknown-linux-gnu.tgz` from [link](https://github.com/koute/bytehound/releases) and extract.
-We get `libbytehound.so` (goes into the image) and `bytehound` (the CLI/server, run locally to analyze).
-
-### Step 2 - Build a *profilable* numaflow image
-
-Edit `numaflow/Dockerfile`:
-
-- Remove `-C target-feature=+crt-static` from the `RUSTFLAGS='...'` line on the `cargo build`
-  in the `rust-builder` stage -> dynamic glibc binary.
-- Add `COPY libbytehound.so /usr/share/libbytehound.so` into the final `numaflow` stage (drop
-  `libbytehound.so` at the build context root first). Use the same path for `LD_PRELOAD` in Step 4.
-
-Edit `numaflow/Makefile`:
-
-- Builder is `rust:1.97.1-trixie` = Debian **trixie** (glibc 2.41).
-
-  Make the final `numaflow` stage base glibc **and >= the builder's glibc**.
-- If using `make image` update `DEV_BASE_IMAGE` to `debian:trixie-slim`
-- Otherwise, if using `make image-multi` update `RELEASE_BASE_IMAGE` to `debian:trixie-slim`
-
-
-
-Verify it's dynamic (in the rust-builder stage or a throwaway container):
+**Local:**
 
 ```bash
-ldd /bin/numaflow-rs      # must list libc.so.6, NOT "not a dynamic executable"
+# Default tag: <IMAGE_NAMESPACE>/numaflow:<VERSION>-memprofile
+make image-memprofile
+
+# Faster local rebuilds (image-dev Cargo profile) + skip clean/UI when already built:
+make image-memprofile CARGO_PROFILE=image-dev SKIP_CLEAN=true SKIP_UI_BUILD=true
+
+# Custom tag / push:
+make image-memprofile MEMPROFILE_IMAGE_TAG=my-tag DOCKER_PUSH=true IMAGE_NAMESPACE=<your-registry>
 ```
 
-### Step 3 - Point the controller at the profiling image
+**CI (multi-arch):** run the `memprofile-image` workflow (`workflow_dispatch`) with the branch to build.
+It publishes `quay.io/<org>/numaflow:<branch>-<sha7>-memprofile` (amd64 + arm64 manifest).
+
+Verify the image is dynamic and includes bytehound:
+
+```bash
+docker run --rm --entrypoint /bin/sh <IMAGE_NAMESPACE>/numaflow:<tag> -c '
+  ldd /bin/numaflow-rs | grep libc   # must list libc.so.6, NOT "not a dynamic executable"
+  test -f /usr/share/libbytehound.so
+'
+```
+
+### Step 2 - Point the controller at the profiling image
 
 ```bash
 kubectl -n <numaflow-ns> set env deploy/<controller> NUMAFLOW_IMAGE=<your-registry>/<img>:<tag>
 kubectl -n <numaflow-ns> rollout restart deploy/<controller>
 ```
 
-### Step 4 - Pipeline spec: profiling env on the reduce vertex
+### Step 3 - Pipeline spec: profiling env on the reduce vertex
 
 ```yaml
   - name: <vertex-name>
     containerTemplate:
       env:
-        - { name: LD_PRELOAD, value: /usr/share/libbytehound.so }            # match Step 2 path
+        - { name: LD_PRELOAD, value: /usr/share/libbytehound.so }
         - { name: MEMORY_PROFILER_TRACK_CHILD_PROCESSES, value: "1" }        # REQUIRED (see note)
         - { name: MEMORY_PROFILER_OUTPUT, value: /var/numaflow/pbq/memory-profiling_%e_%t_%p.dat }
         - { name: MEMORY_PROFILER_LOG, value: info }
@@ -73,7 +74,7 @@ Then `kubectl apply -f <pipeline>.yaml && kubectl delete pod <accum-pod>`.
 `LD_PRELOAD` during its own init in `entrypoint` (to avoid following children), so the exec'd
 `numaflow-rs` starts **unprofiled**. Setting `1` keeps `LD_PRELOAD` across the exec.
 
-### Step 5 - Verify bytehound is attached
+### Step 4 - Verify bytehound is attached
 
 ```bash
 kubectl exec <accum-pod> -c numa -- env LD_PRELOAD= sh -c '
@@ -84,7 +85,7 @@ kubectl exec <accum-pod> -c numa -- env LD_PRELOAD= sh -c '
 
 `env LD_PRELOAD=` clears the var for *your* shell/commands only.
 
-### Step 6 - Collect the `.dat` (do NOT use `kubectl cp`)
+### Step 5 - Collect the `.dat` (do NOT use `kubectl cp`)
 
 `kubectl cp` runs `tar` *inside* the pod; under `TRACK_CHILD_PROCESSES=1` bytehound injects into that
 `tar` and it **SIGSEGVs**. Stream it out with `LD_PRELOAD` cleared:
@@ -96,7 +97,10 @@ kubectl exec <accum-pod> -c numa -- \
 kubectl exec <accum-pod> -c numa -- env LD_PRELOAD= kill -USR1 1
 ```
 
-### Step 7 - Analyze
+### Step 6 - Analyze
+
+Download the `bytehound` CLI from the [bytehound releases](https://github.com/koute/bytehound/releases)
+(prebuilt is x86_64; the image itself already embeds an arch-matched `libbytehound.so` built from source).
 
 ```bash
 ./bytehound server memory-profiling_numaflow-rs_<t>_1.dat   # -> http://localhost:8080

--- a/docs/user-guide/reference/memory-profiling.md
+++ b/docs/user-guide/reference/memory-profiling.md
@@ -24,17 +24,19 @@ We get `libbytehound.so` (goes into the image) and `bytehound` (the CLI/server, 
 
 Edit `numaflow/Dockerfile`:
 
-- Remove `-C target-feature=+crt-static` from **both** `RUSTFLAGS='...'` lines (the `cargo chef cook`
-  line and the `cargo build` line) -> dynamic glibc binary.
+- Remove `-C target-feature=+crt-static` from the `RUSTFLAGS='...'` line on the `cargo build`
+  in the `rust-builder` stage -> dynamic glibc binary.
 - Add `COPY libbytehound.so /usr/share/libbytehound.so` into the final `numaflow` stage (drop
   `libbytehound.so` at the build context root first). Use the same path for `LD_PRELOAD` in Step 4.
 
 Edit `numaflow/Makefile`:
 
-- Builder is `lukemathwalker/cargo-chef:latest-rust-1.97` = Debian **trixie** (glibc 2.41).
+- Builder is `rust:1.97.1-trixie` = Debian **trixie** (glibc 2.41).
+
   Make the final `numaflow` stage base glibc **and >= the builder's glibc**.
 - If using `make image` update `DEV_BASE_IMAGE` to `debian:trixie-slim`
 - Otherwise, if using `make image-multi` update `RELEASE_BASE_IMAGE` to `debian:trixie-slim`
+
 
 
 Verify it's dynamic (in the rust-builder stage or a throwaway container):

--- a/docs/user-guide/reference/memory-profiling.md
+++ b/docs/user-guide/reference/memory-profiling.md
@@ -2,22 +2,22 @@
 
 ## Numa container memory profiling
 
-This section explores attaching [bytehound](https://github.com/koute/bytehound) (heap profiler via `LD_PRELOAD`) 
+This section explores attaching [bytehound](https://github.com/koute/bytehound) (heap profiler via `LD_PRELOAD`)
 mem profiler to the numaflow-core process in the **`numa` main container** and captures a `.dat` for analysis offline
 
-The stock numaflow image **cannot** be profiled as-is since the rust binary is built with `-C target-feature=+crt-static` 
-(fully static -> no dynamic loader) and the release image is `FROM scratch` (no `ld.so`/libc). 
+The stock numaflow image **cannot** be profiled as-is since the rust binary is built with `-C target-feature=+crt-static`
+(fully static -> no dynamic loader) and the release image is `FROM scratch` (no `ld.so`/libc).
 Both make `LD_PRELOAD` silently do nothing. We need a *dynamic glibc* binary on a *glibc* base.
 
 ### Prerequisites
 
-- bytehound prebuilt is **x86_64 only** (v0.11.0). Cluster nodes must be x86_64, or build bytehound from source for arm64. 
+- bytehound prebuilt is **x86_64 only** (v0.11.0). Cluster nodes must be x86_64, or build bytehound from source for arm64.
 - kubectl + permission to edit the numaflow controller Deployment (`numaflow-system`).
 - docker/buildx to build & push the numaflow image.
 
 ### Step 1 - Get `libbytehound.so`
 
-Download `bytehound-x86_64-unknown-linux-gnu.tgz` from [link](https://github.com/koute/bytehound/releases) and extract. 
+Download `bytehound-x86_64-unknown-linux-gnu.tgz` from [link](https://github.com/koute/bytehound/releases) and extract.
 We get `libbytehound.so` (goes into the image) and `bytehound` (the CLI/server, run locally to analyze).
 
 ### Step 2 - Build a *profilable* numaflow image
@@ -31,8 +31,8 @@ Edit `numaflow/Dockerfile`:
 
 Edit `numaflow/Makefile`:
 
-- Builder is `lukemathwalker/cargo-chef:latest-rust-1.95` = Debian **trixie** (glibc 2.41). 
-  Make the final `numaflow` stage base glibc **and >= the builder's glibc**. 
+- Builder is `lukemathwalker/cargo-chef:latest-rust-1.97` = Debian **trixie** (glibc 2.41).
+  Make the final `numaflow` stage base glibc **and >= the builder's glibc**.
 - If using `make image` update `DEV_BASE_IMAGE` to `debian:trixie-slim`
 - Otherwise, if using `make image-multi` update `RELEASE_BASE_IMAGE` to `debian:trixie-slim`
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -54,13 +54,12 @@ verbose_file_reads = "warn"
 [profile.release]
 lto = "fat"
 
-# This profile optimizes for short build times at the expense of larger binary size and slower runtime performance.
-# If you have to rebuild image often, in Dockerfile you may replace `--release` passed to cargo command with `--profile quick-release`
-[profile.quick-release]
-inherits = "release"
-codegen-units = 16
-lto = false
-incremental = true
+# Fast local image builds (`make image-dev`): keep quick compiles from `dev`, but shrink the
+# binary so Docker export/copy is not dominated by a ~682 MB unstripped debug artifact.
+[profile.image-dev]
+inherits = "dev"
+debug = 0
+strip = "symbols"
 
 [workspace.dependencies]
 serving = { path = "serving" }

--- a/rust/numaflow-core/src/config/pipeline/watermark.rs
+++ b/rust/numaflow-core/src/config/pipeline/watermark.rs
@@ -53,7 +53,7 @@ impl WatermarkConfig {
             ot_bucket: Box::leak(
                 format!(
                     "{}-{}-{}-{}_OT",
-                    namespace, pipeline_name, vertex_name, &to.name
+                    namespace, pipeline_name, vertex_name, to.name
                 )
                 .into_boxed_str(),
             ),
@@ -68,7 +68,7 @@ impl WatermarkConfig {
                 ot_bucket: Box::leak(
                     format!(
                         "{}-{}-{}-{}_OT",
-                        namespace, pipeline_name, &from.name, vertex_name
+                        namespace, pipeline_name, from.name, vertex_name
                     )
                     .into_boxed_str(),
                 ),

--- a/rust/numaflow-core/src/pipeline/forwarder/sink_forwarder.rs
+++ b/rust/numaflow-core/src/pipeline/forwarder/sink_forwarder.rs
@@ -709,17 +709,14 @@ mod simple_buffer_tests {
 
         // Create a blackhole sink writer
         use crate::sinker::sink::SinkClientType;
-        let SinkTestHandle {
-            sink_writer,
-            ud_sink_server_handle: _,
-            ..
-        } = SinkTestHandle::create_sink::<crate::sinker::test_utils::NoOpSink>(
-            TestSinkType::BuiltIn(SinkClientType::Blackhole),
-            None,
-            None,
-            batch_size,
-        )
-        .await;
+        let SinkTestHandle { sink_writer, .. } =
+            SinkTestHandle::create_sink::<crate::sinker::test_utils::NoOpSink>(
+                TestSinkType::BuiltIn(SinkClientType::Blackhole),
+                None,
+                None,
+                batch_size,
+            )
+            .await;
 
         // ISB Reader Orchestrator
         let input_stream = Stream::new("bh-sink-input-buffer", "test-in", 0);

--- a/rust/numaflow-core/src/sinker/sink/log.rs
+++ b/rust/numaflow-core/src/sinker/sink/log.rs
@@ -14,7 +14,7 @@ impl Sink for LogSink {
 
             let log_line = format!(
                 "Payload - {} Keys - {} EventTime - {} Headers - {} ID - {}",
-                &String::from_utf8_lossy(&msg.value),
+                String::from_utf8_lossy(&msg.value),
                 msg.keys.join(","),
                 msg.event_time.timestamp_millis(),
                 headers,

--- a/rust/numaflow-core/src/watermark/source/source_wm_fetcher.rs
+++ b/rust/numaflow-core/src/watermark/source/source_wm_fetcher.rs
@@ -48,7 +48,7 @@ impl SourceWatermarkFetcher {
             .read()
             .expect("failed to acquire lock");
 
-        for (_, processor) in processors.iter() {
+        for processor in processors.values() {
             // We only consider active processors.
             if !processor.is_active() {
                 continue;
@@ -108,12 +108,12 @@ impl SourceWatermarkFetcher {
     pub(crate) fn fetch_head_watermark(&mut self, partition_idx: u16) -> Watermark {
         let mut min_wm = i64::MAX;
 
-        for (_, processor) in self
+        for processor in self
             .processor_manager
             .processors
             .read()
             .expect("failed to acquire lock")
-            .iter()
+            .values()
         {
             // We only consider active processors.
             if !processor.is_active() {

--- a/rust/numaflow-testing/src/simplebuffer/buffer.rs
+++ b/rust/numaflow-testing/src/simplebuffer/buffer.rs
@@ -142,7 +142,7 @@ impl BufferState {
                 // FIXME: this does not look very efficient since we will be calling reclaim_acked
                 //   very often.
                 // Update indices for remaining slots
-                for (_, idx) in self.offset_to_index.iter_mut() {
+                for idx in self.offset_to_index.values_mut() {
                     if *idx > 0 {
                         *idx -= 1;
                     }

--- a/rust/numaflow/src/main.rs
+++ b/rust/numaflow/src/main.rs
@@ -22,6 +22,8 @@ fn main() -> std::process::ExitCode {
         .install_default()
         .expect("Installing default CryptoProvider");
 
+    println!("Some changes");
+
     // Tokio runtime automatically spins up N number of worker threads based on the available cpu cores.
     // In a k8s environment, this value is calculated based on the `resources.limits.cpu` value. If it is not set,
     // the worker thread count will be equivalent to the logical cores available on the host node.

--- a/rust/numaflow/src/main.rs
+++ b/rust/numaflow/src/main.rs
@@ -22,8 +22,6 @@ fn main() -> std::process::ExitCode {
         .install_default()
         .expect("Installing default CryptoProvider");
 
-    println!("Some changes");
-
     // Tokio runtime automatically spins up N number of worker threads based on the available cpu cores.
     // In a k8s environment, this value is calculated based on the `resources.limits.cpu` value. If it is not set,
     // the worker thread count will be equivalent to the logical cores available on the host node.

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.95"
+channel = "1.97"

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.97"
+channel = "1.97.1"

--- a/rust/serving/src/app.rs
+++ b/rust/serving/src/app.rs
@@ -53,7 +53,7 @@ where
     T: Clone + Send + Sync + DataStore + 'static,
     U: Clone + Send + Sync + CallbackStore + 'static,
 {
-    let app_addr: SocketAddr = format!("0.0.0.0:{}", &app.settings.app_listen_https_port)
+    let app_addr: SocketAddr = format!("0.0.0.0:{}", app.settings.app_listen_https_port)
         .parse()
         .map_err(|e| InitError(format!("{e:?}")))?;
 

--- a/rust/serving/src/app/direct_proxy.rs
+++ b/rust/serving/src/app/direct_proxy.rs
@@ -47,7 +47,7 @@ async fn proxy(
     // This handler is registered with wildcard capture /*upstream. So the path here will never be empty.
     let path_query = request.uri().path_and_query().unwrap();
 
-    let upstream_uri = format!("http://{}{}", &proxy_state.upstream_addr, path_query);
+    let upstream_uri = format!("http://{}{}", proxy_state.upstream_addr, path_query);
     *request.uri_mut() = Uri::try_from(&upstream_uri)
         .inspect_err(|e| error!(?e, upstream_uri, "Parsing URI for upstream"))
         .map_err(|e| ApiError::BadRequest(e.to_string()))?;

--- a/rust/serving/src/lib.rs
+++ b/rust/serving/src/lib.rs
@@ -66,7 +66,7 @@ where
 
     // Start the metrics server, which serves the prometheus metrics.
     let metrics_addr: SocketAddr =
-        format!("0.0.0.0:{}", &app.settings.metrics_server_listen_port).parse()?;
+        format!("0.0.0.0:{}", app.settings.metrics_server_listen_port).parse()?;
 
     let metrics_server_handle = tokio::spawn(start_https_metrics_server(
         metrics_addr,


### PR DESCRIPTION
### What this PR does / why we need it
- Upgrade tool chain to Rust 1.97
- Use debian trixie (instead of bookworm) for dev image
- Removes the need for cargo-chef using buildkit cache mounts
- Added `make image-dev` that builds image in debug mode and other optimizations
- Workflow for building and pushing image with memory profiler (bytehound)

Image building after  a rust file change reduced from 9minute and 45 seconds to 15 seconds.


<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
