### PR TITLE
feat(api): scaffold /api/v2 with sysinfo and versioned auth errors

### DIFF
--- a/server/apis/v2/handler.go
+++ b/server/apis/v2/handler.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+type handler struct {
+	sysInfo any
+}
+
+// NewHandler creates a v2 API handler.
+func NewHandler(sysInfo any) *handler {
+	return &handler{sysInfo: sysInfo}
+}
+
+// SysInfo returns system information for the UI / clients.
+func (h *handler) SysInfo(c *gin.Context) {
+	WriteOK(c, h.sysInfo)
+}

--- a/server/apis/v2/handler_test.go
+++ b/server/apis/v2/handler_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestWriteOK(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	WriteOK(c, map[string]string{"hello": "world"})
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "world", data["hello"])
+}
+
+func TestWriteError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	WriteError(c, http.StatusNotFound, "NOT_FOUND", "pipeline not found")
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	var resp APIError
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "NOT_FOUND", resp.Error.Code)
+	assert.Equal(t, "pipeline not found", resp.Error.Message)
+}
+
+func TestSysInfo(t *testing.T) {
+	sysInfo := map[string]any{
+		"managedNamespace": "numaflow-system",
+		"namespaced":       false,
+		"version":          "test",
+	}
+	h := NewHandler(sysInfo)
+
+	router := gin.New()
+	router.GET("/sysinfo", h.SysInfo)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/sysinfo", nil)
+	require.NoError(t, err)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data, ok := resp.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "numaflow-system", data["managedNamespace"])
+	assert.Equal(t, false, data["namespaced"])
+	assert.Equal(t, "test", data["version"])
+}

--- a/server/apis/v2/response.go
+++ b/server/apis/v2/response.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// APIResponse is the success envelope for v2 endpoints.
+type APIResponse struct {
+	Data any `json:"data"`
+}
+
+// ErrorBody is the structured error payload for v2 endpoints.
+type ErrorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// APIError is the error envelope for v2 endpoints.
+type APIError struct {
+	Error ErrorBody `json:"error"`
+}
+
+// WriteOK writes a successful JSON response with HTTP 200.
+func WriteOK(c *gin.Context, data any) {
+	c.JSON(http.StatusOK, APIResponse{Data: data})
+}
+
+// WriteError writes a structured JSON error with the given HTTP status code.
+func WriteError(c *gin.Context, status int, code, message string) {
+	c.JSON(status, APIError{
+		Error: ErrorBody{
+			Code:    code,
+			Message: message,
+		},
+	})
+}

--- a/server/cmd/server/start.go
+++ b/server/cmd/server/start.go
@@ -178,6 +178,7 @@ func UrlRewrite(r *gin.Engine) gin.HandlerFunc {
 func CreateAuthRouteMap(baseHref string) authz.RouteMap {
 	return authz.RouteMap{
 		"GET:" + baseHref + "api/v1/sysinfo":                                                              authz.NewRouteInfo(authz.ObjectPipeline, false),
+		"GET:" + baseHref + "api/v2/sysinfo":                                                              authz.NewRouteInfo(authz.ObjectPipeline, false),
 		"GET:" + baseHref + "api/v1/authinfo":                                                             authz.NewRouteInfo(authz.ObjectEvents, false),
 		"GET:" + baseHref + "api/v1/namespaces":                                                           authz.NewRouteInfo(authz.ObjectEvents, false),
 		"GET:" + baseHref + "api/v1/cluster-summary":                                                      authz.NewRouteInfo(authz.ObjectPipeline, false),

--- a/server/cmd/server/start_test.go
+++ b/server/cmd/server/start_test.go
@@ -25,7 +25,9 @@ import (
 func TestCreateAuthRouteMap(t *testing.T) {
 	t.Run("empty base", func(t *testing.T) {
 		got := CreateAuthRouteMap("")
-		assert.Equal(t, 40, len(got))
+		assert.Equal(t, 41, len(got))
+		assert.Contains(t, got, "GET:api/v1/sysinfo")
+		assert.Contains(t, got, "GET:api/v2/sysinfo")
 		assert.Contains(t, got, "GET:api/v1/namespaces/:namespace/isb-services/:isb-service/jetstream")
 		assert.Contains(t, got, "GET:api/v1/namespaces/:namespace/pipelines/:pipeline/isb/streams")
 		assert.Contains(t, got, "GET:api/v1/namespaces/:namespace/pipelines/:pipeline/isb/consumers")
@@ -34,7 +36,8 @@ func TestCreateAuthRouteMap(t *testing.T) {
 
 	t.Run("customize base", func(t *testing.T) {
 		got := CreateAuthRouteMap("abcdefg")
-		assert.Equal(t, 40, len(got))
+		assert.Equal(t, 41, len(got))
+		assert.Contains(t, got, "GET:abcdefgapi/v2/sysinfo")
 		for k := range got {
 			assert.Contains(t, k, "abcdefg")
 		}

--- a/server/routes/auth_middleware.go
+++ b/server/routes/auth_middleware.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 	v1 "github.com/numaproj/numaflow/server/apis/v1"
+	v2 "github.com/numaproj/numaflow/server/apis/v2"
 	"github.com/numaproj/numaflow/server/authn"
 	"github.com/numaproj/numaflow/server/authz"
 	"github.com/numaproj/numaflow/server/common"
@@ -41,9 +43,7 @@ func authMiddleware(ctx context.Context, authorizer authz.Authorizer, dexAuthent
 
 		loginType, err := c.Cookie(common.LoginCookieName)
 		if err != nil {
-			errMsg := fmt.Sprintf("Failed to get login type: %v", err)
-			c.JSON(http.StatusUnauthorized, v1.NewNumaflowAPIResponse(&errMsg, nil))
-			c.Abort()
+			writeAuthError(c, http.StatusUnauthorized, "UNAUTHORIZED", fmt.Sprintf("Failed to get login type: %v", err))
 			return
 		}
 
@@ -54,15 +54,11 @@ func authMiddleware(ctx context.Context, authorizer authz.Authorizer, dexAuthent
 		case "local":
 			userInfo, err = localUsersAuthenticator.Authenticate(c)
 		default:
-			errMsg := fmt.Sprintf("unidentified login type received: %v", loginType)
-			c.JSON(http.StatusUnauthorized, v1.NewNumaflowAPIResponse(&errMsg, nil))
-			c.Abort()
+			writeAuthError(c, http.StatusUnauthorized, "UNAUTHORIZED", fmt.Sprintf("unidentified login type received: %v", loginType))
 			return
 		}
 		if err != nil {
-			errMsg := fmt.Sprintf("Failed to authenticate user: %v", err)
-			c.JSON(http.StatusUnauthorized, v1.NewNumaflowAPIResponse(&errMsg, nil))
-			c.Abort()
+			writeAuthError(c, http.StatusUnauthorized, "UNAUTHORIZED", fmt.Sprintf("Failed to authenticate user: %v", err))
 			return
 		}
 		// Check if the route requires authorization.
@@ -73,10 +69,7 @@ func authMiddleware(ctx context.Context, authorizer authz.Authorizer, dexAuthent
 				// If the user is authorized, continue the request.
 				c.Next()
 			} else {
-				// If the user is not authorized, return an error.
-				errMsg := "user is not authorized to execute the requested action"
-				c.JSON(http.StatusForbidden, v1.NewNumaflowAPIResponse(&errMsg, nil))
-				c.Abort()
+				writeAuthError(c, http.StatusForbidden, "FORBIDDEN", "user is not authorized to execute the requested action")
 			}
 		} else if authRouteMap.GetRouteFromContext(c) != nil && !authRouteMap.GetRouteFromContext(c).RequiresAuthZ {
 			// If the route does not require AuthZ, skip the AuthZ check.
@@ -84,9 +77,27 @@ func authMiddleware(ctx context.Context, authorizer authz.Authorizer, dexAuthent
 		} else {
 			// If the route is not present in the route map, return an error.
 			log.Errorw("route not present in routeMap", "route", authz.GetRouteMapKey(c))
-			errMsg := "Invalid route"
-			c.JSON(http.StatusForbidden, v1.NewNumaflowAPIResponse(&errMsg, nil))
-			c.Abort()
+			writeAuthError(c, http.StatusForbidden, "INVALID_ROUTE", "Invalid route")
 		}
 	}
+}
+
+// writeAuthError writes an auth failure using the v2 envelope for /api/v2 paths
+// and the legacy v1 envelope otherwise, then aborts the request.
+func writeAuthError(c *gin.Context, status int, code, message string) {
+	if isAPIV2Request(c) {
+		v2.WriteError(c, status, code, message)
+	} else {
+		msg := message
+		c.JSON(status, v1.NewNumaflowAPIResponse(&msg, nil))
+	}
+	c.Abort()
+}
+
+func isAPIV2Request(c *gin.Context) bool {
+	// Prefer FullPath when available (includes baseHref + /api/v2/...).
+	if path := c.FullPath(); path != "" && strings.Contains(path, "/api/v2") {
+		return true
+	}
+	return strings.Contains(c.Request.URL.Path, "/api/v2")
 }

--- a/server/routes/auth_middleware_test.go
+++ b/server/routes/auth_middleware_test.go
@@ -608,3 +608,77 @@ func TestAuthMiddleware_BothAuthTypesWork(t *testing.T) {
 	router.ServeHTTP(w2, req2)
 	assert.Equal(t, http.StatusOK, w2.Code)
 }
+
+func TestAuthMiddleware_V2MissingLoginCookie_UsesV2ErrorEnvelope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	ctx := context.Background()
+	routeMap := authz.RouteMap{
+		"GET:/api/v2/sysinfo": authz.NewRouteInfo("pipeline", false),
+	}
+
+	router := gin.New()
+	v2Group := router.Group("/api/v2")
+	v2Group.Use(authMiddleware(ctx, &mockAuthorizer{}, &mockAuthenticator{}, &mockAuthenticator{}, routeMap))
+	v2Group.GET("/sysinfo", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": "ok"})
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/v2/sysinfo", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.NotContains(t, response, "errMsg")
+	errObj, ok := response["error"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "UNAUTHORIZED", errObj["code"])
+	assert.Contains(t, errObj["message"], "Failed to get login type")
+}
+
+func TestAuthMiddleware_V2Forbidden_UsesV2ErrorEnvelope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	ctx := context.Background()
+	user := createTestUserInfo("user@example.com", []string{"viewer"})
+	authorizer := &mockAuthorizer{
+		authorizeFunc: func(c *gin.Context, userInfo *authn.UserInfo) bool {
+			return false
+		},
+	}
+	localAuth := &mockAuthenticator{
+		authenticateFunc: func(c *gin.Context) (*authn.UserInfo, error) {
+			return user, nil
+		},
+	}
+	routeMap := authz.RouteMap{
+		"GET:/api/v2/secure": authz.NewRouteInfo("pipeline", true),
+	}
+
+	router := gin.New()
+	v2Group := router.Group("/api/v2")
+	v2Group.Use(authMiddleware(ctx, authorizer, &mockAuthenticator{}, localAuth, routeMap))
+	v2Group.GET("/secure", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": "ok"})
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/v2/secure", nil)
+	req.AddCookie(&http.Cookie{Name: common.LoginCookieName, Value: "local"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.NotContains(t, response, "errMsg")
+	errObj, ok := response["error"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "FORBIDDEN", errObj["code"])
+	assert.Equal(t, "user is not authorized to execute the requested action", errObj["message"])
+}

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/numaproj/numaflow/server/apis/v1"
+	v2 "github.com/numaproj/numaflow/server/apis/v2"
 	"github.com/numaproj/numaflow/server/authz"
 )
 
@@ -72,6 +73,11 @@ func Routes(ctx context.Context, r *gin.Engine, sysInfo SystemInfo, authInfo Aut
 	// they share the AuthN/AuthZ middleware.
 	r1Group := r.Group(baseHref + "api/v1")
 	r1Group.Use(cleanResponseMiddleware())
+
+	// r2Group mounts the v2 API beside v1. Same middleware chain; handlers use v2 envelopes.
+	r2Group := r.Group(baseHref + "api/v2")
+	r2Group.Use(cleanResponseMiddleware())
+
 	if !authInfo.DisableAuth {
 		authorizer, err := authz.NewCasbinObject(ctx, authRouteMap)
 		if err != nil {
@@ -79,6 +85,7 @@ func Routes(ctx context.Context, r *gin.Engine, sysInfo SystemInfo, authInfo Aut
 		}
 		// Add the AuthN/AuthZ middleware to the group.
 		r1Group.Use(authMiddleware(ctx, authorizer, dexObj, localUsersAuthObj, authRouteMap))
+		r2Group.Use(authMiddleware(ctx, authorizer, dexObj, localUsersAuthObj, authRouteMap))
 		v1Routes(ctx, r1Group, dexObj, localUsersAuthObj, promQlServiceObj, sysInfo.IsReadOnly, sysInfo.DaemonClientProtocol)
 	} else {
 		v1Routes(ctx, r1Group, nil, nil, promQlServiceObj, sysInfo.IsReadOnly, sysInfo.DaemonClientProtocol)
@@ -86,6 +93,14 @@ func Routes(ctx context.Context, r *gin.Engine, sysInfo SystemInfo, authInfo Aut
 	r1Group.GET("/sysinfo", func(c *gin.Context) {
 		c.JSON(http.StatusOK, v1.NewNumaflowAPIResponse(nil, sysInfo))
 	})
+	v2Routes(r2Group, sysInfo)
+}
+
+// v2Routes defines the routes for the v2 API. For adding a new route, add a new handler
+// function along with an entry in CreateAuthRouteMap.
+func v2Routes(r gin.IRouter, sysInfo SystemInfo) {
+	handler := v2.NewHandler(sysInfo)
+	r.GET("/sysinfo", handler.SysInfo)
 }
 
 func v1RoutesNoAuth(r gin.IRouter, dexObj *v1.DexObject, localUsersAuthObject *v1.LocalUsersAuthObject) {

--- a/server/routes/routes_test.go
+++ b/server/routes/routes_test.go
@@ -66,3 +66,28 @@ func TestRoutes(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
 }
+
+func TestV2SysInfoRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	sysInfo := SystemInfo{
+		ManagedNamespace:     "numaflow-system",
+		Namespaced:           false,
+		IsReadOnly:           true,
+		DisableMetricsCharts: true,
+		Version:              "v-test",
+		DaemonClientProtocol: "grpc",
+	}
+	v2Routes(router.Group("/api/v2"), sysInfo)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/api/v2/sysinfo", nil)
+	require.NoError(t, err)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"managedNamespace":"numaflow-system"`)
+	assert.Contains(t, w.Body.String(), `"version":"v-test"`)
+	assert.Contains(t, w.Body.String(), `"data"`)
+	assert.NotContains(t, w.Body.String(), `"errMsg"`)
+}


### PR DESCRIPTION
### What this PR does / why we need it

Scaffold a versioned HTTP API surface under `/api/v2` beside the existing `/api/v1` UI server routes.

- Add `server/apis/v2` with success/error helpers (`{"data": ...}` / `{"error": {"code","message"}}`) and real HTTP status codes
- Mount `GET /api/v2/sysinfo` (same system fields as v1) with AuthZ route-map entry
- Make auth middleware return the **v2** error envelope for `/api/v2` paths on 401/403, while keeping `{errMsg, data}` for v1

This is the first slice of a lightweight, versioned API redesign. Follow-ups will add cluster summary and other v2 endpoints without breaking v1.

### Related issues

Fixes #

### Testing

- `go test ./server/apis/v2/... ./server/routes/... ./server/cmd/server/...`
- Manual: `curl -sk https://127.0.0.1:8443/api/v2/sysinfo` returns `{ "data": { ... } }` without `errMsg`
- Auth middleware tests cover v2 401/403 envelopes vs v1 `errMsg`

### Special notes for reviewers

- v1 handlers and response shape are unchanged for success paths
- Auth middleware is shared; error body is selected by `/api/v2` path detection
- No UI migration in this PR

<img width="1028" height="730" alt="Screenshot 2026-07-17 at 2 24 20 PM" src="https://github.com/user-attachments/assets/5001e9c2-c43c-4886-8f89-7236e7668fc8" />
