### PR TITLE
fix: own pipeline cleanup job by its ISB Service to avoid deleting a recreated pipeline's buffers

### DIFF
--- a/pkg/reconciler/pipeline/controller.go
+++ b/pkg/reconciler/pipeline/controller.go
@@ -631,7 +631,14 @@ func (r *pipelineReconciler) cleanUpBuffers(ctx context.Context, pl *dfv1.Pipeli
 		args = append(args, fmt.Sprintf("--side-inputs-store=%s", pl.GetSideInputsStoreName()))
 
 		batchJob := buildISBBatchJob(pl, r.image, isbSvc.Status.Config, "isbsvc-delete", args, "cln")
-		batchJob.OwnerReferences = []metav1.OwnerReference{}
+		batchJob.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion: dfv1.SchemeGroupVersion.String(),
+				Kind:       dfv1.ISBGroupVersionKind.Kind,
+				Name:       isbSvc.Name,
+				UID:        isbSvc.UID,
+			},
+		}
 		if err := r.client.Create(ctx, batchJob); err != nil && !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create buffer clean up job, err: %w", err)
 		}

--- a/pkg/reconciler/pipeline/controller.go
+++ b/pkg/reconciler/pipeline/controller.go
@@ -329,7 +329,7 @@ func (r *pipelineReconciler) reconcileFixedResources(ctx context.Context, pl *df
 		}
 		args := []string{fmt.Sprintf("--buffers=%s", strings.Join(bfs, ",")), fmt.Sprintf("--buckets=%s", strings.Join(bks, ","))}
 		args = append(args, fmt.Sprintf("--side-inputs-store=%s", pl.GetSideInputsStoreName()))
-		batchJob := buildISBBatchJob(pl, r.image, isbSvc.Status.Config, "isbsvc-create", args, "cre")
+		batchJob := buildISBBatchJob(pl, r.image, isbSvc.Status.Config, "isbsvc-create", args, "cre", *metav1.NewControllerRef(pl.GetObjectMeta(), dfv1.PipelineGroupVersionKind))
 		if err := r.client.Create(ctx, batchJob); err != nil && !apierrors.IsAlreadyExists(err) {
 			r.recorder.Eventf(pl, corev1.EventTypeWarning, "CreateJobForISBCreationFailed", "Failed to create a Job: %w", err.Error())
 			return fmt.Errorf("failed to create ISB creating job, err: %w", err)
@@ -348,7 +348,7 @@ func (r *pipelineReconciler) reconcileFixedResources(ctx context.Context, pl *df
 			bks = append(bks, k)
 		}
 		args := []string{fmt.Sprintf("--buffers=%s", strings.Join(bfs, ",")), fmt.Sprintf("--buckets=%s", strings.Join(bks, ","))}
-		batchJob := buildISBBatchJob(pl, r.image, isbSvc.Status.Config, "isbsvc-delete", args, "del")
+		batchJob := buildISBBatchJob(pl, r.image, isbSvc.Status.Config, "isbsvc-delete", args, "del", *metav1.NewControllerRef(pl.GetObjectMeta(), dfv1.PipelineGroupVersionKind))
 		if err := r.client.Create(ctx, batchJob); err != nil && !apierrors.IsAlreadyExists(err) {
 			r.recorder.Eventf(pl, corev1.EventTypeWarning, "CreateJobForISBDeletionFailed", "Failed to create a Job: %w", err.Error())
 			return fmt.Errorf("failed to create ISB deleting job, err: %w", err)
@@ -630,15 +630,13 @@ func (r *pipelineReconciler) cleanUpBuffers(ctx context.Context, pl *dfv1.Pipeli
 		args = append(args, fmt.Sprintf("--buckets=%s", strings.Join(allBuckets, ",")))
 		args = append(args, fmt.Sprintf("--side-inputs-store=%s", pl.GetSideInputsStoreName()))
 
-		batchJob := buildISBBatchJob(pl, r.image, isbSvc.Status.Config, "isbsvc-delete", args, "cln")
-		batchJob.OwnerReferences = []metav1.OwnerReference{
-			{
-				APIVersion: dfv1.SchemeGroupVersion.String(),
-				Kind:       dfv1.ISBGroupVersionKind.Kind,
-				Name:       isbSvc.Name,
-				UID:        isbSvc.UID,
-			},
+		isbSvcOwner := metav1.OwnerReference{
+			APIVersion: dfv1.SchemeGroupVersion.String(),
+			Kind:       dfv1.ISBGroupVersionKind.Kind,
+			Name:       isbSvc.Name,
+			UID:        isbSvc.UID,
 		}
+		batchJob := buildISBBatchJob(pl, r.image, isbSvc.Status.Config, "isbsvc-delete", args, "cln", isbSvcOwner)
 		if err := r.client.Create(ctx, batchJob); err != nil && !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create buffer clean up job, err: %w", err)
 		}
@@ -869,7 +867,7 @@ func copyEdges(pl *dfv1.Pipeline, edges []dfv1.Edge) []dfv1.CombinedEdge {
 	return result
 }
 
-func buildISBBatchJob(pl *dfv1.Pipeline, image string, isbSvcConfig dfv1.BufferServiceConfig, subCommand string, args []string, jobType string) *batchv1.Job {
+func buildISBBatchJob(pl *dfv1.Pipeline, image string, isbSvcConfig dfv1.BufferServiceConfig, subCommand string, args []string, jobType string, owner metav1.OwnerReference) *batchv1.Job {
 	isbsType, envs := sharedutil.GetIsbSvcEnvVars(isbSvcConfig)
 	envs = append(envs, corev1.EnvVar{Name: dfv1.EnvPipelineName, Value: pl.Name})
 	c := corev1.Container{
@@ -921,11 +919,9 @@ func buildISBBatchJob(pl *dfv1.Pipeline, image string, isbSvcConfig dfv1.BufferS
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: pl.Namespace,
 			// The name won't be over length limit, because we have validated "{pipeline}-{vertex}-headless" is no longer than 63.
-			Name:   fmt.Sprintf("%s-%s-%v", pl.Name, jobType, randomStr),
-			Labels: l,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(pl.GetObjectMeta(), dfv1.PipelineGroupVersionKind),
-			},
+			Name:            fmt.Sprintf("%s-%s-%v", pl.Name, jobType, randomStr),
+			Labels:          l,
+			OwnerReferences: []metav1.OwnerReference{owner},
 		},
 		Spec: spec,
 	}

--- a/pkg/reconciler/pipeline/controller_test.go
+++ b/pkg/reconciler/pipeline/controller_test.go
@@ -800,7 +800,7 @@ func Test_copyEdges(t *testing.T) {
 
 func Test_buildISBBatchJob(t *testing.T) {
 	t.Run("test build ISB batch job", func(t *testing.T) {
-		j := buildISBBatchJob(testPipeline, testFlowImage, fakeIsbSvcConfig, "subcmd", []string{"sss"}, "test")
+		j := buildISBBatchJob(testPipeline, testFlowImage, fakeIsbSvcConfig, "subcmd", []string{"sss"}, "test", *metav1.NewControllerRef(testPipeline.GetObjectMeta(), dfv1.PipelineGroupVersionKind))
 		assert.Equal(t, 1, len(j.Spec.Template.Spec.Containers))
 		assert.True(t, len(j.Spec.Template.Spec.Containers[0].Args) > 0)
 		assert.Contains(t, j.Name, testPipeline.Name+"-test-")
@@ -856,7 +856,7 @@ func Test_buildISBBatchJob(t *testing.T) {
 				},
 			},
 		}
-		j := buildISBBatchJob(pl, testFlowImage, fakeIsbSvcConfig, "subcmd", []string{"sss"}, "test")
+		j := buildISBBatchJob(pl, testFlowImage, fakeIsbSvcConfig, "subcmd", []string{"sss"}, "test", *metav1.NewControllerRef(pl.GetObjectMeta(), dfv1.PipelineGroupVersionKind))
 		assert.Equal(t, 1, len(j.Spec.Template.Spec.Containers))
 		assert.Equal(t, j.Spec.Template.Spec.Containers[0].Resources, resources)
 		assert.Greater(t, len(j.Spec.Template.Spec.Containers[0].Env), 1)

--- a/pkg/reconciler/pipeline/controller_test.go
+++ b/pkg/reconciler/pipeline/controller_test.go
@@ -916,7 +916,10 @@ func Test_cleanupBuffers(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(jobs.Items))
 		assert.Contains(t, jobs.Items[0].Name, "cln")
-		assert.Equal(t, 0, len(jobs.Items[0].OwnerReferences))
+		assert.Equal(t, 1, len(jobs.Items[0].OwnerReferences))
+		assert.Equal(t, dfv1.ISBGroupVersionKind.Kind, jobs.Items[0].OwnerReferences[0].Kind)
+		assert.Equal(t, testIsbSvc.Name, jobs.Items[0].OwnerReferences[0].Name)
+		assert.Equal(t, testIsbSvc.UID, jobs.Items[0].OwnerReferences[0].UID)
 	})
 }
 


### PR DESCRIPTION
### What this PR does

Makes the pipeline buffer-cleanup Job (`isbsvc-delete`, job type `cln`) owned by the **InterStepBufferService** it cleans up, instead of clearing its OwnerReferences entirely. Two commits: the behavioral fix (with the matching unit-test update), and a small follow-up refactor that has every `buildISBBatchJob` caller pass the job's owner explicitly, removing the build-then-mutate call site.

### The problem

We do an A/B deployment that alternates namespaces. Each deployment cycle brings up a new set of pipelines and if they are healthy we drain and tear down the old set.

If we do two A/B deployments back-to-back, we see a race where these cleanup jobs hang around after the application is marked as deleted, and then when the new deployment is brought back, up they delete resources on the next generation of the application.

The root cause of this is that numaflow pipelines don't clean up after themselves properly. They don't clean up after themselves properly because this cleanup job doesn't have the right owner.

Not sure what you guys think about this particular solution. Happy to take suggestions. 

We will probably work around this by not reusing the same namespace for new generations of deployment.  But we think it is probably a gap worth filling nevertheless. 

