### PR TITLE
feat(sqs): utilize nack options for SQS

### DIFF
--- a/rust/extns/numaflow-sqs/src/source.rs
+++ b/rust/extns/numaflow-sqs/src/source.rs
@@ -49,7 +49,11 @@ pub struct SqsSourceConfig {
     pub message_attribute_names: Vec<String>,
     pub assume_role_config: Option<AssumeRoleConfig>,
 }
-
+#[derive(Debug)]
+pub struct SqsNack {
+    pub receipt_handle: Bytes,
+    pub visibility_timeout: Option<i32>,
+}
 /// Internal message types for the actor implementation.
 ///
 /// The actor pattern is used to:
@@ -65,6 +69,10 @@ enum SQSActorMessage {
     Delete {
         respond_to: oneshot::Sender<Result<()>>,
         offsets: Vec<Bytes>,
+    },
+    Nack {
+        respond_to: oneshot::Sender<Result<()>>,
+        offsets: Vec<SqsNack>,
     },
     GetPending {
         respond_to: oneshot::Sender<Result<Option<usize>>>,
@@ -132,6 +140,7 @@ impl SqsActor {
                     .send(messages)
                     .expect("failed to send response from SqsActorMessage::Receive");
             }
+
             SQSActorMessage::Delete {
                 respond_to,
                 offsets,
@@ -141,6 +150,17 @@ impl SqsActor {
                     .send(status)
                     .expect("failed to send response from SqsActorMessage::Delete");
             }
+
+            SQSActorMessage::Nack {
+                respond_to,
+                offsets,
+            } => {
+                let status = self.nack_messages(offsets).await;
+                respond_to
+                    .send(status)
+                    .expect("failed to send response from SqsActorMessage::Nack");
+            }
+
             SQSActorMessage::GetPending { respond_to } => {
                 let status = self.get_pending_messages().await;
                 respond_to
@@ -336,6 +356,37 @@ impl SqsActor {
         Ok(())
     }
 
+    /// Changes visibility timeout for messages, serves as Numaflow source nack.
+    async fn nack_messages(&mut self, offsets: Vec<SqsNack>) -> Result<()> {
+        for nack in offsets {
+            let receipt_handle = std::str::from_utf8(&nack.receipt_handle).map_err(|err| {
+                error!(?err, "failed to parse receipt handle");
+                SqsSourceError::from(Error::Other("failed to parse receipt handle".to_string()))
+            })?;
+
+            let mut request = self
+                .client
+                .change_message_visibility()
+                .queue_url(&self.queue_url)
+                .receipt_handle(receipt_handle);
+
+            if let Some(timeout) = nack.visibility_timeout {
+                request = request.visibility_timeout(timeout);
+            }
+
+            if let Err(err) = request.send().await {
+                error!(
+                    ?err,
+                    queue_url = self.queue_url,
+                    "Failed to change message visibility"
+                );
+
+                return Err(SqsSourceError::from(Error::Sqs(extract_aws_error(&err))));
+            }
+        }
+
+        Ok(())
+    }
     /// get the pending message count from SQS using the ApproximateNumberOfMessages attribute
     /// Note: The ApproximateNumberOfMessages metrics may not achieve consistency until at least
     /// 1 minute after the producers stop sending messages.
@@ -542,6 +593,22 @@ impl SqsSource {
             respond_to: tx,
         };
         self.actor_tx.send(msg).await.expect("rx was dropped");
+        rx.await.map_err(Error::ActorTaskTerminated)?
+    }
+
+    /// Change message visibility for the provided offsets.
+    pub async fn nack_offsets(&self, offsets: Vec<SqsNack>) -> Result<()> {
+        tracing::debug!(?offsets, "Nacking offsets");
+
+        let (tx, rx) = oneshot::channel();
+
+        let msg = SQSActorMessage::Nack {
+            offsets,
+            respond_to: tx,
+        };
+
+        self.actor_tx.send(msg).await.expect("rx was dropped");
+
         rx.await.map_err(Error::ActorTaskTerminated)?
     }
 

--- a/rust/numaflow-core/src/source/sqs.rs
+++ b/rust/numaflow-core/src/source/sqs.rs
@@ -137,9 +137,21 @@ impl source::SourceAcker for SqsSource {
             };
 
             let visibility_timeout = nack
-                .option
-                .and_then(|opts| opts.delay)
-                .map(|delay_ms| (delay_ms / 1000) as i32);
+            .option
+            .and_then(|opts| opts.delay)
+            .map(|delay_ms| {
+                let visibility_timeout = delay_ms.div_ceil(1000) as i32;
+
+                if delay_ms % 1000 != 0 {
+                    tracing::warn!(
+                        requested_delay_ms = delay_ms,
+                        visibility_timeout_secs = visibility_timeout,
+                        "SQS visibility timeout only supports whole seconds; rounding requested delay up"
+                    );
+                }
+
+                visibility_timeout
+            });
 
             sqs_offsets.push(SqsNack {
                 receipt_handle: string_offset.offset,

--- a/rust/numaflow-core/src/source/sqs.rs
+++ b/rust/numaflow-core/src/source/sqs.rs
@@ -265,7 +265,7 @@ pub mod tests {
         let receive_message_output = get_receive_message_output();
 
         let delete_message_output = get_delete_message_output();
-
+        let change_visibility_output = get_change_message_visibility_output();
         let queue_attributes_output = get_queue_attributes_output();
 
         let sqs_operation_mocks = MockResponseInterceptor::new()
@@ -273,6 +273,7 @@ pub mod tests {
             .with_rule(&queue_url_output)
             .with_rule(&receive_message_output)
             .with_rule(&delete_message_output)
+            .with_rule(&change_visibility_output)
             .with_rule(&queue_attributes_output);
 
         let sqs_client =
@@ -409,6 +410,17 @@ pub mod tests {
                     .build()
                     .unwrap()
             })
+    }
+    fn get_change_message_visibility_output() -> Rule {
+        mock!(aws_sdk_sqs::Client::change_message_visibility)
+        .match_requests(|inp| {
+            inp.queue_url().unwrap()
+                == "https://sqs.us-west-2.amazonaws.com/926113353675/test-q/"
+        })
+        .then_output(|| {
+            aws_sdk_sqs::operation::change_message_visibility::ChangeMessageVisibilityOutput::builder()
+                .build()
+        })
     }
 
     fn get_receive_message_output() -> Rule {

--- a/rust/numaflow-core/src/source/sqs.rs
+++ b/rust/numaflow-core/src/source/sqs.rs
@@ -1,4 +1,4 @@
-use numaflow_sqs::source::{SqsMessage, SqsSource, SqsSourceBuilder, SqsSourceConfig};
+use numaflow_sqs::source::{SqsMessage, SqsNack, SqsSource, SqsSourceBuilder, SqsSourceConfig};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -125,12 +125,31 @@ impl source::SourceAcker for SqsSource {
         self.ack_offsets(sqs_offsets).await.map_err(Into::into)
     }
 
-    async fn nack(&mut self, _offsets: Vec<NackOffset>) -> crate::error::Result<()> {
-        // SQS doesn't support nack - no-op
-        Ok(())
+    async fn nack(&mut self, offsets: Vec<NackOffset>) -> crate::error::Result<()> {
+        let mut sqs_offsets = Vec::with_capacity(offsets.len());
+
+        for nack in offsets {
+            let Offset::String(string_offset) = nack.offset else {
+                return Err(Error::Source(format!(
+                    "Expected Offset::String type for SQS. offset={:?}",
+                    nack.offset
+                )));
+            };
+
+            let visibility_timeout = nack
+                .option
+                .and_then(|opts| opts.delay)
+                .map(|delay_ms| (delay_ms / 1000) as i32);
+
+            sqs_offsets.push(SqsNack {
+                receipt_handle: string_offset.offset.into(),
+                visibility_timeout,
+            });
+        }
+
+        self.nack_offsets(sqs_offsets).await.map_err(Into::into)
     }
 }
-
 impl source::LagReader for SqsSource {
     async fn pending(&mut self) -> crate::error::Result<Option<usize>> {
         Ok(self.pending_count().await)

--- a/rust/numaflow-core/src/source/sqs.rs
+++ b/rust/numaflow-core/src/source/sqs.rs
@@ -167,7 +167,6 @@ impl source::LagReader for SqsSource {
         Ok(self.pending_count().await)
     }
 }
-
 #[cfg(feature = "sqs-tests")]
 #[cfg(test)]
 pub mod tests {
@@ -187,7 +186,13 @@ pub mod tests {
     use tokio_util::sync::CancellationToken;
 
     use super::*;
+    use crate::shared::grpc::create_rpc_channel;
+    use crate::sinker::sink::{SinkClientType, SinkWriterBuilder};
     use crate::source::{Source, SourceType};
+    use numaflow::shared::ServerExtras;
+    use numaflow::sink;
+    use numaflow_pb::clients::sink::sink_client::SinkClient;
+    use tokio::sync::oneshot;
 
     #[tokio::test]
     async fn test_sqs_message_conversion() {
@@ -269,7 +274,33 @@ pub mod tests {
             Some(b"xyz789".as_slice())
         );
     }
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
 
+    struct NackOneSink {
+        first: Arc<AtomicBool>,
+    }
+
+    #[tonic::async_trait]
+    impl sink::Sinker for NackOneSink {
+        async fn sink(
+            &self,
+            mut input: tokio::sync::mpsc::Receiver<sink::SinkRequest>,
+        ) -> Vec<sink::Response> {
+            let mut responses = Vec::new();
+            while let Some(datum) = input.recv().await {
+                if self.first.swap(false, Ordering::SeqCst) {
+                    responses.push(sink::Response::nack(datum.id, None));
+                } else {
+                    responses.push(sink::Response::ok(datum.id));
+                }
+            }
+
+            responses
+        }
+    }
     #[tokio::test]
     async fn test_sqs_source_e2e() {
         let queue_url_output = get_queue_url_output();
@@ -314,7 +345,28 @@ pub mod tests {
         use crate::tracker::Tracker;
         let tracker = Tracker::new(None, CancellationToken::new());
         let cln_token = CancellationToken::new();
+        // Start User Defined Sink server
+        let (_shutdown_tx, shutdown_rx) = oneshot::channel();
 
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let sock_file = tmp_dir.path().join("sink.sock");
+        let server_info_file = tmp_dir.path().join("sink-server-info");
+
+        let server_socket = sock_file.clone();
+        let server_info = server_info_file.clone();
+
+        tokio::spawn(async move {
+            sink::Server::new(NackOneSink {
+                first: Arc::new(AtomicBool::new(true)),
+            })
+            .with_socket_file(server_socket)
+            .with_server_info_file(server_info)
+            .start_with_shutdown(shutdown_rx)
+            .await
+            .expect("failed to start sink server");
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
         let source: Source<crate::typ::WithoutRateLimiter> = Source::new(
             1,
             1,
@@ -330,12 +382,19 @@ pub mod tests {
         .await;
 
         // create sink writer
-        use crate::sinker::sink::{SinkClientType, SinkWriterBuilder};
-        let sink_writer =
-            SinkWriterBuilder::new(10, Duration::from_millis(100), SinkClientType::Log)
-                .build()
-                .await
-                .unwrap();
+        let sink_writer = SinkWriterBuilder::new(
+            10,
+            Duration::from_millis(100),
+            SinkClientType::UserDefined(
+                Box::new(SinkClient::new(
+                    create_rpc_channel(sock_file).await.unwrap(),
+                )),
+                None,
+            ),
+        )
+        .build()
+        .await
+        .unwrap();
 
         // create the forwarder with the source and sink writer
         let forwarder =
@@ -380,6 +439,8 @@ pub mod tests {
             "queue attributes output calls: {}",
             queue_attributes_output.num_calls()
         );
+        assert_eq!(change_visibility_output.num_calls(), 1);
+        assert!(delete_message_output.num_calls() >= 1);
     }
 
     fn get_queue_attributes_output() -> Rule {
@@ -436,21 +497,35 @@ pub mod tests {
     }
 
     fn get_receive_message_output() -> Rule {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_clone = Arc::clone(&calls);
+
         mock!(aws_sdk_sqs::Client::receive_message)
             .match_requests(|inp| {
-                inp.queue_url().unwrap() == "https://sqs.us-west-2.amazonaws.com/926113353675/test-q/"
+                inp.queue_url().unwrap()
+                    == "https://sqs.us-west-2.amazonaws.com/926113353675/test-q/"
             })
-            .then_output(|| {
-                aws_sdk_sqs::operation::receive_message::ReceiveMessageOutput::builder()
-                    .messages(
-                        aws_sdk_sqs::types::Message::builder()
-                            .message_id("219f8380-5770-4cc2-8c3e-5c715e145f5e")
-                            .body("This is a test message")
-                            .receipt_handle("AQEBaZ+j5qUoOAoxlmrCQPkBm9njMWXqemmIG6shMHCO6fV20JrQYg/AiZ8JELwLwOu5U61W+aIX5Qzu7GGofxJuvzymr4Ph53RiR0mudj4InLSgpSspYeTRDteBye5tV/txbZDdNZxsi+qqZA9xPnmMscKQqF6pGhnGIKrnkYGl45Nl6GPIZv62LrIRb6mSqOn1fn0yqrvmWuuY3w2UzQbaYunJWGxpzZze21EOBtywknU3Je/g7G9is+c6K9hGniddzhLkK1tHzZKjejOU4jokaiB4nmi0dF3JqLzDsQuPF0Gi8qffhEvw56nl8QCbluSJScFhJYvoagGnDbwOnd9z50L239qtFIgETdpKyirlWwl/NGjWJ45dqWpiW3d2Ws7q")
-                            .attributes(MessageSystemAttributeName::SentTimestamp, "1677112427387")
-                            .build()
-                    )
-                    .build()
+            .then_output(move || {
+                let count = calls_clone.fetch_add(1, Ordering::SeqCst);
+
+                if count < 2 {
+                    aws_sdk_sqs::operation::receive_message::ReceiveMessageOutput::builder()
+                        .messages(
+                            aws_sdk_sqs::types::Message::builder()
+                                .message_id("219f8380-5770-4cc2-8c3e-5c715e145f5e")
+                                .body("This is a test message")
+                                .receipt_handle("AQEBaZ+j5qUoOAoxlmrCQPkBm9njMWXqemmIG6shMHCO6fV20JrQYg/AiZ8JELwLwOu5U61W+aIX5Qzu7GGofxJuvzymr4Ph53RiR0mudj4InLSgpSspYeTRDteBye5tV/txbZDdNZxsi+qqZA9xPnmMscKQqF6pGhnGIKrnkYGl45Nl6GPIZv62LrIRb6mSqOn1fn0yqrvmWuuY3w2UzQbaYunJWGxpzZze21EOBtywknU3Je/g7G9is+c6K9hGniddzhLkK1tHzZKjejOU4jokaiB4nmi0dF3JqLzDsQuPF0Gi8qffhEvw56nl8QCbluSJScFhJYvoagGnDbwOnd9z50L239qtFIgETdpKyirlWwl/NGjWJ45dqWpiW3d2Ws7q")
+                                .attributes(
+                                    MessageSystemAttributeName::SentTimestamp,
+                                    "1677112427387",
+                                )
+                                .build(),
+                        )
+                        .build()
+                } else {
+                    aws_sdk_sqs::operation::receive_message::ReceiveMessageOutput::builder()
+                        .build()
+                }
             })
     }
 

--- a/rust/numaflow-core/src/source/sqs.rs
+++ b/rust/numaflow-core/src/source/sqs.rs
@@ -142,7 +142,7 @@ impl source::SourceAcker for SqsSource {
                 .map(|delay_ms| (delay_ms / 1000) as i32);
 
             sqs_offsets.push(SqsNack {
-                receipt_handle: string_offset.offset.into(),
+                receipt_handle: string_offset.offset,
                 visibility_timeout,
             });
         }


### PR DESCRIPTION
### What this PR does / why we need it

Implements support for SQS nack options by utilizing the SQS `ChangeMessageVisibility` API for negative acknowledgements.

This change introduces SQS-specific nack handling by propagating `NackOffset` information from `numaflow-core` to the SQS extension, allowing per-message visibility timeout to be applied when supported.

### Related issues

Fixes #3493

### Testing

- Ran `cargo fmt`.
- Verified the changes at the module level.
- Full workspace verification (`cargo check`) is currently blocked by an unrelated `krb5-src` dependency issue, which is not introduced by this change.

### Special notes for reviewers

- Introduces `SqsNack` to carry SQS-specific nack information.
- Adds `SQSActorMessage::Nack` and implements handling via the SQS `ChangeMessageVisibility` API.
- Wires `SourceAcker::nack()` in `numaflow-core` to convert generic `NackOffset` values into SQS-specific nack requests.
- Existing ack behavior remains unchanged.