### PR TITLE
refactor(ui): split PodLogs helpers and fix log stream lifecycle

### DIFF
--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/constants.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/constants.ts
@@ -1,0 +1,5 @@
+export const MAX_LOGS = 1000;
+
+export const NO_LOGS_MATCHING_SEARCH = "No logs matching search.";
+
+export const LOADING_LOGS = "Loading logs...";

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/constants.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/constants.ts
@@ -1,5 +1,5 @@
 export const MAX_LOGS = 1000;
 
-export const NO_LOGS_MATCHING_SEARCH = "No logs matching search.";
+export const NO_LOGS_MATCHING_SEARCH = "No logs match your search.";
 
 export const LOADING_LOGS = "Loading logs...";

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/filterLogs.test.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/filterLogs.test.ts
@@ -1,0 +1,22 @@
+import { filterLogs } from "./filterLogs";
+import { NO_LOGS_MATCHING_SEARCH } from "./constants";
+
+describe("filterLogs", () => {
+  const logs = ["alpha line", "beta line", "gamma"];
+
+  it("returns source logs when search is empty", () => {
+    expect(filterLogs(logs, "", false)).toEqual(logs);
+  });
+
+  it("filters by case-insensitive include", () => {
+    expect(filterLogs(logs, "BETA", false)).toEqual(["beta line"]);
+  });
+
+  it("supports negate search", () => {
+    expect(filterLogs(logs, "line", true)).toEqual(["gamma"]);
+  });
+
+  it("returns a placeholder when nothing matches", () => {
+    expect(filterLogs(logs, "xyz", false)).toEqual([NO_LOGS_MATCHING_SEARCH]);
+  });
+});

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/filterLogs.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/filterLogs.ts
@@ -1,0 +1,22 @@
+import { NO_LOGS_MATCHING_SEARCH } from "./constants";
+
+export function filterLogs(
+  logs: string[],
+  search: string,
+  negateSearch: boolean
+): string[] {
+  if (!search) {
+    return logs;
+  }
+  const searchLowerCase = search.toLowerCase();
+  const filtered = logs.filter((log) =>
+    negateSearch
+      ? !log.toLowerCase().includes(searchLowerCase)
+      : log.toLowerCase().includes(searchLowerCase)
+  );
+
+  if (!filtered.length) {
+    return [NO_LOGS_MATCHING_SEARCH];
+  }
+  return filtered;
+}

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.test.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.test.tsx
@@ -73,7 +73,7 @@ describe("PodLogs", () => {
       )[0],
       { target: { value: "xyz" } }
     );
-    expect(screen.getByText("No logs matching search.")).toBeVisible();
+    expect(screen.getByText("No logs match your search.")).toBeVisible();
     //negate logs search
     fireEvent.click(
       container.getElementsByClassName(

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import Box from "@mui/material/Box";
@@ -28,62 +29,13 @@ import Tooltip from "@mui/material/Tooltip";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Checkbox from "@mui/material/Checkbox";
 import Highlighter from "react-highlight-words";
-import "@stardazed/streams-polyfill";
-import { ReadableStreamDefaultReadResult } from "stream/web";
-import { getBaseHref } from "../../../../../../../../../../../../../utils";
 import { PodLogsProps } from "../../../../../../../../../../../../../types/declarations/pods";
 import { AppContextProps } from "../../../../../../../../../../../../../types/declarations/app";
 import { AppContext } from "../../../../../../../../../../../../../App";
+import { filterLogs } from "./filterLogs";
+import { usePodLogStream } from "./usePodLogStream";
 
 import "./style.css";
-
-const MAX_LOGS = 1000;
-
-const parsePodLogs = (
-  value: string,
-  enableTimestamp: boolean,
-  levelFilter: string,
-  type: string,
-  isErrorMessage: boolean
-): string[] => {
-  const rawLogs = value.split("\n").filter((s) => s.trim().length);
-  return rawLogs.map((raw: string) => {
-    // 30 characters for RFC 3339 timestamp
-    const timestamp =
-      raw.length >= 31 && !isErrorMessage ? raw.substring(0, 30) : "";
-    const logWithoutTimestamp =
-      raw.length >= 31 && !isErrorMessage ? raw.substring(31) : raw;
-
-    let msg = enableTimestamp ? `${timestamp} ` : "";
-
-    if (type === "monoVertex") {
-      if (
-        levelFilter !== "all" &&
-        !logWithoutTimestamp.includes(levelFilter.toUpperCase())
-      )
-        return "";
-
-      return `${msg}${logWithoutTimestamp}`;
-    } else {
-      let obj;
-      try {
-        obj = JSON.parse(logWithoutTimestamp);
-      } catch {
-        obj = logWithoutTimestamp;
-      }
-      // println log, it is not an object
-      if (obj === logWithoutTimestamp) {
-        if (levelFilter !== "all" && !obj.toLowerCase().includes(levelFilter))
-          return "";
-      } else if (obj?.level) {
-        // logger log
-        msg += `${obj.level.toUpperCase()} `;
-        if (levelFilter !== "all" && obj.level !== levelFilter) return "";
-      }
-      return `${msg}${logWithoutTimestamp}`;
-    }
-  });
-};
 
 export function PodLogs({
   namespaceId,
@@ -91,13 +43,6 @@ export function PodLogs({
   containerName,
   type,
 }: PodLogsProps) {
-  const [logs, setLogs] = useState<string[]>([]);
-  const [previousLogs, setPreviousLogs] = useState<string[]>([]);
-  const [filteredLogs, setFilteredLogs] = useState<string[]>([]);
-  const [logRequestKey, setLogRequestKey] = useState<string>("");
-  const [reader, setReader] = useState<
-    ReadableStreamDefaultReader | undefined
-  >();
   const [search, setSearch] = useState<string>("");
   const [negateSearch, setNegateSearch] = useState<boolean>(false);
   const [wrapLines, setWrapLines] = useState<boolean>(false);
@@ -109,172 +54,26 @@ export function PodLogs({
   const [showPreviousLogs, setShowPreviousLogs] = useState(false);
   const { host } = useContext<AppContextProps>(AppContext);
 
+  // Restart streaming if the source changes while paused
   useEffect(() => {
-    // reset logs in memory on any log source change
-    setLogs([]);
-    setPreviousLogs([]);
-    // and start logs again if paused
     setPaused(false);
   }, [namespaceId, podName, containerName]);
 
-  useEffect(() => {
-    if (paused) {
-      return;
-    }
-    const requestKey = `${namespaceId}-${podName}-${containerName}`;
-    if (logRequestKey && logRequestKey !== requestKey && reader) {
-      // Cancel open reader on param change
-      reader.cancel();
-      setReader(undefined);
-      return;
-    } else if (reader) {
-      // Don't open a new reader if one exists
-      return;
-    }
-    setLogRequestKey(requestKey);
-    setLogs(["Loading logs..."]);
-    fetch(
-      `${host}${getBaseHref()}/api/v1/namespaces/${namespaceId}/pods/${podName}/logs?container=${containerName}&follow=true&tailLines=${MAX_LOGS}`
-    )
-      .then((response) => {
-        if (response && response.body) {
-          const r = response.body
-            .pipeThrough(new TextDecoderStream())
-            .getReader();
-          setReader(r);
-          r.read().then(function process({
-            done,
-            value,
-          }): Promise<ReadableStreamDefaultReadResult<string>> {
-            if (done) {
-              return;
-            }
-            if (value) {
-              // Check if the value is an error response
-              let isErrorMessage = false;
-              try {
-                const jsonResponse = JSON.parse(value);
-                if (jsonResponse?.errMsg) {
-                  // If there's an error message, set value to errMsg
-                  value = jsonResponse.errMsg;
-                  isErrorMessage = true;
-                }
-              } catch {
-                //do nothing
-              }
-              setLogs((logs) => {
-                const latestLogs = parsePodLogs(
-                  value,
-                  enableTimestamp,
-                  levelFilter,
-                  type,
-                  isErrorMessage
-                )?.filter((logs) => logs !== "");
-                let updated = [...logs, ...latestLogs];
-                if (updated.length > MAX_LOGS) {
-                  updated = updated.slice(updated.length - MAX_LOGS);
-                }
-                return updated;
-              });
-            }
-            return r.read().then(process);
-          });
-        }
-      })
-      .catch(console.error);
-  }, [
+  const { logs, previousLogs } = usePodLogStream({
     namespaceId,
     podName,
     containerName,
-    reader,
+    type,
+    host,
     paused,
-    host,
     enableTimestamp,
     levelFilter,
-  ]);
-
-  useEffect(() => {
-    if (showPreviousLogs) {
-      setPreviousLogs([]);
-      const url = `${host}${getBaseHref()}/api/v1/namespaces/${namespaceId}/pods/${podName}/logs?container=${containerName}&follow=true&tailLines=${MAX_LOGS}&previous=true`;
-      fetch(url)
-        .then((response) => {
-          if (response && response.body) {
-            const reader = response.body
-              .pipeThrough(new TextDecoderStream())
-              .getReader();
-
-            reader.read().then(function process({ done, value }) {
-              if (done) {
-                return;
-              }
-              if (value) {
-                // Check if the value is an error response
-                let isErrorMessage = false;
-                try {
-                  const jsonResponse = JSON.parse(value);
-                  if (jsonResponse?.errMsg) {
-                    // If there's an error message, set value to errMsg
-                    value = jsonResponse.errMsg;
-                    isErrorMessage = true;
-                  }
-                } catch {
-                  //do nothing
-                }
-                setPreviousLogs((prevLogs) => {
-                  const latestLogs = parsePodLogs(
-                    value,
-                    enableTimestamp,
-                    levelFilter,
-                    type,
-                    isErrorMessage
-                  )?.filter((logs) => logs !== "");
-                  let updated = [...prevLogs, ...latestLogs];
-                  if (updated.length > MAX_LOGS) {
-                    updated = updated.slice(updated.length - MAX_LOGS);
-                  }
-                  return updated;
-                });
-              }
-              return reader.read().then(process);
-            });
-          }
-        })
-        .catch(console.error);
-    } else {
-      // Clear previous logs when the checkbox is unchecked
-      setPreviousLogs([]);
-    }
-  }, [
     showPreviousLogs,
-    namespaceId,
-    podName,
-    containerName,
-    host,
-    enableTimestamp,
-    levelFilter,
-  ]);
+  });
 
-  useEffect(() => {
-    if (!search) {
-      if (showPreviousLogs) {
-        setFilteredLogs(previousLogs);
-      } else {
-        setFilteredLogs(logs);
-      }
-      return;
-    }
-    const searchLowerCase = search.toLowerCase();
-    const filtered = (showPreviousLogs ? previousLogs : logs)?.filter((log) =>
-      negateSearch
-        ? !log.toLowerCase().includes(searchLowerCase)
-        : log.toLowerCase().includes(searchLowerCase)
-    );
-
-    if (!filtered.length) {
-      filtered.push("No logs matching search.");
-    }
-    setFilteredLogs(filtered);
+  const filteredLogs = useMemo(() => {
+    const source = showPreviousLogs ? previousLogs : logs;
+    return filterLogs(source, search, negateSearch);
   }, [showPreviousLogs, previousLogs, logs, search, negateSearch]);
 
   const handleSearchChange = useCallback(
@@ -300,12 +99,8 @@ export function PodLogs({
   }, []);
 
   const handlePause = useCallback(() => {
-    setPaused(!paused);
-    if (!paused && reader) {
-      reader.cancel();
-      setReader(undefined);
-    }
-  }, [paused, reader]);
+    setPaused((prev) => !prev);
+  }, []);
 
   const handleColorMode = useCallback(() => {
     setColorMode(colorMode === "light" ? "dark" : "light");
@@ -332,26 +127,15 @@ export function PodLogs({
 
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-  }, [logs]);
+  }, [logs, podName, containerName]);
 
   const handleTimestamps = useCallback(() => {
     setEnableTimestamp((prev) => !prev);
-    if (reader) {
-      reader.cancel();
-      setReader(undefined);
-    }
-  }, [reader]);
+  }, []);
 
-  const handleLevelChange = useCallback(
-    (e) => {
-      setLevelFilter(e.target.value);
-      if (reader) {
-        reader.cancel();
-        setReader(undefined);
-      }
-    },
-    [reader]
-  );
+  const handleLevelChange = useCallback((e) => {
+    setLevelFilter(e.target.value);
+  }, []);
 
   const logsBtnStyle = {
     height: "2.4rem",

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/parsePodLogs.test.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/parsePodLogs.test.ts
@@ -1,0 +1,96 @@
+import { extractLogChunk, parsePodLogs } from "./parsePodLogs";
+
+describe("extractLogChunk", () => {
+  it("returns errMsg when the chunk is an API error payload", () => {
+    expect(extractLogChunk(JSON.stringify({ errMsg: "boom" }))).toEqual({
+      text: "boom",
+      isErrorMessage: true,
+    });
+  });
+
+  it("returns the raw text for normal log chunks", () => {
+    const line = "2023-09-04T11:50:19.712416709Z hello";
+    expect(extractLogChunk(line)).toEqual({
+      text: line,
+      isErrorMessage: false,
+    });
+  });
+});
+
+describe("parsePodLogs", () => {
+  const ts = "2023-09-04T11:50:19.712416709Z";
+
+  it("parses JSON logger lines and prefixes level", () => {
+    const body = JSON.stringify({
+      level: "info",
+      msg: "hello",
+    });
+    const result = parsePodLogs(`${ts} ${body}`, {
+      enableTimestamp: false,
+      levelFilter: "all",
+      type: "pipeline",
+      isErrorMessage: false,
+    });
+    expect(result).toEqual([`INFO ${body}`]);
+  });
+
+  it("filters JSON logs by level", () => {
+    const info = JSON.stringify({ level: "info", msg: "ok" });
+    const error = JSON.stringify({ level: "error", msg: "bad" });
+    const result = parsePodLogs(`${ts} ${info}\n${ts} ${error}`, {
+      enableTimestamp: false,
+      levelFilter: "error",
+      type: "pipeline",
+      isErrorMessage: false,
+    }).filter((l) => l !== "");
+    expect(result).toEqual([`ERROR ${error}`]);
+  });
+
+  it("includes timestamps when enabled", () => {
+    const body = JSON.stringify({ level: "warn", msg: "careful" });
+    const result = parsePodLogs(`${ts} ${body}`, {
+      enableTimestamp: true,
+      levelFilter: "all",
+      type: "pipeline",
+      isErrorMessage: false,
+    });
+    expect(result[0]).toBe(`${ts} WARN ${body}`);
+  });
+
+  it("skips timestamp slicing for API error messages", () => {
+    const err = "Failed to get pod logs: not found";
+    const result = parsePodLogs(err, {
+      enableTimestamp: false,
+      levelFilter: "all",
+      type: "pipeline",
+      isErrorMessage: true,
+    });
+    expect(result).toEqual([err]);
+  });
+
+  it("filters monoVertex plain-text logs by uppercase level token", () => {
+    const result = parsePodLogs(
+      `${ts} something INFO happened\n${ts} something ERROR happened`,
+      {
+        enableTimestamp: false,
+        levelFilter: "error",
+        type: "monoVertex",
+        isErrorMessage: false,
+      }
+    ).filter((l) => l !== "");
+    expect(result).toEqual(["something ERROR happened"]);
+  });
+
+  it("filters plain (non-JSON) pipeline logs with substring match", () => {
+    const result = parsePodLogs(
+      `${ts} this is an error line\n${ts} this is fine`,
+      {
+        enableTimestamp: false,
+        levelFilter: "error",
+        type: "pipeline",
+        isErrorMessage: false,
+      }
+    ).filter((l) => l !== "");
+    expect(result).toEqual(["this is an error line"]);
+  });
+});

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/parsePodLogs.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/parsePodLogs.ts
@@ -1,0 +1,76 @@
+export type ParsePodLogsOptions = {
+  enableTimestamp: boolean;
+  levelFilter: string;
+  type: string;
+  isErrorMessage: boolean;
+};
+
+export type LogChunk = {
+  text: string;
+  isErrorMessage: boolean;
+};
+
+/**
+ * Detect API error payloads ({ errMsg }) vs raw log chunks from the stream.
+ */
+export function extractLogChunk(value: string): LogChunk {
+  try {
+    const jsonResponse = JSON.parse(value);
+    if (jsonResponse?.errMsg) {
+      return { text: jsonResponse.errMsg, isErrorMessage: true };
+    }
+  } catch {
+    // not a JSON error payload
+  }
+  return { text: value, isErrorMessage: false };
+}
+
+export function parsePodLogs(
+  value: string,
+  opts: ParsePodLogsOptions
+): string[] {
+  const { enableTimestamp, levelFilter, type, isErrorMessage } = opts;
+  const rawLogs = value.split("\n").filter((s) => s.trim().length);
+  return rawLogs.map((raw: string) => {
+    // 30 characters for RFC 3339 timestamp
+    const timestamp =
+      raw.length >= 31 && !isErrorMessage ? raw.substring(0, 30) : "";
+    const logWithoutTimestamp =
+      raw.length >= 31 && !isErrorMessage ? raw.substring(31) : raw;
+
+    let msg = enableTimestamp ? `${timestamp} ` : "";
+
+    if (type === "monoVertex") {
+      if (
+        levelFilter !== "all" &&
+        !logWithoutTimestamp.includes(levelFilter.toUpperCase())
+      )
+        return "";
+
+      return `${msg}${logWithoutTimestamp}`;
+    }
+
+    let obj: unknown;
+    try {
+      obj = JSON.parse(logWithoutTimestamp);
+    } catch {
+      obj = logWithoutTimestamp;
+    }
+    // println log, it is not an object
+    if (obj === logWithoutTimestamp) {
+      if (levelFilter !== "all" && !obj.toLowerCase().includes(levelFilter))
+        return "";
+    } else if (
+      obj &&
+      typeof obj === "object" &&
+      "level" in obj &&
+      typeof (obj as { level: unknown }).level === "string"
+    ) {
+      const level = (obj as { level: string }).level;
+      // logger log
+      msg += `${level.toUpperCase()} `;
+      if (levelFilter !== "all" && level !== levelFilter) return "";
+    }
+    return `${msg}${logWithoutTimestamp}`;
+  });
+}

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/usePodLogStream.test.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/usePodLogStream.test.ts
@@ -1,5 +1,153 @@
-import { appendCapped, buildPodLogsUrl } from "./usePodLogStream";
+import { TextDecoder, TextEncoder } from "util";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  appendCapped,
+  buildPodLogsUrl,
+  usePodLogStream,
+  UsePodLogStreamParams,
+} from "./usePodLogStream";
 import { MAX_LOGS } from "./constants";
+
+// jsdom lacks these; @stardazed/streams-polyfill's TextDecoderStream needs them.
+Object.assign(global, { TextDecoder, TextEncoder });
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function abortError(): Error {
+  return Object.assign(new Error("Aborted"), { name: "AbortError" });
+}
+
+type FetchHandle = {
+  url: string;
+  signal: AbortSignal;
+  cancelSpy: jest.Mock;
+  resolveFetch: () => void;
+  pushText: (text: string) => void;
+  close: () => void;
+};
+
+/**
+ * Controllable fetch mock: body.pipeThrough(...).getReader() yields string
+ * chunks so tests do not depend on TextDecoderStream in jsdom.
+ */
+function installFetchMock() {
+  const handles: FetchHandle[] = [];
+  const fetchMock = jest.fn(
+    (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const signal = init?.signal as AbortSignal;
+      const cancelSpy = jest.fn().mockResolvedValue(undefined);
+      const pendingReads: Array<
+        (result: ReadableStreamReadResult<string>) => void
+      > = [];
+      const queued: ReadableStreamReadResult<string>[] = [];
+
+      const settleRead = (result: ReadableStreamReadResult<string>) => {
+        const waiter = pendingReads.shift();
+        if (waiter) {
+          waiter(result);
+          return;
+        }
+        queued.push(result);
+      };
+
+      const reader = {
+        read: () => {
+          if (queued.length > 0) {
+            return Promise.resolve(queued.shift()!);
+          }
+          return new Promise<ReadableStreamReadResult<string>>((resolve) => {
+            pendingReads.push(resolve);
+          });
+        },
+        cancel: (reason?: unknown) => cancelSpy(reason),
+      };
+
+      const body = {
+        pipeThrough: () => ({
+          getReader: () => reader,
+        }),
+      };
+
+      const d = deferred<Response>();
+      let settled = false;
+
+      const rejectOnce = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        d.reject(abortError());
+      };
+
+      const handle: FetchHandle = {
+        url,
+        signal,
+        cancelSpy,
+        resolveFetch: () => {
+          if (settled) {
+            return;
+          }
+          if (signal?.aborted) {
+            rejectOnce();
+            return;
+          }
+          settled = true;
+          d.resolve({
+            ok: true,
+            body,
+          } as unknown as Response);
+        },
+        pushText: (text: string) => {
+          settleRead({ done: false, value: text });
+        },
+        close: () => {
+          settleRead({ done: true, value: undefined });
+        },
+      };
+
+      signal?.addEventListener("abort", () => {
+        rejectOnce();
+        // Unblock any pending reader.read() calls.
+        while (pendingReads.length > 0) {
+          pendingReads.shift()!({ done: true, value: undefined });
+        }
+      });
+
+      handles.push(handle);
+      return d.promise;
+    }
+  );
+
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return { handles, fetchMock };
+}
+
+const defaultParams: UsePodLogStreamParams = {
+  namespaceId: "ns",
+  podName: "pod-a",
+  containerName: "numa",
+  type: "monoVertex",
+  host: "http://localhost",
+  paused: false,
+  enableTimestamp: false,
+  levelFilter: "all",
+  showPreviousLogs: false,
+};
 
 describe("buildPodLogsUrl", () => {
   it("builds the live follow URL", () => {
@@ -42,5 +190,137 @@ describe("appendCapped", () => {
       "d",
       "e",
     ]);
+  });
+});
+
+describe("usePodLogStream lifecycle", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {
+      // silence expected abort noise
+    });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    jest.restoreAllMocks();
+  });
+
+  it("aborts the live fetch on unmount", async () => {
+    const { handles } = installFetchMock();
+
+    const { unmount } = renderHook(() => usePodLogStream(defaultParams));
+
+    await waitFor(() => expect(handles.length).toBe(1));
+    const live = handles[0];
+
+    act(() => {
+      unmount();
+    });
+
+    expect(live.signal.aborted).toBe(true);
+  });
+
+  it("aborts an in-flight live fetch when paused before the reader arrives", async () => {
+    const { handles } = installFetchMock();
+
+    const { rerender } = renderHook(
+      (props: UsePodLogStreamParams) => usePodLogStream(props),
+      { initialProps: defaultParams }
+    );
+
+    await waitFor(() => expect(handles.length).toBe(1));
+    const live = handles[0];
+    expect(live.signal.aborted).toBe(false);
+
+    rerender({ ...defaultParams, paused: true });
+
+    await waitFor(() => expect(live.signal.aborted).toBe(true));
+
+    // Resolving after pause must not append real log lines.
+    act(() => {
+      live.resolveFetch();
+    });
+
+    // No second live fetch while paused.
+    expect(handles.filter((h) => !h.url.includes("previous=true"))).toHaveLength(
+      1
+    );
+  });
+
+  it("aborts the first live fetch when podName changes mid-flight", async () => {
+    const { handles } = installFetchMock();
+
+    const { result, rerender } = renderHook(
+      (props: UsePodLogStreamParams) => usePodLogStream(props),
+      { initialProps: defaultParams }
+    );
+
+    await waitFor(() =>
+      expect(handles.some((h) => h.url.includes("/pods/pod-a/"))).toBe(true)
+    );
+    const first = handles.find((h) => h.url.includes("/pods/pod-a/"))!;
+
+    rerender({ ...defaultParams, podName: "pod-b" });
+
+    await waitFor(() => expect(first.signal.aborted).toBe(true));
+    await waitFor(() =>
+      expect(
+        handles.some(
+          (h) => h.url.includes("/pods/pod-b/") && !h.signal.aborted
+        )
+      ).toBe(true)
+    );
+
+    const second = handles.find(
+      (h) => h.url.includes("/pods/pod-b/") && !h.signal.aborted
+    )!;
+
+    await act(async () => {
+      second.resolveFetch();
+      await Promise.resolve();
+      second.pushText("only-from-pod-b\n");
+      second.close();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.logs.some((line) => line.includes("only-from-pod-b"))
+      ).toBe(true);
+    });
+    expect(
+      result.current.logs.some((line) => line.includes("from-pod-a"))
+    ).toBe(false);
+  });
+
+  it("aborts the previous-logs fetch when showPreviousLogs is toggled off", async () => {
+    const { handles } = installFetchMock();
+
+    const { rerender } = renderHook(
+      (props: UsePodLogStreamParams) => usePodLogStream(props),
+      {
+        initialProps: {
+          ...defaultParams,
+          showPreviousLogs: true,
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(handles.some((h) => h.url.includes("previous=true"))).toBe(true);
+    });
+
+    const previous = handles.find((h) => h.url.includes("previous=true"));
+    expect(previous).toBeDefined();
+    expect(previous!.signal.aborted).toBe(false);
+
+    rerender({
+      ...defaultParams,
+      showPreviousLogs: false,
+    });
+
+    await waitFor(() => expect(previous!.signal.aborted).toBe(true));
   });
 });

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/usePodLogStream.test.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/usePodLogStream.test.ts
@@ -1,0 +1,46 @@
+import { appendCapped, buildPodLogsUrl } from "./usePodLogStream";
+import { MAX_LOGS } from "./constants";
+
+describe("buildPodLogsUrl", () => {
+  it("builds the live follow URL", () => {
+    expect(
+      buildPodLogsUrl({
+        host: "http://localhost",
+        namespaceId: "ns",
+        podName: "pod-a",
+        containerName: "numa",
+      })
+    ).toBe(
+      `http://localhost/api/v1/namespaces/ns/pods/pod-a/logs?container=numa&follow=true&tailLines=${MAX_LOGS}`
+    );
+  });
+
+  it("appends previous=true when requested", () => {
+    expect(
+      buildPodLogsUrl({
+        host: "",
+        namespaceId: "ns",
+        podName: "pod-a",
+        containerName: "numa",
+        previous: true,
+        tailLines: 500,
+      })
+    ).toBe(
+      "/api/v1/namespaces/ns/pods/pod-a/logs?container=numa&follow=true&tailLines=500&previous=true"
+    );
+  });
+});
+
+describe("appendCapped", () => {
+  it("appends without trimming under the cap", () => {
+    expect(appendCapped(["a"], ["b", "c"], 10)).toEqual(["a", "b", "c"]);
+  });
+
+  it("drops oldest lines when over the cap", () => {
+    expect(appendCapped(["a", "b", "c"], ["d", "e"], 3)).toEqual([
+      "c",
+      "d",
+      "e",
+    ]);
+  });
+});

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/usePodLogStream.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/usePodLogStream.ts
@@ -1,0 +1,217 @@
+import { useEffect, useState } from "react";
+import "@stardazed/streams-polyfill";
+import { getBaseHref } from "../../../../../../../../../../../../../utils";
+import { LOADING_LOGS, MAX_LOGS } from "./constants";
+import { extractLogChunk, parsePodLogs } from "./parsePodLogs";
+
+export type BuildPodLogsUrlParams = {
+  host: string;
+  namespaceId: string;
+  podName: string;
+  containerName: string;
+  previous?: boolean;
+  tailLines?: number;
+};
+
+export function buildPodLogsUrl({
+  host,
+  namespaceId,
+  podName,
+  containerName,
+  previous = false,
+  tailLines = MAX_LOGS,
+}: BuildPodLogsUrlParams): string {
+  const base = `${host}${getBaseHref()}/api/v1/namespaces/${namespaceId}/pods/${podName}/logs?container=${containerName}&follow=true&tailLines=${tailLines}`;
+  return previous ? `${base}&previous=true` : base;
+}
+
+export function appendCapped(
+  existing: string[],
+  incoming: string[],
+  max: number = MAX_LOGS
+): string[] {
+  let updated = [...existing, ...incoming];
+  if (updated.length > max) {
+    updated = updated.slice(updated.length - max);
+  }
+  return updated;
+}
+
+export type UsePodLogStreamParams = {
+  namespaceId: string;
+  podName: string;
+  containerName: string;
+  type: string;
+  host: string;
+  paused: boolean;
+  enableTimestamp: boolean;
+  levelFilter: string;
+  showPreviousLogs: boolean;
+};
+
+export function usePodLogStream({
+  namespaceId,
+  podName,
+  containerName,
+  type,
+  host,
+  paused,
+  enableTimestamp,
+  levelFilter,
+  showPreviousLogs,
+}: UsePodLogStreamParams): { logs: string[]; previousLogs: string[] } {
+  const [logs, setLogs] = useState<string[]>([]);
+  const [previousLogs, setPreviousLogs] = useState<string[]>([]);
+  const [logRequestKey, setLogRequestKey] = useState<string>("");
+  const [reader, setReader] = useState<
+    ReadableStreamDefaultReader<string> | undefined
+  >();
+
+  // Reset buffers when the log source changes; also unpause so streaming restarts.
+  useEffect(() => {
+    setLogs([]);
+    setPreviousLogs([]);
+  }, [namespaceId, podName, containerName]);
+
+  // Cancel the live reader when pausing (mirrors previous handlePause behavior).
+  // Intentionally depends only on `paused` so setting the reader does not re-run this.
+  useEffect(() => {
+    if (paused && reader) {
+      reader.cancel();
+      setReader(undefined);
+    }
+  }, [paused]);
+
+  // Restart the live stream when parse options change.
+  // Intentionally omits `reader` so this only runs when parse options change.
+  useEffect(() => {
+    if (reader) {
+      reader.cancel();
+      setReader(undefined);
+    }
+  }, [enableTimestamp, levelFilter]);
+
+  // Live follow stream
+  useEffect(() => {
+    if (paused) {
+      return;
+    }
+    const requestKey = `${namespaceId}-${podName}-${containerName}`;
+    if (logRequestKey && logRequestKey !== requestKey && reader) {
+      // Cancel open reader on param change
+      reader.cancel();
+      setReader(undefined);
+      return;
+    } else if (reader) {
+      // Don't open a new reader if one exists
+      return;
+    }
+    setLogRequestKey(requestKey);
+    setLogs([LOADING_LOGS]);
+    fetch(
+      buildPodLogsUrl({
+        host,
+        namespaceId,
+        podName,
+        containerName,
+      })
+    )
+      .then((response) => {
+        if (response && response.body) {
+          const r = response.body
+            .pipeThrough(new TextDecoderStream())
+            .getReader();
+          setReader(r);
+          r.read().then(async function process({
+            done,
+            value,
+          }: ReadableStreamReadResult<string>): Promise<void> {
+            if (done) {
+              return;
+            }
+            if (value) {
+              const { text, isErrorMessage } = extractLogChunk(value);
+              setLogs((current) => {
+                const latestLogs = parsePodLogs(text, {
+                  enableTimestamp,
+                  levelFilter,
+                  type,
+                  isErrorMessage,
+                }).filter((line) => line !== "");
+                return appendCapped(current, latestLogs);
+              });
+            }
+            await process(await r.read());
+          });
+        }
+      })
+      .catch(console.error);
+  }, [
+    namespaceId,
+    podName,
+    containerName,
+    reader,
+    paused,
+    host,
+    enableTimestamp,
+    levelFilter,
+  ]);
+
+  // Previous terminated container stream
+  useEffect(() => {
+    if (!showPreviousLogs) {
+      setPreviousLogs([]);
+      return;
+    }
+    setPreviousLogs([]);
+    fetch(
+      buildPodLogsUrl({
+        host,
+        namespaceId,
+        podName,
+        containerName,
+        previous: true,
+      })
+    )
+      .then((response) => {
+        if (response && response.body) {
+          const prevReader = response.body
+            .pipeThrough(new TextDecoderStream())
+            .getReader();
+
+          prevReader.read().then(async function process({
+            done,
+            value,
+          }: ReadableStreamReadResult<string>): Promise<void> {
+            if (done) {
+              return;
+            }
+            if (value) {
+              const { text, isErrorMessage } = extractLogChunk(value);
+              setPreviousLogs((prevLogs) => {
+                const latestLogs = parsePodLogs(text, {
+                  enableTimestamp,
+                  levelFilter,
+                  type,
+                  isErrorMessage,
+                }).filter((line) => line !== "");
+                return appendCapped(prevLogs, latestLogs);
+              });
+            }
+            await process(await prevReader.read());
+          });
+        }
+      })
+      .catch(console.error);
+  }, [
+    showPreviousLogs,
+    namespaceId,
+    podName,
+    containerName,
+    host,
+    enableTimestamp,
+    levelFilter,
+  ]);
+
+  return { logs, previousLogs };
+}

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/usePodLogStream.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/usePodLogStream.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import "@stardazed/streams-polyfill";
 import { getBaseHref } from "../../../../../../../../../../../../../utils";
 import { LOADING_LOGS, MAX_LOGS } from "./constants";
@@ -37,6 +37,24 @@ export function appendCapped(
   return updated;
 }
 
+function cancelReader(
+  reader: ReadableStreamDefaultReader<string> | undefined
+): void {
+  if (!reader) {
+    return;
+  }
+  void reader.cancel().catch(() => {
+    // Reader may already be closed/cancelled.
+  });
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    (err instanceof DOMException && err.name === "AbortError") ||
+    (err instanceof Error && err.name === "AbortError")
+  );
+}
+
 export type UsePodLogStreamParams = {
   namespaceId: string;
   podName: string;
@@ -62,10 +80,17 @@ export function usePodLogStream({
 }: UsePodLogStreamParams): { logs: string[]; previousLogs: string[] } {
   const [logs, setLogs] = useState<string[]>([]);
   const [previousLogs, setPreviousLogs] = useState<string[]>([]);
-  const [logRequestKey, setLogRequestKey] = useState<string>("");
-  const [reader, setReader] = useState<
+
+  const liveAbortRef = useRef<AbortController | undefined>();
+  const prevAbortRef = useRef<AbortController | undefined>();
+  const liveReaderRef = useRef<
     ReadableStreamDefaultReader<string> | undefined
   >();
+  const prevReaderRef = useRef<
+    ReadableStreamDefaultReader<string> | undefined
+  >();
+  const liveGenerationRef = useRef(0);
+  const prevGenerationRef = useRef(0);
 
   // Reset buffers when the log source changes; also unpause so streaming restarts.
   useEffect(() => {
@@ -73,88 +98,100 @@ export function usePodLogStream({
     setPreviousLogs([]);
   }, [namespaceId, podName, containerName]);
 
-  // Cancel the live reader when pausing (mirrors previous handlePause behavior).
-  // Intentionally depends only on `paused` so setting the reader does not re-run this.
-  useEffect(() => {
-    if (paused && reader) {
-      reader.cancel();
-      setReader(undefined);
-    }
-  }, [paused]);
-
-  // Restart the live stream when parse options change.
-  // Intentionally omits `reader` so this only runs when parse options change.
-  useEffect(() => {
-    if (reader) {
-      reader.cancel();
-      setReader(undefined);
-    }
-  }, [enableTimestamp, levelFilter]);
-
-  // Live follow stream
+  // Live follow stream. Cleanup aborts in-flight fetch/reader on pause, unmount,
+  // identity change, and parse-option restart.
   useEffect(() => {
     if (paused) {
       return;
     }
-    const requestKey = `${namespaceId}-${podName}-${containerName}`;
-    if (logRequestKey && logRequestKey !== requestKey && reader) {
-      // Cancel open reader on param change
-      reader.cancel();
-      setReader(undefined);
-      return;
-    } else if (reader) {
-      // Don't open a new reader if one exists
-      return;
-    }
-    setLogRequestKey(requestKey);
+
+    const controller = new AbortController();
+    liveAbortRef.current = controller;
+    const generation = ++liveGenerationRef.current;
+
     setLogs([LOADING_LOGS]);
-    fetch(
-      buildPodLogsUrl({
-        host,
-        namespaceId,
-        podName,
-        containerName,
-      })
-    )
-      .then((response) => {
-        if (response && response.body) {
-          const r = response.body
-            .pipeThrough(new TextDecoderStream())
-            .getReader();
-          setReader(r);
-          r.read().then(async function process({
-            done,
-            value,
-          }: ReadableStreamReadResult<string>): Promise<void> {
-            if (done) {
-              return;
-            }
-            if (value) {
-              const { text, isErrorMessage } = extractLogChunk(value);
-              setLogs((current) => {
-                const latestLogs = parsePodLogs(text, {
-                  enableTimestamp,
-                  levelFilter,
-                  type,
-                  isErrorMessage,
-                }).filter((line) => line !== "");
-                return appendCapped(current, latestLogs);
-              });
-            }
-            await process(await r.read());
-          });
+
+    const run = async () => {
+      try {
+        const response = await fetch(
+          buildPodLogsUrl({
+            host,
+            namespaceId,
+            podName,
+            containerName,
+          }),
+          { signal: controller.signal }
+        );
+        if (
+          controller.signal.aborted ||
+          generation !== liveGenerationRef.current
+        ) {
+          return;
         }
-      })
-      .catch(console.error);
+        if (!response?.body) {
+          return;
+        }
+        const reader = response.body
+          .pipeThrough(new TextDecoderStream())
+          .getReader();
+        liveReaderRef.current = reader;
+
+        while (
+          !controller.signal.aborted &&
+          generation === liveGenerationRef.current
+        ) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          if (
+            controller.signal.aborted ||
+            generation !== liveGenerationRef.current
+          ) {
+            break;
+          }
+          if (value) {
+            const { text, isErrorMessage } = extractLogChunk(value);
+            setLogs((current) => {
+              const latestLogs = parsePodLogs(text, {
+                enableTimestamp,
+                levelFilter,
+                type,
+                isErrorMessage,
+              }).filter((line) => line !== "");
+              return appendCapped(current, latestLogs);
+            });
+          }
+        }
+      } catch (err) {
+        if (!isAbortError(err)) {
+          console.error(err);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      controller.abort();
+      cancelReader(liveReaderRef.current);
+      liveReaderRef.current = undefined;
+      if (liveAbortRef.current === controller) {
+        liveAbortRef.current = undefined;
+      }
+      if (generation === liveGenerationRef.current) {
+        liveGenerationRef.current++;
+      }
+    };
   }, [
     namespaceId,
     podName,
     containerName,
-    reader,
     paused,
     host,
     enableTimestamp,
     levelFilter,
+    type,
   ]);
 
   // Previous terminated container stream
@@ -163,46 +200,86 @@ export function usePodLogStream({
       setPreviousLogs([]);
       return;
     }
-    setPreviousLogs([]);
-    fetch(
-      buildPodLogsUrl({
-        host,
-        namespaceId,
-        podName,
-        containerName,
-        previous: true,
-      })
-    )
-      .then((response) => {
-        if (response && response.body) {
-          const prevReader = response.body
-            .pipeThrough(new TextDecoderStream())
-            .getReader();
 
-          prevReader.read().then(async function process({
-            done,
-            value,
-          }: ReadableStreamReadResult<string>): Promise<void> {
-            if (done) {
-              return;
-            }
-            if (value) {
-              const { text, isErrorMessage } = extractLogChunk(value);
-              setPreviousLogs((prevLogs) => {
-                const latestLogs = parsePodLogs(text, {
-                  enableTimestamp,
-                  levelFilter,
-                  type,
-                  isErrorMessage,
-                }).filter((line) => line !== "");
-                return appendCapped(prevLogs, latestLogs);
-              });
-            }
-            await process(await prevReader.read());
-          });
+    const controller = new AbortController();
+    prevAbortRef.current = controller;
+    const generation = ++prevGenerationRef.current;
+
+    setPreviousLogs([]);
+
+    const run = async () => {
+      try {
+        const response = await fetch(
+          buildPodLogsUrl({
+            host,
+            namespaceId,
+            podName,
+            containerName,
+            previous: true,
+          }),
+          { signal: controller.signal }
+        );
+        if (
+          controller.signal.aborted ||
+          generation !== prevGenerationRef.current
+        ) {
+          return;
         }
-      })
-      .catch(console.error);
+        if (!response?.body) {
+          return;
+        }
+        const prevReader = response.body
+          .pipeThrough(new TextDecoderStream())
+          .getReader();
+        prevReaderRef.current = prevReader;
+
+        while (
+          !controller.signal.aborted &&
+          generation === prevGenerationRef.current
+        ) {
+          const { done, value } = await prevReader.read();
+          if (done) {
+            break;
+          }
+          if (
+            controller.signal.aborted ||
+            generation !== prevGenerationRef.current
+          ) {
+            break;
+          }
+          if (value) {
+            const { text, isErrorMessage } = extractLogChunk(value);
+            setPreviousLogs((prevLogs) => {
+              const latestLogs = parsePodLogs(text, {
+                enableTimestamp,
+                levelFilter,
+                type,
+                isErrorMessage,
+              }).filter((line) => line !== "");
+              return appendCapped(prevLogs, latestLogs);
+            });
+          }
+        }
+      } catch (err) {
+        if (!isAbortError(err)) {
+          console.error(err);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      controller.abort();
+      cancelReader(prevReaderRef.current);
+      prevReaderRef.current = undefined;
+      if (prevAbortRef.current === controller) {
+        prevAbortRef.current = undefined;
+      }
+      if (generation === prevGenerationRef.current) {
+        prevGenerationRef.current++;
+      }
+    };
   }, [
     showPreviousLogs,
     namespaceId,
@@ -211,6 +288,7 @@ export function usePodLogStream({
     host,
     enableTimestamp,
     levelFilter,
+    type,
   ]);
 
   return { logs, previousLogs };


### PR DESCRIPTION
### What this PR does / why we need it

The PodLogs UI mixed streaming, parsing, and filtering in one component, which made it hard to test and fix lifecycle bugs.

This PR:
- Splits PodLogs into focused helpers: log stream hook, parse, and filter
- Fixes stream lifecycle issues so live and previous log fetches are aborted on unmount, pause, and pod/container changes
- Uses `AbortController` and reader refs so pause and identity changes cannot leave orphaned follow streams or stack duplicate readers

### Related issues

Related to #3513

### Testing

- `yarn --cwd ui test --watchAll=false usePodLogStream`
- `yarn --cwd ui lint`
- Manual: open Logs tab, pause/resume, switch pod/container, toggle previous logs, and leave the tab to confirm streams stop cleanly

### Special notes for reviewers

NA
