### PR TITLE
chore(docs): update nats docs

### DIFF
--- a/docs/core-concepts/inter-step-buffer-service.md
+++ b/docs/core-concepts/inter-step-buffer-service.md
@@ -149,12 +149,12 @@ There are 2 places to configure JetStream settings:
 A sample JetStream configuration:
 
 ```
-# https://docs.nats.io/running-a-nats-service/configuration#limits
+# https://docs.nats.io/reference/config/max_payload
 # Only "max_payload" is supported for configuration in this section.
 # Max payload size in bytes, defaults to 1 MB. It is not recommended to use values over 8MB but max_payload can be set up to 64MB.
 max_payload: 1048576
 #
-# https://docs.nats.io/running-a-nats-service/configuration#jetstream
+# https://docs.nats.io/reference/config/jetstream
 # Only configure "max_memory_store" or "max_file_store" in this section, do not set "store_dir" as it has been hardcoded.
 #
 # e.g. 1G. -1 means no limit, up to 75% of available memory. This only take effect for streams created using memory storage.
@@ -224,7 +224,7 @@ JetStream service. By default `TLS` is not enabled.
 
 Encryption at rest can be enabled by setting `spec.jetstream.encryption: true`.
 Be aware this will impact the performance a bit, see the detail at
-[official doc](https://docs.nats.io/reference/config/jetstream/encryption_key).
+[official doc](https://docs.nats.io/learn/security/encryption#encryption-at-rest).
 
 Once a JetStream ISB Service is created, toggling the `encryption` field will
 cause problem for the exiting messages, so if you want to change the value,

--- a/docs/core-concepts/inter-step-buffer-service.md
+++ b/docs/core-concepts/inter-step-buffer-service.md
@@ -224,7 +224,7 @@ JetStream service. By default `TLS` is not enabled.
 
 Encryption at rest can be enabled by setting `spec.jetstream.encryption: true`.
 Be aware this will impact the performance a bit, see the detail at
-[official doc](https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/encryption_at_rest).
+[official doc](https://docs.nats.io/reference/config/jetstream/encryption_key).
 
 Once a JetStream ISB Service is created, toggling the `encryption` field will
 cause problem for the exiting messages, so if you want to change the value,

--- a/docs/core-concepts/inter-step-buffer.md
+++ b/docs/core-concepts/inter-step-buffer.md
@@ -17,4 +17,4 @@ Inter-Step Buffer can be implemented by a variety of data buffering technologies
 
 Supported Inter-Step Buffer implementations:
 
-- [Nats JetStream](https://docs.nats.io/nats-concepts/jetstream)
+- [Nats JetStream](https://docs.nats.io/concepts/jetstream)

--- a/docs/user-guide/sources/jetstream.md
+++ b/docs/user-guide/sources/jetstream.md
@@ -1,6 +1,6 @@
 # Jetstream Source
 
-A `Jetstream` source is used to ingest the messages from a [Jetstream stream](https://docs.nats.io/nats-concepts/jetstream).
+A `Jetstream` source is used to ingest the messages from a [Jetstream stream](https://docs.nats.io/concepts/jetstream).
 
 ```yaml
 spec:
@@ -38,7 +38,7 @@ spec:
 
 The `consumer` field represents the name of the consumer of the stream. If not specified, a consumer with name format `numaflow-<pipeline_name>-<vertex_name>-<stream_name>` will used. Numaflow will attempt to create this consumer on the stream if it doesn't exist.
 
-The [valid values](https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy) for `deliver_policy` are:
+The [valid values](https://docs.nats.io/learn/jetstream/reading-back) for `deliver_policy` are:
 
 - `all`
 - `new`

--- a/docs/user-guide/sources/jetstream.md
+++ b/docs/user-guide/sources/jetstream.md
@@ -38,7 +38,7 @@ spec:
 
 The `consumer` field represents the name of the consumer of the stream. If not specified, a consumer with name format `numaflow-<pipeline_name>-<vertex_name>-<stream_name>` will used. Numaflow will attempt to create this consumer on the stream if it doesn't exist.
 
-The [valid values](https://docs.nats.io/learn/jetstream/reading-back) for `deliver_policy` are:
+The [valid values](https://docs.nats.io/learn/jetstream/reading-back#pitfalls) for `deliver_policy` are:
 
 - `all`
 - `new`


### PR DESCRIPTION
### What this PR does / why we need it
`make docs` was failing as nats documentation has been recently updated https://github.com/nats-io/nats.docs.v2

```
[./docs/core-concepts/inter-step-buffer-service.md]:
[404] https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/encryption_at_rest | Rejected status code (this depends on your "accept" configuration): Not Found

[./docs/core-concepts/inter-step-buffer.md]:
[404] https://docs.nats.io/nats-concepts/jetstream | Error (cached)

[./docs/user-guide/sources/jetstream.md]:
[404] https://docs.nats.io/nats-concepts/jetstream | Rejected status code (this depends on your "accept" configuration): Not Found
[404] https://docs.nats.io/nats-concepts/jetstream/consumers#deliverpolicy | Rejected status code (this depends on your "accept" configuration): Not Found
```
