### PR TITLE
feat: support cron-based autoscaling for source vertices

### DIFF
--- a/docs/user-guide/reference/autoscaling.md
+++ b/docs/user-guide/reference/autoscaling.md
@@ -45,6 +45,13 @@ spec:
         targetBufferAvailability: 50 # Optional, defaults to 50.
         replicasPerScaleUp: 2 # Optional, defaults to 2.
         replicasPerScaleDown: 2 # Optional, defaults to 2.
+        cron: # Optional.
+          timezone: America/Los_Angeles # Optional, defaults to UTC.
+          schedules:
+            - start: "0 0 22 * * *" # Second Minute Hour Day-of-month Month Day-of-week
+              end: "0 0 6 * * *"
+              min: 10
+              max: 20
 ---
 # A MonoVertex example.
 apiVersion: numaflow.numaproj.io/v1alpha1
@@ -63,7 +70,7 @@ spec:
     targetProcessingSeconds: 20 # Optional, defaults to 20.
     replicasPerScaleUp: 2 # Optional, defaults to 2.
     replicasPerScaleDown: 2 # Optional, defaults to 2.
-    cron: # Optional; supported only for MonoVertex.
+    cron: # Optional.
       timezone: America/Los_Angeles # Optional, defaults to UTC.
       schedules:
         - start: "0 0 22 * * *" # Second Minute Hour Day-of-month Month Day-of-week
@@ -122,7 +129,7 @@ spec:
 - `replicasPerScale` - (Deprecated: Use `replicasPerScaleUp` and
   `replicasPerScaleDown` instead, will be removed in v1.5) Maximum number of
   replica change happens in one scale up or down operation, defaults to `2`.
-- `cron` - [MonoVertex only] Defines time-based overrides for `min` and `max`.
+- `cron` - Defines time-based overrides for `min` and `max`.
   Cron expressions use the six-field extended format: `second minute hour
   day-of-month month day-of-week`. `timezone` accepts an IANA time zone and
   defaults to `UTC` when omitted. Each schedule requires `start`, `end`, `min`,

--- a/docs/user-guide/reference/autoscaling.md
+++ b/docs/user-guide/reference/autoscaling.md
@@ -45,13 +45,6 @@ spec:
         targetBufferAvailability: 50 # Optional, defaults to 50.
         replicasPerScaleUp: 2 # Optional, defaults to 2.
         replicasPerScaleDown: 2 # Optional, defaults to 2.
-        cron: # Optional; supported only for source vertices.
-          timezone: America/Los_Angeles # Optional, defaults to UTC.
-          schedules:
-            - start: "0 0 22 * * *" # Second Minute Hour Day-of-month Month Day-of-week
-              end: "0 0 6 * * *"
-              min: 10
-              max: 20
 ---
 # A MonoVertex example.
 apiVersion: numaflow.numaproj.io/v1alpha1
@@ -138,6 +131,34 @@ spec:
   and `max`; its bounds may be lower or higher than the base `scale.min` and
   `scale.max`. When multiple windows overlap, schedules are evaluated in the
   configured order and the first active schedule takes precedence.
+
+#### Cron Autoscaling for Source Vertices
+
+Cron-based autoscaling allows time-based overrides of `min` and `max` replicas.
+It is **only valid for Pipeline source vertices** (and MonoVertices — see the
+MonoVertex example above). Configuring `cron` on a non-source Pipeline vertex
+(UDF or Sink) will be **rejected at validation time** with an error.
+
+```yaml
+apiVersion: numaflow.numaproj.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: my-pipeline
+spec:
+  vertices:
+    - name: input
+      source:
+        generator:
+          rpu: 5
+      scale:
+        cron: # Optional; only valid on source vertices.
+          timezone: America/Los_Angeles # Optional, defaults to UTC.
+          schedules:
+            - start: "0 0 22 * * *" # Second Minute Hour Day-of-month Month Day-of-week
+              end: "0 0 6 * * *"
+              min: 10
+              max: 20
+```
 
 To disable Numaflow autoscaling, set `disabled: true` as following.
 

--- a/docs/user-guide/reference/autoscaling.md
+++ b/docs/user-guide/reference/autoscaling.md
@@ -45,7 +45,7 @@ spec:
         targetBufferAvailability: 50 # Optional, defaults to 50.
         replicasPerScaleUp: 2 # Optional, defaults to 2.
         replicasPerScaleDown: 2 # Optional, defaults to 2.
-        cron: # Optional.
+        cron: # Optional; supported only for source vertices.
           timezone: America/Los_Angeles # Optional, defaults to UTC.
           schedules:
             - start: "0 0 22 * * *" # Second Minute Hour Day-of-month Month Day-of-week
@@ -70,7 +70,7 @@ spec:
     targetProcessingSeconds: 20 # Optional, defaults to 20.
     replicasPerScaleUp: 2 # Optional, defaults to 2.
     replicasPerScaleDown: 2 # Optional, defaults to 2.
-    cron: # Optional.
+    cron: # Optional; supported only for MonoVertex.
       timezone: America/Los_Angeles # Optional, defaults to UTC.
       schedules:
         - start: "0 0 22 * * *" # Second Minute Hour Day-of-month Month Day-of-week
@@ -129,7 +129,9 @@ spec:
 - `replicasPerScale` - (Deprecated: Use `replicasPerScaleUp` and
   `replicasPerScaleDown` instead, will be removed in v1.5) Maximum number of
   replica change happens in one scale up or down operation, defaults to `2`.
-- `cron` - Defines time-based overrides for `min` and `max`.
+- `cron` - [MonoVertex and source vertices only] Defines time-based overrides
+  for `min` and `max`. Note: configuring cron autoscaling on a non-source
+  pipeline vertex will fail validation with an error.
   Cron expressions use the six-field extended format: `second minute hour
   day-of-month month day-of-week`. `timezone` accepts an IANA time zone and
   defaults to `UTC` when omitted. Each schedule requires `start`, `end`, `min`,

--- a/pkg/reconciler/monovertex/scaling/scaling.go
+++ b/pkg/reconciler/monovertex/scaling/scaling.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
-	cron "github.com/robfig/cron/v3"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,60 +33,9 @@ import (
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	mvtxdaemonclient "github.com/numaproj/numaflow/pkg/mvtxdaemon/client"
+	scalingutil "github.com/numaproj/numaflow/pkg/reconciler/scaling"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 )
-
-type parsedCronSchedule struct {
-	schedule dfv1.CronSchedule
-	start    cron.Schedule
-	end      cron.Schedule
-}
-
-func (p *parsedCronSchedule) isActiveAt(t time.Time) bool {
-	return p.end.Next(t).Before(p.start.Next(t))
-}
-
-func parseCronSchedules(cronScheduling *dfv1.CronScheduling) ([]parsedCronSchedule, error) {
-	parser := cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-	result := make([]parsedCronSchedule, 0, len(cronScheduling.Schedules))
-	for _, schedule := range cronScheduling.Schedules {
-		start, err := parser.Parse(schedule.Start)
-		if err != nil {
-			return nil, fmt.Errorf("invalid cron start expression %q: %w", schedule.Start, err)
-		}
-		end, err := parser.Parse(schedule.End)
-		if err != nil {
-			return nil, fmt.Errorf("invalid cron end expression %q: %w", schedule.End, err)
-		}
-		result = append(result, parsedCronSchedule{schedule: schedule, start: start, end: end})
-	}
-	return result, nil
-}
-
-func effectiveScaleBoundsAt(scale dfv1.Scale, parsed []parsedCronSchedule, at time.Time) (int32, int32, bool) {
-	minReplicas := scale.GetMinReplicas()
-	maxReplicas := scale.GetMaxReplicas()
-	if scale.Cron == nil || len(parsed) == 0 {
-		return minReplicas, maxReplicas, false
-	}
-	location, err := time.LoadLocation(scale.Cron.GetTimezone())
-	if err != nil {
-		return minReplicas, maxReplicas, false
-	}
-	at = at.In(location)
-	for i := range parsed {
-		if parsed[i].isActiveAt(at) {
-			if parsed[i].schedule.Min != nil {
-				minReplicas = *parsed[i].schedule.Min
-			}
-			if parsed[i].schedule.Max != nil {
-				maxReplicas = *parsed[i].schedule.Max
-			}
-			return minReplicas, maxReplicas, true
-		}
-	}
-	return minReplicas, maxReplicas, false
-}
 
 type Scaler struct {
 	client     client.Client
@@ -100,7 +48,7 @@ type Scaler struct {
 	monoVtxMetricsCache    *lru.Cache[string, int64]
 	mvtxDaemonClientsCache *lru.Cache[string, mvtxdaemonclient.MonoVertexDaemonClient]
 	// Cache to store the pre-parsed cron schedules for each MonoVertex
-	cronScheduleCache *lru.Cache[string, []parsedCronSchedule]
+	cronScheduleCache *lru.Cache[string, []scalingutil.ParsedCronSchedule]
 }
 
 // NewScaler returns a Scaler instance.
@@ -124,7 +72,7 @@ func NewScaler(client client.Client, opts ...Option) *Scaler {
 	})
 	monoVtxMetricsCache, _ := lru.New[string, int64](10000)
 	s.monoVtxMetricsCache = monoVtxMetricsCache
-	s.cronScheduleCache, _ = lru.New[string, []parsedCronSchedule](1000)
+	s.cronScheduleCache, _ = lru.New[string, []scalingutil.ParsedCronSchedule](1000)
 	return s
 }
 
@@ -181,7 +129,7 @@ func (s *Scaler) scale(ctx context.Context, id int, keyCh <-chan string) {
 }
 
 // parsedCronSchedulesFor returns the parsed cron schedules for a MonoVertex.
-func (s *Scaler) parsedCronSchedulesFor(monoVtx *dfv1.MonoVertex) ([]parsedCronSchedule, error) {
+func (s *Scaler) parsedCronSchedulesFor(monoVtx *dfv1.MonoVertex) ([]scalingutil.ParsedCronSchedule, error) {
 	if monoVtx.Spec.Scale.Cron == nil {
 		return nil, nil
 	}
@@ -189,7 +137,7 @@ func (s *Scaler) parsedCronSchedulesFor(monoVtx *dfv1.MonoVertex) ([]parsedCronS
 	if parsed, ok := s.cronScheduleCache.Get(key); ok {
 		return parsed, nil
 	}
-	parsed, err := parseCronSchedules(monoVtx.Spec.Scale.Cron)
+	parsed, err := scalingutil.ParseCronSchedules(monoVtx.Spec.Scale.Cron)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +151,7 @@ func (s *Scaler) effectiveScaleBoundsFor(monoVtx *dfv1.MonoVertex, at time.Time)
 	if err != nil {
 		return 0, 0, false, err
 	}
-	minReplicas, maxReplicas, cronActive := effectiveScaleBoundsAt(monoVtx.Spec.Scale, parsed, at)
+	minReplicas, maxReplicas, cronActive := scalingutil.EffectiveScaleBoundsAt(monoVtx.Spec.Scale, parsed, at)
 	return minReplicas, maxReplicas, cronActive, nil
 }
 

--- a/pkg/reconciler/monovertex/scaling/scaling_test.go
+++ b/pkg/reconciler/monovertex/scaling/scaling_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	scalingutil "github.com/numaproj/numaflow/pkg/reconciler/scaling"
 )
 
 func monoVtxWithScale(targetSec uint32, readyReplicas uint32, currentReplicas uint32) *dfv1.MonoVertex {
@@ -213,11 +214,11 @@ func TestParsedCronScheduleIsActiveAt(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			parsed, err := parseCronSchedules(&dfv1.CronScheduling{
+			parsed, err := scalingutil.ParseCronSchedules(&dfv1.CronScheduling{
 				Schedules: []dfv1.CronSchedule{{Start: tc.start, End: tc.end}},
 			})
 			require.NoError(t, err)
-			assert.Equal(t, tc.expected, parsed[0].isActiveAt(tc.at))
+			assert.Equal(t, tc.expected, parsed[0].IsActiveAt(tc.at))
 		})
 	}
 }
@@ -235,7 +236,7 @@ func TestParseCronSchedulesRejectsInvalidExpressions(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := parseCronSchedules(&dfv1.CronScheduling{
+			_, err := scalingutil.ParseCronSchedules(&dfv1.CronScheduling{
 				Schedules: []dfv1.CronSchedule{{Start: tc.start, End: tc.end}},
 			})
 			assert.Error(t, err)
@@ -260,15 +261,15 @@ func TestEffectiveScaleBoundsAt(t *testing.T) {
 			},
 		},
 	}
-	parsed, err := parseCronSchedules(scale.Cron)
+	parsed, err := scalingutil.ParseCronSchedules(scale.Cron)
 	require.NoError(t, err)
 
-	minReplicas, maxReplicas, active := effectiveScaleBoundsAt(scale, parsed, now)
+	minReplicas, maxReplicas, active := scalingutil.EffectiveScaleBoundsAt(scale, parsed, now)
 	assert.True(t, active)
 	assert.Equal(t, int32(1), minReplicas)
 	assert.Equal(t, int32(5), maxReplicas)
 
-	minReplicas, maxReplicas, active = effectiveScaleBoundsAt(scale, parsed, now.Add(2*time.Hour))
+	minReplicas, maxReplicas, active = scalingutil.EffectiveScaleBoundsAt(scale, parsed, now.Add(2*time.Hour))
 	assert.False(t, active)
 	assert.Equal(t, int32(0), minReplicas)
 	assert.Equal(t, int32(50), maxReplicas)
@@ -407,7 +408,7 @@ func TestParsedCronSchedulesForGenerationChange(t *testing.T) {
 	parsed, err := scaler.parsedCronSchedulesFor(updated)
 	require.NoError(t, err)
 
-	assert.Equal(t, "0 0 10 * * *", parsed[0].schedule.Start)
+	assert.Equal(t, "0 0 10 * * *", parsed[0].Schedule.Start)
 	assert.Equal(t, 2, scaler.cronScheduleCache.Len())
 }
 
@@ -421,6 +422,6 @@ func TestParsedCronSchedulesForUIDChange(t *testing.T) {
 	parsed, err := scaler.parsedCronSchedulesFor(recreated)
 	require.NoError(t, err)
 
-	assert.Equal(t, "0 0 11 * * *", parsed[0].schedule.Start)
+	assert.Equal(t, "0 0 11 * * *", parsed[0].Schedule.Start)
 	assert.Equal(t, 2, scaler.cronScheduleCache.Len())
 }

--- a/pkg/reconciler/scaling/utils.go
+++ b/pkg/reconciler/scaling/utils.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaling
+
+import (
+	"fmt"
+	"time"
+
+	cron "github.com/robfig/cron/v3"
+
+	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+)
+
+// ParsedCronSchedule holds a parsed start/end cron schedule pair.
+type ParsedCronSchedule struct {
+	Schedule dfv1.CronSchedule
+	Start    cron.Schedule
+	End      cron.Schedule
+}
+
+// IsActiveAt reports whether time t falls within this cron schedule window.
+func (p *ParsedCronSchedule) IsActiveAt(t time.Time) bool {
+	return p.End.Next(t).Before(p.Start.Next(t))
+}
+
+// ParseCronSchedules parses a CronScheduling spec into a slice of ParsedCronSchedule.
+func ParseCronSchedules(cronScheduling *dfv1.CronScheduling) ([]ParsedCronSchedule, error) {
+	parser := cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	result := make([]ParsedCronSchedule, 0, len(cronScheduling.Schedules))
+	for _, schedule := range cronScheduling.Schedules {
+		start, err := parser.Parse(schedule.Start)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cron start expression %q: %w", schedule.Start, err)
+		}
+		end, err := parser.Parse(schedule.End)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cron end expression %q: %w", schedule.End, err)
+		}
+		result = append(result, ParsedCronSchedule{Schedule: schedule, Start: start, End: end})
+	}
+	return result, nil
+}
+
+// EffectiveScaleBoundsAt returns the effective scale bounds (minReplicas, maxReplicas, active) for a given Scale spec at time at.
+func EffectiveScaleBoundsAt(scale dfv1.Scale, parsed []ParsedCronSchedule, at time.Time) (int32, int32, bool) {
+	minReplicas := scale.GetMinReplicas()
+	maxReplicas := scale.GetMaxReplicas()
+	if scale.Cron == nil || len(parsed) == 0 {
+		return minReplicas, maxReplicas, false
+	}
+	location, err := time.LoadLocation(scale.Cron.GetTimezone())
+	if err != nil {
+		return minReplicas, maxReplicas, false
+	}
+	at = at.In(location)
+	for i := range parsed {
+		if parsed[i].IsActiveAt(at) {
+			if parsed[i].Schedule.Min != nil {
+				minReplicas = *parsed[i].Schedule.Min
+			}
+			if parsed[i].Schedule.Max != nil {
+				maxReplicas = *parsed[i].Schedule.Max
+			}
+			return minReplicas, maxReplicas, true
+		}
+	}
+	return minReplicas, maxReplicas, false
+}

--- a/pkg/reconciler/scaling/utils_test.go
+++ b/pkg/reconciler/scaling/utils_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2022 The Numaproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaling
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+
+	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+)
+
+func TestParseCronSchedules(t *testing.T) {
+	t.Run("valid schedule", func(t *testing.T) {
+		cs := &dfv1.CronScheduling{
+			Schedules: []dfv1.CronSchedule{
+				{
+					Start: "0 0 9 * * *",
+					End:   "0 0 17 * * *",
+				},
+			},
+		}
+
+		parsed, err := ParseCronSchedules(cs)
+		assert.NoError(t, err)
+		assert.Len(t, parsed, 1)
+	})
+
+	t.Run("invalid start", func(t *testing.T) {
+		cs := &dfv1.CronScheduling{
+			Schedules: []dfv1.CronSchedule{
+				{
+					Start: "invalid",
+					End:   "0 0 17 * * *",
+				},
+			},
+		}
+
+		_, err := ParseCronSchedules(cs)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid end", func(t *testing.T) {
+		cs := &dfv1.CronScheduling{
+			Schedules: []dfv1.CronSchedule{
+				{
+					Start: "0 0 9 * * *",
+					End:   "invalid",
+				},
+			},
+		}
+
+		_, err := ParseCronSchedules(cs)
+		assert.Error(t, err)
+	})
+}
+
+func TestEffectiveScaleBoundsAt(t *testing.T) {
+	min := int32(5)
+	max := int32(10)
+
+	scale := dfv1.Scale{
+		Min: ptr.To[int32](1),
+		Max: ptr.To[int32](3),
+		Cron: &dfv1.CronScheduling{
+			Timezone: "UTC",
+			Schedules: []dfv1.CronSchedule{
+				{
+					Start: "0 0 9 * * *",
+					End:   "0 0 17 * * *",
+					Min:   &min,
+					Max:   &max,
+				},
+			},
+		},
+	}
+
+	parsed, err := ParseCronSchedules(scale.Cron)
+	assert.NoError(t, err)
+
+	t.Run("active", func(t *testing.T) {
+		now := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+
+		gotMin, gotMax, active := EffectiveScaleBoundsAt(scale, parsed, now)
+
+		assert.True(t, active)
+		assert.Equal(t, min, gotMin)
+		assert.Equal(t, max, gotMax)
+	})
+
+	t.Run("inactive", func(t *testing.T) {
+		now := time.Date(2026, 1, 5, 20, 0, 0, 0, time.UTC)
+
+		gotMin, gotMax, active := EffectiveScaleBoundsAt(scale, parsed, now)
+
+		assert.False(t, active)
+		assert.Equal(t, int32(1), gotMin)
+		assert.Equal(t, int32(3), gotMax)
+	})
+}

--- a/pkg/reconciler/validator/pipeline_validate.go
+++ b/pkg/reconciler/validator/pipeline_validate.go
@@ -211,6 +211,9 @@ func validateVertex(v dfv1.AbstractVertex) error {
 	if errs := k8svalidation.IsDNS1035Label(v.Name); len(errs) > 0 {
 		return fmt.Errorf("invalid vertex name %q, %v", v.Name, errs)
 	}
+	if v.Scale.Cron != nil && !v.IsASource() {
+		return fmt.Errorf("vertex %q: cron autoscaling is only supported for source vertices", v.Name)
+	}
 	if err := validateCronScaling(v.Scale); err != nil {
 		return fmt.Errorf("vertex %q: invalid scale.cron: %w", v.Name, err)
 	}

--- a/pkg/reconciler/validator/pipeline_validate.go
+++ b/pkg/reconciler/validator/pipeline_validate.go
@@ -211,8 +211,8 @@ func validateVertex(v dfv1.AbstractVertex) error {
 	if errs := k8svalidation.IsDNS1035Label(v.Name); len(errs) > 0 {
 		return fmt.Errorf("invalid vertex name %q, %v", v.Name, errs)
 	}
-	if v.Scale.Cron != nil {
-		return fmt.Errorf("vertex %q: cron autoscaling is not supported for pipeline vertices", v.Name)
+	if err := validateCronScaling(v.Scale); err != nil {
+		return fmt.Errorf("vertex %q: invalid scale.cron: %w", v.Name, err)
 	}
 	min, max := int32(0), int32(dfv1.DefaultMaxReplicas)
 	if v.Scale.Min != nil {

--- a/pkg/reconciler/validator/pipeline_validate_test.go
+++ b/pkg/reconciler/validator/pipeline_validate_test.go
@@ -248,11 +248,22 @@ func TestValidatePipeline(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("cron autoscaling is not supported for pipeline vertices", func(t *testing.T) {
+	t.Run("valid cron autoscaling is accepted for pipeline vertex", func(t *testing.T) {
 		testObj := testPipeline.DeepCopy()
-		testObj.Spec.Vertices[1].Scale.Cron = &dfv1.CronScheduling{}
+		testObj.Spec.Vertices[1].Scale.Cron = &dfv1.CronScheduling{
+			Schedules: []dfv1.CronSchedule{
+				{Start: "0 0 9 * * *", End: "0 0 18 * * *", Min: ptr.To[int32](1), Max: ptr.To[int32](5)},
+			},
+		}
 		err := ValidatePipeline(testObj)
-		assert.ErrorContains(t, err, `vertex "p1": cron autoscaling is not supported for pipeline vertices`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid cron config on pipeline vertex is rejected", func(t *testing.T) {
+		testObj := testPipeline.DeepCopy()
+		testObj.Spec.Vertices[1].Scale.Cron = &dfv1.CronScheduling{} // empty schedules → validateCronScaling rejects
+		err := ValidatePipeline(testObj)
+		assert.ErrorContains(t, err, `vertex "p1": invalid scale.cron`)
 	})
 
 	t.Run("test nil pipeline", func(t *testing.T) {

--- a/pkg/reconciler/validator/pipeline_validate_test.go
+++ b/pkg/reconciler/validator/pipeline_validate_test.go
@@ -248,9 +248,9 @@ func TestValidatePipeline(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("valid cron autoscaling is accepted for pipeline vertex", func(t *testing.T) {
+	t.Run("valid cron autoscaling is accepted for source pipeline vertex", func(t *testing.T) {
 		testObj := testPipeline.DeepCopy()
-		testObj.Spec.Vertices[1].Scale.Cron = &dfv1.CronScheduling{
+		testObj.Spec.Vertices[0].Scale.Cron = &dfv1.CronScheduling{
 			Schedules: []dfv1.CronSchedule{
 				{Start: "0 0 9 * * *", End: "0 0 18 * * *", Min: ptr.To[int32](1), Max: ptr.To[int32](5)},
 			},
@@ -259,11 +259,22 @@ func TestValidatePipeline(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("invalid cron config on pipeline vertex is rejected", func(t *testing.T) {
+	t.Run("cron autoscaling on non-source pipeline vertex is rejected", func(t *testing.T) {
 		testObj := testPipeline.DeepCopy()
-		testObj.Spec.Vertices[1].Scale.Cron = &dfv1.CronScheduling{} // empty schedules → validateCronScaling rejects
+		testObj.Spec.Vertices[1].Scale.Cron = &dfv1.CronScheduling{
+			Schedules: []dfv1.CronSchedule{
+				{Start: "0 0 9 * * *", End: "0 0 18 * * *", Min: ptr.To[int32](1), Max: ptr.To[int32](5)},
+			},
+		}
 		err := ValidatePipeline(testObj)
-		assert.ErrorContains(t, err, `vertex "p1": invalid scale.cron`)
+		assert.ErrorContains(t, err, `vertex "p1": cron autoscaling is only supported for source vertices`)
+	})
+
+	t.Run("invalid cron config on source pipeline vertex is rejected", func(t *testing.T) {
+		testObj := testPipeline.DeepCopy()
+		testObj.Spec.Vertices[0].Scale.Cron = &dfv1.CronScheduling{} // empty schedules → validateCronScaling rejects
+		err := ValidatePipeline(testObj)
+		assert.ErrorContains(t, err, `vertex "input": invalid scale.cron`)
 	})
 
 	t.Run("test nil pipeline", func(t *testing.T) {

--- a/pkg/reconciler/vertex/scaling/scaling.go
+++ b/pkg/reconciler/vertex/scaling/scaling.go
@@ -255,11 +255,11 @@ func (s *Scaler) scaleOneVertex(ctx context.Context, key string, worker int) err
 		if cronActive {
 			if current < minReplicas {
 				log.Infof("Cron window active [min=%d, max=%d], current=%d is outside bounds; scaling up.", minReplicas, maxReplicas, current)
-				return s.patchVertexReplicas(ctx, vertex, minReplicas)
+				return s.scaleUpVertex(ctx, vertex, current, minReplicas, secondsSinceLastScale, scaleUpCooldown)
 			}
 			if current > maxReplicas {
 				log.Infof("Cron window active [min=%d, max=%d], current=%d is outside bounds; scaling down.", minReplicas, maxReplicas, current)
-				return s.patchVertexReplicas(ctx, vertex, maxReplicas)
+				return s.scaleDownVertex(ctx, vertex, current, maxReplicas, secondsSinceLastScale, scaleDownCooldown)
 			}
 		}
 	} else {
@@ -593,6 +593,34 @@ func (s *Scaler) patchVertexReplicas(ctx context.Context, vertex *dfv1.Vertex, d
 	}
 	log.Infow("Auto scaling - vertex replicas changed.", zap.Int32p("from", origin), zap.Int32("to", desiredReplicas), zap.String("namespace", vertex.Namespace), zap.String("pipeline", vertex.Spec.PipelineName), zap.String("vertex", vertex.Spec.Name))
 	return nil
+}
+
+func (s *Scaler) scaleUpVertex(ctx context.Context, vertex *dfv1.Vertex, current, desired int32, secondsSinceLastScale, scaleUpCooldown float64) error {
+	log := logging.FromContext(ctx)
+	maxAllowedUp := int32(vertex.Spec.Scale.GetReplicasPerScaleUp())
+	diff := desired - current
+	if diff > maxAllowedUp {
+		diff = maxAllowedUp
+	}
+	if secondsSinceLastScale < scaleUpCooldown {
+		log.Infof("Cooldown period for scaling up, skip scaling.")
+		return nil
+	}
+	return s.patchVertexReplicas(ctx, vertex, current+diff)
+}
+
+func (s *Scaler) scaleDownVertex(ctx context.Context, vertex *dfv1.Vertex, current, desired int32, secondsSinceLastScale, scaleDownCooldown float64) error {
+	log := logging.FromContext(ctx)
+	maxAllowedDown := int32(vertex.Spec.Scale.GetReplicasPerScaleDown())
+	diff := current - desired
+	if diff > maxAllowedDown {
+		diff = maxAllowedDown
+	}
+	if secondsSinceLastScale < scaleDownCooldown {
+		log.Infof("Cooldown period for scaling down, skip scaling.")
+		return nil
+	}
+	return s.patchVertexReplicas(ctx, vertex, current-diff)
 }
 
 // KeyOfVertex returns the unique key of a vertex

--- a/pkg/reconciler/vertex/scaling/scaling.go
+++ b/pkg/reconciler/vertex/scaling/scaling.go
@@ -33,6 +33,7 @@ import (
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	daemonclient "github.com/numaproj/numaflow/pkg/daemon/client"
+	scalingutil "github.com/numaproj/numaflow/pkg/reconciler/scaling"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 )
 
@@ -46,6 +47,8 @@ type Scaler struct {
 	// Cache to store the vertex metrics such as pending message number
 	vertexMetricsCache *lru.Cache[string, int64]
 	daemonClientsCache *lru.Cache[string, daemonclient.DaemonClient]
+	// Cache to store the pre-parsed cron schedules for each Vertex
+	cronScheduleCache *lru.Cache[string, []scalingutil.ParsedCronSchedule]
 }
 
 // NewScaler returns a Scaler instance.
@@ -69,6 +72,7 @@ func NewScaler(client client.Client, opts ...Option) *Scaler {
 	})
 	vertexMetricsCache, _ := lru.New[string, int64](10000)
 	s.vertexMetricsCache = vertexMetricsCache
+	s.cronScheduleCache, _ = lru.New[string, []scalingutil.ParsedCronSchedule](1000)
 	return s
 }
 
@@ -122,6 +126,33 @@ func (s *Scaler) scale(ctx context.Context, id int, keyCh <-chan string) {
 			}
 		}
 	}
+}
+
+// parsedCronSchedulesFor returns the parsed cron schedules for a Vertex.
+func (s *Scaler) parsedCronSchedulesFor(vertex *dfv1.Vertex) ([]scalingutil.ParsedCronSchedule, error) {
+	if vertex.Spec.Scale.Cron == nil {
+		return nil, nil
+	}
+	key := fmt.Sprintf("%s/%d", vertex.UID, vertex.Generation)
+	if parsed, ok := s.cronScheduleCache.Get(key); ok {
+		return parsed, nil
+	}
+	parsed, err := scalingutil.ParseCronSchedules(vertex.Spec.Scale.Cron)
+	if err != nil {
+		return nil, err
+	}
+	s.cronScheduleCache.Add(key, parsed)
+	return parsed, nil
+}
+
+// effectiveScaleBoundsFor returns the effective scale bounds for a Vertex at a given time.
+func (s *Scaler) effectiveScaleBoundsFor(vertex *dfv1.Vertex, at time.Time) (int32, int32, bool, error) {
+	parsed, err := s.parsedCronSchedulesFor(vertex)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	minReplicas, maxReplicas, cronActive := scalingutil.EffectiveScaleBoundsAt(vertex.Spec.Scale, parsed, at)
+	return minReplicas, maxReplicas, cronActive, nil
 }
 
 // scaleOneVertex implements the detailed logic of scaling up/down a vertex.
@@ -209,12 +240,38 @@ func (s *Scaler) scaleOneVertex(ctx context.Context, key string, worker int) err
 		return nil
 	}
 
-	if vertex.Spec.Scale.GetMaxReplicas() == vertex.Spec.Scale.GetMinReplicas() {
+	var minReplicas, maxReplicas int32
+	var cronActive bool
+	var err error
+
+	if vertex.IsASource() {
+		minReplicas, maxReplicas, cronActive, err = s.effectiveScaleBoundsFor(vertex, time.Now())
+		if err != nil {
+			log.Errorw("Failed to parse cron schedules.", zap.Error(err))
+			return err
+		}
+
+		current := int32(vertex.Status.Replicas)
+		if cronActive {
+			if current < minReplicas {
+				log.Infof("Cron window active [min=%d, max=%d], current=%d is outside bounds; scaling up.", minReplicas, maxReplicas, current)
+				return s.patchVertexReplicas(ctx, vertex, minReplicas)
+			}
+			if current > maxReplicas {
+				log.Infof("Cron window active [min=%d, max=%d], current=%d is outside bounds; scaling down.", minReplicas, maxReplicas, current)
+				return s.patchVertexReplicas(ctx, vertex, maxReplicas)
+			}
+		}
+	} else {
+		minReplicas = vertex.Spec.Scale.GetMinReplicas()
+		maxReplicas = vertex.Spec.Scale.GetMaxReplicas()
+	}
+
+	if maxReplicas == minReplicas {
 		log.Infof("Vertex %s has same scale.min and scale.max, skip scaling.", vertex.Name)
 		return nil
 	}
 
-	var err error
 	daemonClient, _ := s.daemonClientsCache.Get(pl.GetDaemonServiceURL())
 	if daemonClient == nil {
 		daemonClient, err = daemonclient.NewGRPCDaemonServiceClient(pl.GetDaemonServiceURL())
@@ -339,8 +396,6 @@ func (s *Scaler) scaleOneVertex(ctx context.Context, key string, worker int) err
 	}
 
 	log.Infof("Calculated desired replica number of vertex %q is: %d.", vertex.Name, desired)
-	maxReplicas := vertex.Spec.Scale.GetMaxReplicas()
-	minReplicas := vertex.Spec.Scale.GetMinReplicas()
 	if desired > maxReplicas {
 		log.Infof("Calculated desired replica number %d of vertex %q is greater than max, using max %d.", desired, vertex.Name, maxReplicas)
 		desired = maxReplicas

--- a/pkg/reconciler/vertex/scaling/scaling_test.go
+++ b/pkg/reconciler/vertex/scaling/scaling_test.go
@@ -16,10 +16,16 @@ package scaling
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
@@ -175,4 +181,150 @@ func Test_desiredReplicasSinglePartition(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestScaleOneVertex_AppliesActiveCronBoundsBeforeMetrics(t *testing.T) {
+	tests := []struct {
+		name                 string
+		current              int32
+		cronMin              int32
+		cronMax              int32
+		replicasPerScaleUp   uint32
+		replicasPerScaleDown uint32
+		scaleUpCooldown      uint32
+		scaleDownCooldown    uint32
+		lastScaledSecondsAgo int
+		expected             int32
+	}{
+		{
+			// diff=1-0=1, maxAllowedUp=2 → clamped diff=1 → 0+1=1
+			name:                 "scale up from zero for nightly DLQ drain",
+			current:              0,
+			cronMin:              1,
+			cronMax:              5,
+			replicasPerScaleUp:   2,
+			replicasPerScaleDown: 2,
+			scaleUpCooldown:      90,
+			scaleDownCooldown:    90,
+			lastScaledSecondsAgo: 600,
+			expected:             1,
+		},
+		{
+			// diff=10-5=5, maxAllowedDown=2 → clamped diff=2 → 10-2=8
+			name:                 "scale down toward cron max",
+			current:              10,
+			cronMin:              1,
+			cronMax:              5,
+			replicasPerScaleUp:   2,
+			replicasPerScaleDown: 2,
+			scaleUpCooldown:      90,
+			scaleDownCooldown:    90,
+			lastScaledSecondsAgo: 600,
+			expected:             8,
+		},
+		{
+			// secondsSinceLastScale≈60: global early-exit requires BOTH cooldowns active (60<30 && 60<90)=false → proceeds;
+			// scaleUpVertex sees 60 < 90 → cooldown active → no patch.
+			name:                 "scale up cooldown prevents scaling",
+			current:              0,
+			cronMin:              1,
+			cronMax:              5,
+			replicasPerScaleUp:   2,
+			replicasPerScaleDown: 2,
+			scaleUpCooldown:      90,
+			scaleDownCooldown:    30,
+			lastScaledSecondsAgo: 60,
+			expected:             0, // no change
+		},
+		{
+			// secondsSinceLastScale≈60: global early-exit (60<90 && 60<30)=false → proceeds;
+			// scaleDownVertex sees 60 < 90 → cooldown active → no patch.
+			name:                 "scale down cooldown prevents scaling",
+			current:              10,
+			cronMin:              1,
+			cronMax:              5,
+			replicasPerScaleUp:   2,
+			replicasPerScaleDown: 2,
+			scaleUpCooldown:      30,
+			scaleDownCooldown:    90,
+			lastScaledSecondsAgo: 60,
+			expected:             10, // no change
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			location, err := time.LoadLocation("America/Los_Angeles")
+			if err != nil {
+				t.Fatal(err)
+			}
+			now := time.Now().In(location)
+			start := now.Add(-time.Minute)
+			end := now.Add(time.Minute)
+			cronExpression := func(t time.Time) string {
+				return fmt.Sprintf("0 %d %d %d %d *", t.Minute(), t.Hour(), t.Day(), int(t.Month()))
+			}
+
+			pl := &dfv1.Pipeline{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pl",
+					Namespace: "default",
+				},
+				Spec: dfv1.PipelineSpec{
+					Lifecycle: dfv1.Lifecycle{
+						DesiredPhase: dfv1.PipelinePhaseRunning,
+					},
+				},
+			}
+			vertex := &dfv1.Vertex{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pl-source",
+					Namespace: "default",
+				},
+				Spec: dfv1.VertexSpec{
+					Replicas:     ptr.To(tc.current),
+					PipelineName: "test-pl",
+					AbstractVertex: dfv1.AbstractVertex{
+						Name:   "source",
+						Source: &dfv1.Source{},
+						Scale: dfv1.Scale{
+							ReplicasPerScaleUp:       ptr.To(tc.replicasPerScaleUp),
+							ReplicasPerScaleDown:     ptr.To(tc.replicasPerScaleDown),
+							ScaleUpCooldownSeconds:   ptr.To(tc.scaleUpCooldown),
+							ScaleDownCooldownSeconds: ptr.To(tc.scaleDownCooldown),
+							Cron: &dfv1.CronScheduling{
+								Timezone: "America/Los_Angeles",
+								Schedules: []dfv1.CronSchedule{
+									{
+										Start: cronExpression(start),
+										End:   cronExpression(end),
+										Min:   ptr.To(tc.cronMin),
+										Max:   ptr.To(tc.cronMax),
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: dfv1.VertexStatus{
+					Phase:           dfv1.VertexPhaseRunning,
+					Replicas:        uint32(tc.current),
+					DesiredReplicas: uint32(tc.current),
+					LastScaledAt:    metav1.NewTime(time.Now().Add(-time.Duration(tc.lastScaledSecondsAgo) * time.Second)),
+				},
+			}
+
+			scheme := runtime.NewScheme()
+			require.NoError(t, dfv1.AddToScheme(scheme))
+			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pl, vertex).Build()
+			scaler := NewScaler(cl)
+
+			err = scaler.scaleOneVertex(context.Background(), "default/test-pl-source", 1)
+			assert.NoError(t, err)
+
+			updated := &dfv1.Vertex{}
+			assert.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(vertex), updated))
+			assert.Equal(t, tc.expected, *updated.Spec.Replicas)
+		})
+	}
 }

--- a/pkg/reconciler/vertex/scaling/scaling_test.go
+++ b/pkg/reconciler/vertex/scaling/scaling_test.go
@@ -1,11 +1,10 @@
 /*
 Copyright 2022 The Numaproj Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package scaling
 
 import (
@@ -55,9 +53,7 @@ func Test_BasicOperations(t *testing.T) {
 	s.StopWatching("key1")
 	assert.False(t, s.Contains("key1"))
 }
-
 func Test_desiredReplicasSinglePartition(t *testing.T) {
-
 	t.Run("test src", func(t *testing.T) {
 		cl := fake.NewClientBuilder().Build()
 		s := NewScaler(cl)
@@ -75,7 +71,6 @@ func Test_desiredReplicasSinglePartition(t *testing.T) {
 		assert.Equal(t, int32(13), s.desiredReplicas(context.TODO(), src, []float64{800, 210, 750}, []int64{18932, 800, 24988}, int64(30000), int64(24000), int64(27000)))
 		assert.Equal(t, int32(15), s.desiredReplicas(context.TODO(), src, []float64{800, 21, 750}, []int64{18932, 800, 24988}, int64(30000), int64(24000), int64(27000)))
 	})
-
 	t.Run("test udf", func(t *testing.T) {
 		cl := fake.NewClientBuilder().Build()
 		s := NewScaler(cl)
@@ -83,7 +78,6 @@ func Test_desiredReplicasSinglePartition(t *testing.T) {
 		udf.Spec.UDF = &dfv1.UDF{}
 		udf.Spec.Scale.TargetProcessingSeconds = ptr.To[uint32](5)
 		udf.Spec.Scale.TargetBufferAvailability = ptr.To[uint32](90)
-
 		tests := []struct {
 			name                    string
 			partitionProcessingRate []float64
@@ -169,7 +163,6 @@ func Test_desiredReplicasSinglePartition(t *testing.T) {
 				want:                    11,
 			},
 		}
-
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				udf := fakeVertex.DeepCopy()
@@ -182,5 +175,4 @@ func Test_desiredReplicasSinglePartition(t *testing.T) {
 			})
 		}
 	})
-
 }


### PR DESCRIPTION
### What this PR does / why we need it

Adds support for cron-based autoscaling for source vertices.

This change allows source vertices to honor cron schedules defined under `spec.scale.cron`. During an active cron window, the autoscaler applies the configured `min` and `max` replica bounds before performing the normal autoscaling calculations. Outside the scheduled window, the default scale bounds are used.

The implementation includes:
- Parsing and validation of cron schedules.
- Caching parsed cron schedules to avoid repeated parsing.
- Determining effective scale bounds based on the current time.
- Applying cron-specific min/max replica limits for source vertices.
- Unit tests covering cron schedule parsing and effective bound calculation.

### Related issues

Fixes #3547

### Testing

Unit tests:
```bash
go test ./pkg/reconciler/vertex/scaling/...