### PR TITLE
refactor(rust): box nack_options in Message

### DIFF
--- a/rust/numaflow-core/src/mapper/map.rs
+++ b/rust/numaflow-core/src/mapper/map.rs
@@ -620,7 +620,7 @@ impl From<UserDefinedMessage<'_>> for Message {
                 }
                 Some(Arc::new(metadata))
             },
-            nack_options: value.0.nack_options.map(Into::into),
+            nack_options: value.0.nack_options.map(|o| Box::new(o.into())),
         }
     }
 }
@@ -1276,7 +1276,7 @@ mod tests {
         let msg: Message = UserDefinedMessage(result, &parent_info, 0).into();
         assert!(msg.nacked(), "NACK tag must make the message nacked()");
         assert_eq!(
-            msg.nack_options,
+            msg.nack_options.clone().map(|o| *o),
             Some(NackOptions {
                 reason: Some("retry".to_string()),
                 max_deliveries: Some(3),

--- a/rust/numaflow-core/src/message.rs
+++ b/rust/numaflow-core/src/message.rs
@@ -122,8 +122,9 @@ pub(crate) struct Message {
     /// is_late is used to indicate if the message is a late data. Late data is data that arrives
     /// after the watermark has passed. This is set only at source.
     pub(crate) is_late: bool,
-    // TODO: Move to using Option<Box<NackOptions>> in a separate PR
-    pub(crate) nack_options: Option<NackOptions>,
+    /// Nack options are boxed so they do not inflate every Message on the hot
+    /// path, since they are only populated on the (rare) nack path.
+    pub(crate) nack_options: Option<Box<NackOptions>>,
 }
 
 /// AckHandle is used to send the ack/nak to the source. It uses a reference count to track

--- a/rust/numaflow-core/src/pipeline/isb/writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/writer.rs
@@ -95,7 +95,11 @@ impl ISBWriteTask {
 
         if message.nacked() {
             // TODO: send nacked message metric
-            mark_failed!(self.msg_handle, "message nacked", message.nack_options);
+            mark_failed!(
+                self.msg_handle,
+                "message nacked",
+                message.nack_options.map(|o| *o)
+            );
             return;
         }
 
@@ -2136,7 +2140,7 @@ mod simple_buffer_tests {
             ..Default::default()
         };
         let (mut msg, ack_rx) = create_test_message(1, "hello", Some(vec!["U+005C__NACK__"]));
-        msg.message.nack_options = Some(opts.clone());
+        msg.message.nack_options = Some(Box::new(opts.clone()));
         tx.send(msg).await.unwrap();
         drop(tx);
 

--- a/rust/numaflow-core/src/sinker/actor.rs
+++ b/rust/numaflow-core/src/sinker/actor.rs
@@ -171,7 +171,7 @@ where
                         // would've been filtered out already before messages were sent
                         // to sink for writing. So we can overwrite nack options here.
                         let mut msg = msg;
-                        msg.nack_options = options;
+                        msg.nack_options = options.map(Box::new);
                         nacked_messages.push(msg);
                     }
                     None => {

--- a/rust/numaflow-core/src/sinker/sink.rs
+++ b/rust/numaflow-core/src/sinker/sink.rs
@@ -265,7 +265,7 @@ impl SinkWriter {
                                 Self::split_batch_handles(read_batch, processed_messages);
 
                             for nacked_handle in nacked_handles {
-                                let opts = nacked_handle.message.nack_options.clone();
+                                let opts = nacked_handle.message.nack_options.clone().map(|o| *o);
                                 mark_failed!(nacked_handle, "message nacked", opts);
                             }
                             mark_success_batch!(acked_handles);
@@ -1754,7 +1754,7 @@ mod tests {
                 offset: format!("o-{id}").into(),
                 index: id as i32,
             },
-            nack_options,
+            nack_options: nack_options.map(Box::new),
             ..Default::default()
         };
         (MessageHandle::new(message, ack_tx), ack_rx)
@@ -2067,7 +2067,7 @@ mod tests {
         // processed batch reports h1 as nacked, carrying options on the message.
         let nacked_msg = Message {
             id: id1.clone(),
-            nack_options: Some(opts.clone()),
+            nack_options: Some(Box::new(opts.clone())),
             ..Default::default()
         };
         let processed = ProcessedSinkBatch::new().with_nacked(vec![nacked_msg]);
@@ -2079,7 +2079,7 @@ mod tests {
         assert_eq!(
             nacked
                 .first()
-                .and_then(|h| h.message().nack_options.clone()),
+                .and_then(|h| h.message().nack_options.clone().map(|o| *o)),
             Some(opts.clone())
         );
         assert_eq!(acked.len(), 2, "the other two are acked (complement)");
@@ -2089,7 +2089,7 @@ mod tests {
             h.mark_success();
         }
         for h in nacked {
-            let o = h.message().nack_options.clone();
+            let o = h.message().nack_options.clone().map(|o| *o);
             h.mark_failed("message nacked", o);
         }
         assert_eq!(rx0.await.unwrap(), ReadAck::Ack);

--- a/rust/numaflow-core/src/transformer/user_defined.rs
+++ b/rust/numaflow-core/src/transformer/user_defined.rs
@@ -76,7 +76,7 @@ impl From<UserDefinedTransformerMessage<'_>> for Message {
                 Some(Arc::new(metadata))
             },
             is_late: value.1.is_late,
-            nack_options: value.0.nack_options.map(Into::into),
+            nack_options: value.0.nack_options.map(|o| Box::new(o.into())),
         }
     }
 }
@@ -647,7 +647,7 @@ mod tests {
         let out = messages.first().expect("one message");
         assert!(out.nacked());
         assert_eq!(
-            out.nack_options,
+            out.nack_options.clone().map(|o| *o),
             Some(crate::message::NackOptions {
                 delay: Some(5000),
                 max_deliveries: Some(3),
@@ -697,7 +697,7 @@ mod tests {
         let msg: Message = UserDefinedTransformerMessage(result, &parent_info, 0).into();
         assert!(msg.nacked());
         assert_eq!(
-            msg.nack_options,
+            msg.nack_options.clone().map(|o| *o),
             Some(NackOptions {
                 reason: Some("retry".to_string()),
                 max_deliveries: Some(2),


### PR DESCRIPTION
`Message.nack_options` was stored inline as `Option<NackOptions>`, but `NackOptions` is only populated on the (rare) nack path while `Message` is passed around on the hot path. This boxes it to `Option<Box<NackOptions>>` so the field costs one pointer when unset instead of the full `NackOptions`, following the `TODO` left in `message.rs` (originally noted by @vaibhavtiwari33 in #3455).

Callers box on write and deref on read; behavior is unchanged. The existing nack tests pass (`cargo test -p numaflow-core -- nack` — 29 passing).

Closes #3490

---
<sub>Disclosure: prepared with AI assistance.</sub>
