### PR TITLE
feat(ui): add virtualized rendering for pod logs

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -31,6 +31,7 @@
     "@mui/material": "^5.6.3",
     "@mui/x-date-pickers": "^7.23.2",
     "@stardazed/streams-polyfill": "^2.4.0",
+    "@tanstack/react-virtual": "^3.14.9",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.5.1",
@@ -43,6 +44,7 @@
     "@types/react": "^18.0.0",
     "@types/react-bootstrap-daterangepicker": "^7.0.0",
     "@types/react-dom": "^18.0.0",
+    "@types/react-highlight-words": "^0.20.1",
     "@types/react-router-dom": "^5.3.3",
     "@types/react-test-renderer": "^18.0.0",
     "@visx/event": "^2.6.0",
@@ -118,7 +120,7 @@
   },
   "jest": {
     "transformIgnorePatterns": [
-      "/node_modules/(?!d3|d3-array|internmap|delaunator|robust-predicates|@xyflow|react-toastify|moment)"
+      "/node_modules/(?!d3|d3-array|internmap|delaunator|robust-predicates|@xyflow|@tanstack/react-virtual|@tanstack/virtual-core|react-toastify|moment)"
     ],
     "moduleNameMapper": {
       "\\.css$": "<rootDir>/mocks/styleMock.js",

--- a/ui/src/components/pages/Namespace/partials/NamespaceListingWrapper/ISBServiceCard/ISBServiceCard.test.tsx
+++ b/ui/src/components/pages/Namespace/partials/NamespaceListingWrapper/ISBServiceCard/ISBServiceCard.test.tsx
@@ -170,7 +170,7 @@ const mockData = {
 //Mock the DeleteModal component
 jest.mock("../../DeleteModal", () => {
   return {
-    DeleteModal: ({ _, onDeleteCompleted, onCancel }) => {
+    DeleteModal: ({ onDeleteCompleted, onCancel }) => {
       return (
         <div data-testid="mock-delete-confirmation">
           <button onClick={onDeleteCompleted}>Mock Delete Confirmation</button>

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/LogVirtualList.test.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/LogVirtualList.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import { LogVirtualList } from "./LogVirtualList";
+
+const VIEWPORT_HEIGHT = 160;
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (this.getAttribute("data-testid") === "log-virtual-list") {
+        return VIEWPORT_HEIGHT;
+      }
+      return 16;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (this.getAttribute("data-testid") === "log-virtual-list") {
+        return VIEWPORT_HEIGHT;
+      }
+      return 16;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value(this: HTMLElement) {
+      const height =
+        this.getAttribute("data-testid") === "log-virtual-list"
+          ? VIEWPORT_HEIGHT
+          : 16;
+      return {
+        x: 0,
+        y: 0,
+        width: 400,
+        height,
+        top: 0,
+        left: 0,
+        bottom: height,
+        right: 400,
+        toJSON: () => ({}),
+      };
+    },
+  });
+});
+
+describe("LogVirtualList", () => {
+  it("renders only a viewport subset of a long log list", () => {
+    const logs = Array.from({ length: 100 }, (_, i) => `log-line-${i}`);
+
+    render(
+      <div style={{ height: VIEWPORT_HEIGHT }}>
+        <LogVirtualList
+          logs={logs}
+          search=""
+          wrapLines={false}
+          colorMode="light"
+          podName="pod-a"
+        />
+      </div>
+    );
+
+    expect(screen.getByTestId("log-virtual-list")).toBeInTheDocument();
+    expect(screen.getByText("log-line-0")).toBeInTheDocument();
+
+    const rows = screen.getAllByTestId("log-virtual-row");
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.length).toBeLessThan(logs.length);
+    expect(screen.queryByText("log-line-99")).not.toBeInTheDocument();
+  });
+
+  it("highlights search matches in visible rows", () => {
+    render(
+      <div style={{ height: VIEWPORT_HEIGHT }}>
+        <LogVirtualList
+          logs={["alpha foo", "beta bar"]}
+          search="foo"
+          wrapLines={false}
+          colorMode="dark"
+          podName="pod-a"
+        />
+      </div>
+    );
+
+    expect(screen.getByText("foo")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/LogVirtualList.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/LogVirtualList.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef } from "react";
+import Box from "@mui/material/Box";
+import Highlighter from "react-highlight-words";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { LOG_ROW_HEIGHT_PX } from "./constants";
+
+export type LogVirtualListProps = {
+  logs: string[];
+  search: string;
+  wrapLines: boolean;
+  colorMode: string;
+  podName: string;
+};
+
+export function LogVirtualList({
+  logs,
+  search,
+  wrapLines,
+  colorMode,
+  podName,
+}: LogVirtualListProps) {
+  const parentRef = useRef<HTMLDivElement | null>(null);
+
+  const virtualizer = useVirtualizer({
+    count: logs.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => LOG_ROW_HEIGHT_PX,
+    overscan: 10,
+    // Non-zero seed so the first paint (and jsdom tests) can resolve rows
+    // before the scroll element is measured.
+    initialRect: { width: 800, height: 320 },
+    measureElement: wrapLines
+      ? (element) => element.getBoundingClientRect().height
+      : undefined,
+  });
+
+  useEffect(() => {
+    virtualizer.measure();
+  }, [wrapLines, virtualizer]);
+
+  const isLight = colorMode === "light";
+
+  return (
+    <Box
+      ref={parentRef}
+      data-testid="log-virtual-list"
+      sx={{
+        backgroundColor: isLight ? "whitesmoke" : "black",
+        fontWeight: 600,
+        borderRadius: "0.4rem",
+        padding: "1rem 0rem",
+        height: "calc(100% - 6rem)",
+        overflow: "auto",
+      }}
+    >
+      <Box
+        sx={{
+          height: `${virtualizer.getTotalSize()}px`,
+          width: "100%",
+          position: "relative",
+        }}
+      >
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const line = logs[virtualRow.index];
+          return (
+            <Box
+              key={`${virtualRow.index}-${podName}-logs`}
+              data-index={virtualRow.index}
+              data-testid="log-virtual-row"
+              ref={wrapLines ? virtualizer.measureElement : undefined}
+              component="span"
+              sx={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${virtualRow.start}px)`,
+                whiteSpace: wrapLines ? "normal" : "nowrap",
+                height: wrapLines ? "auto" : `${LOG_ROW_HEIGHT_PX}px`,
+                lineHeight: `${LOG_ROW_HEIGHT_PX}px`,
+              }}
+            >
+              <Highlighter
+                searchWords={[search]}
+                autoEscape={true}
+                textToHighlight={line}
+                style={{
+                  color: isLight ? "black" : "white",
+                  fontFamily: "Consolas,Liberation Mono,Courier,monospace",
+                  fontWeight: "normal",
+                  background: isLight ? "#E6E6E6" : "#333333",
+                  fontSize: "1.4rem",
+                  textWrap: wrapLines ? "wrap" : "nowrap",
+                  border: "1px solid #cacaca",
+                }}
+                highlightStyle={{
+                  color: isLight ? "white" : "black",
+                  backgroundColor: isLight ? "black" : "white",
+                }}
+              />
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/constants.ts
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/constants.ts
@@ -3,3 +3,6 @@ export const MAX_LOGS = 1000;
 export const NO_LOGS_MATCHING_SEARCH = "No logs match your search.";
 
 export const LOADING_LOGS = "Loading logs...";
+
+// Matches unwrap row height of 1.6rem with html font-size 10px (App.css).
+export const LOG_ROW_HEIGHT_PX = 16;

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.test.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.test.tsx
@@ -5,6 +5,28 @@ import { PodLogs } from "./index";
 
 Object.assign(global, { TextDecoder, TextEncoder });
 
+// jsdom reports 0 for layout; give the virtual log scroller a viewport.
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (this.getAttribute("data-testid") === "log-virtual-list") {
+        return 320;
+      }
+      return 16;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (this.getAttribute("data-testid") === "log-virtual-list") {
+        return 320;
+      }
+      return 16;
+    },
+  });
+});
+
 describe("PodLogs", () => {
   let originFetch: any;
   beforeEach(() => {

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
@@ -28,11 +28,11 @@ import { ClockIcon } from "@mui/x-date-pickers";
 import Tooltip from "@mui/material/Tooltip";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Checkbox from "@mui/material/Checkbox";
-import Highlighter from "react-highlight-words";
 import { PodLogsProps } from "../../../../../../../../../../../../../types/declarations/pods";
 import { AppContextProps } from "../../../../../../../../../../../../../types/declarations/app";
 import { AppContext } from "../../../../../../../../../../../../../App";
 import { filterLogs } from "./filterLogs";
+import { LogVirtualList } from "./LogVirtualList";
 import { usePodLogStream } from "./usePodLogStream";
 
 import "./style.css";
@@ -75,6 +75,12 @@ export function PodLogs({
     const source = showPreviousLogs ? previousLogs : logs;
     return filterLogs(source, search, negateSearch);
   }, [showPreviousLogs, previousLogs, logs, search, negateSearch]);
+
+  const orderedLogs = useMemo(
+    () =>
+      logsOrder === "desc" ? filteredLogs.slice().reverse() : filteredLogs,
+    [filteredLogs, logsOrder]
+  );
 
   const handleSearchChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -350,98 +356,13 @@ export function PodLogs({
         }
       />
       <Box sx={{ height: "calc(100% - 9rem)" }}>
-        <Box
-          sx={{
-            backgroundColor: `${
-              colorMode === "light" ? "whitesmoke" : "black"
-            }`,
-            fontWeight: 600,
-            borderRadius: "0.4rem",
-            padding: "1rem 0rem",
-            height: "calc(100% - 6rem)",
-            overflow: "scroll",
-          }}
-        >
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              height: "100%",
-            }}
-          >
-            {logsOrder === "asc" &&
-              filteredLogs.map((l: string, idx) => (
-                <Box
-                  key={`${idx}-${podName}-logs`}
-                  component="span"
-                  sx={{
-                    whiteSpace: wrapLines ? "normal" : "nowrap",
-                    height: wrapLines ? "auto" : "1.6rem",
-                    lineHeight: "1.6rem",
-                  }}
-                >
-                  <Highlighter
-                    searchWords={[search]}
-                    autoEscape={true}
-                    textToHighlight={l}
-                    style={{
-                      color: colorMode === "light" ? "black" : "white",
-                      fontFamily: "Consolas,Liberation Mono,Courier,monospace",
-                      fontWeight: "normal",
-                      background: colorMode === "light" ? "#E6E6E6" : "#333333",
-                      fontSize: "1.4rem",
-                      textWrap: wrapLines ? "wrap" : "nowrap",
-                      border: "1px solid #cacaca",
-                    }}
-                    highlightStyle={{
-                      color: `${colorMode === "light" ? "white" : "black"}`,
-                      backgroundColor: `${
-                        colorMode === "light" ? "black" : "white"
-                      }`,
-                    }}
-                  />
-                </Box>
-              ))}
-            {logsOrder === "desc" &&
-              filteredLogs
-                .slice()
-                .reverse()
-                .map((l: string, idx) => (
-                  <Box
-                    key={`${idx}-${podName}-logs`}
-                    component="span"
-                    sx={{
-                      whiteSpace: wrapLines ? "normal" : "nowrap",
-                      height: wrapLines ? "auto" : "1.6rem",
-                      lineHeight: "1.6rem",
-                    }}
-                  >
-                    <Highlighter
-                      searchWords={[search]}
-                      autoEscape={true}
-                      textToHighlight={l}
-                      style={{
-                        color: colorMode === "light" ? "black" : "white",
-                        fontFamily:
-                          "Consolas,Liberation Mono,Courier,monospace",
-                        fontWeight: "normal",
-                        background:
-                          colorMode === "light" ? "#E6E6E6" : "#333333",
-                        fontSize: "1.4rem",
-                        textWrap: wrapLines ? "wrap" : "nowrap",
-                        border: "1px solid #cacaca",
-                      }}
-                      highlightStyle={{
-                        color: `${colorMode === "light" ? "white" : "black"}`,
-                        backgroundColor: `${
-                          colorMode === "light" ? "black" : "white"
-                        }`,
-                      }}
-                    />
-                  </Box>
-                ))}
-          </Box>
-        </Box>
+        <LogVirtualList
+          logs={orderedLogs}
+          search={search}
+          wrapLines={wrapLines}
+          colorMode={colorMode}
+          podName={podName}
+        />
       </Box>
     </Box>
   );

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2454,6 +2454,18 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@tanstack/react-virtual@^3.14.9":
+  version "3.14.9"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz#b735e93a059a25f577a9577d7f014343ec7205a5"
+  integrity sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==
+  dependencies:
+    "@tanstack/virtual-core" "3.17.7"
+
+"@tanstack/virtual-core@3.17.7":
+  version "3.17.7"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz#d64525d2c97a53a22f32f55246efdd679af2c392"
+  integrity sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==
+
 "@testing-library/dom@^9.0.0":
   version "9.3.4"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.4.tgz#50696ec28376926fec0a1bf87d9dbac5e27f60ce"
@@ -2927,6 +2939,13 @@
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-highlight-words@^0.20.1":
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/@types/react-highlight-words/-/react-highlight-words-0.20.1.tgz#f84a47b36d5e571afc7da47f273aaabf366b71a0"
+  integrity sha512-EgF6RaoibBurIhxk3X3d5xL0uMqjD7KtShvZ8S+d7/o6xZ+mQ4rct1a2E49vWA9r63OzrHCIyghqvQHASb/ERw==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
### What this PR does / why we need it

Pod logs in the UI rendered every line in the DOM at once. With large log buffers that got slow and hard to scroll.

This PR adds a virtualized log list (`LogVirtualList` via `@tanstack/react-virtual`) so only visible rows are mounted. Search highlight, wrap lines, and sort order still work the same.

### Related issues

Related to #3513

### Testing

- Unit tests added for `LogVirtualList` and updated for `PodLogs`.
- Related UI tests pass.

### Notes for reviewers
- Jest is configured to transpile `@tanstack/react-virtual`.
