### PR TITLE
feat: set max message size to 64mb for udsource

### DIFF
--- a/rust/numaflow-core/src/shared/create_components.rs
+++ b/rust/numaflow-core/src/shared/create_components.rs
@@ -614,7 +614,9 @@ async fn create_source_client(
 
     let channel =
         create_rpc_channel(PathBuf::from(user_defined_config.socket_path.clone())).await?;
-    let mut client = SourceClient::new(channel);
+    let mut client = SourceClient::new(channel)
+        .max_encoding_message_size(user_defined_config.grpc_max_message_size)
+        .max_decoding_message_size(user_defined_config.grpc_max_message_size);
     wait_until_source_ready(&cln_token, &mut client).await?;
     Ok((client, server_info))
 }


### PR DESCRIPTION
### What this PR does / why we need it
Encountered the following error on release 1.8.x:
```
{"timestamp":"2026-08-03T14:33:41.936624Z","level":"ERROR","message":"Error while reading messages: Grpc(Status { code: OutOfRange, message: \"Error, decoded message length too large: found 4280014 bytes, the limit is: 4194304 bytes\", source: None })","target":"numaflow_core::source"}
{"timestamp":"2026-08-03T14:33:41.936652Z","level":"INFO","message":"Source stopped, waiting for inflight messages to be acked/nacked","status":"Err(Grpc(Status { code: OutOfRange, message: \"Error, decoded message length too large: found 4280014 bytes, the limit is: 4194304 bytes\", source: None }))","target":"numaflow_core::source"}
{"timestamp":"2026-08-03T14:33:41.936659Z","level":"INFO","message":"All inflight messages are acked/nacked. Source stopped.","target":"numaflow_core::source"}
```

The max limit increase change was not merged to main, so patching release-1.8.
The same change is already available in main now (post cutting release-1.8: [link](https://github.com/numaproj/numaflow/pull/3459)) but it will be released in v1.9

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
