### PR TITLE
docs: add ArgoCD ignoreDifferences guidance for autoscaled MonoVertex/Vertex

### DIFF
--- a/docs/operations/argocd.md
+++ b/docs/operations/argocd.md
@@ -14,7 +14,7 @@ healthy and scaling correctly.
 Add an `ignoreDifferences` entry to your ArgoCD `Application` so it stops
 comparing `spec.replicas` for autoscaled resources:
 
-\`\`\`yaml
+```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/docs/operations/argocd.md
+++ b/docs/operations/argocd.md
@@ -1,0 +1,39 @@
+# Using Numaflow with ArgoCD
+
+Numaflow's autoscaler updates `spec.replicas` on `MonoVertex` and `Vertex`
+objects directly (via the Kubernetes scale subresource), the same way a
+Horizontal Pod Autoscaler updates `spec.replicas` on a `Deployment`.
+
+If you manage Numaflow resources with ArgoCD, this can cause ArgoCD to
+report the resource as `OutOfSync`, because the live `replicas` value no
+longer matches what's committed in Git — even though the pipeline is
+healthy and scaling correctly.
+
+## Recommended fix
+
+Add an `ignoreDifferences` entry to your ArgoCD `Application` so it stops
+comparing `spec.replicas` for autoscaled resources:
+
+\`\`\`yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-numaflow-app
+spec:
+  ignoreDifferences:
+    - group: numaflow.numaproj.io
+      kind: MonoVertex
+      jsonPointers:
+        - /spec/replicas
+    - group: numaflow.numaproj.io
+      kind: Vertex
+      jsonPointers:
+        - /spec/replicas
+  syncPolicy:
+    syncOptions:
+      - RespectIgnoreDifferences=true
+\`\`\`
+
+This tells ArgoCD to treat autoscaler-driven replica changes as expected
+drift instead of a sync error, while still tracking real spec changes
+made in Git.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,6 +157,7 @@ nav:
   - Operator Manual:
       - Releases ⧉: "operations/releases.md"
       - operations/installation.md
+      - Using ArgoCD: operations/argocd.md
       - Validating Webhook: operations/validating-webhook.md
       - Configuration:
           - Controller Configuration: "operations/controller-configmap.md"


### PR DESCRIPTION
## Problem
   Autoscaled MonoVertex/Vertex resources appear as "OutOfSync" in ArgoCD
   because the autoscaler updates spec.replicas via the scale subresource,
   which diverges from the value committed in Git.

   ## Fix
   Adds a new docs page explaining how to configure `ignoreDifferences`
   in the ArgoCD Application spec so this expected drift isn't flagged
   as a sync error.

   Fixes #3576