### PR TITLE
doc: link monovertex bypass with conditional forward

### DIFF
--- a/docs/user-guide/reference/conditional-forwarding.md
+++ b/docs/user-guide/reference/conditional-forwarding.md
@@ -1,5 +1,12 @@
 # Conditional Forwarding
 
+Conditional forwarding is supported in both [Pipelines](../../core-concepts/pipeline.md) and [MonoVertex](../../core-concepts/monovertex.md).
+After processing, messages can be routed to different destinations based on `tags` returned in the result.
+
+---
+
+## Pipeline
+
 In a [pipeline](../../core-concepts/pipeline.md), after processing the data, conditional forwarding is doable based on the `tags` returned in the result.
 Below is a list of different logic operations that can be done on tags.
 
@@ -11,13 +18,13 @@ For example, there's a UDF used to process numbers, and forward the result to di
 even or odd. In this case, you can set the `tag` to `even-tag` or `odd-tag` in each of the returned messages,
 and define the edges as below:
 
-## Default Behavior
+### Default Behavior
 
 * If no `conditions` are specified in the spec, the message will be forwarded to all the downstream vertices (independent
   of the `tags` in the `Messages`).
 * In the code, if the `Messages` are not tagged but conditions are configured, we will still honour the edge conditions.
 
-## Syntax
+### Syntax
 
 ```yaml
 edges:
@@ -30,7 +37,7 @@ edges:
           - ...
 ```
 
-## Example
+### Example
 
 ```yaml
 edges:
@@ -57,3 +64,14 @@ edges:
           - odd-tag
           - even-tag
 ```
+
+---
+
+## MonoVertex
+
+MonoVertex supports [bypass routing](monovertex-bypass.md), which allows tagging messages so they skip components (e.g. UDF or primary sink)
+and are routed directly to a `fallback` or `onSuccess` sink. Conditions follow the same `tags` operator pattern (`and`, `or`, `not`) as pipeline conditional forwarding.
+
+For example, a message flagged as faulty in the transformer can be tagged and sent straight to a DLQ, bypassing the UDF and primary sink entirely.
+
+See [MonoVertex Bypass Routing](monovertex-bypass.md) for the full spec and caveats.


### PR DESCRIPTION
users won't know about the conditional forwarding of monovertex unless linked