### PR TITLE
fix: avoid unnecessary calls to SQS during nack

### DIFF
--- a/rust/extns/numaflow-sqs/src/source.rs
+++ b/rust/extns/numaflow-sqs/src/source.rs
@@ -52,7 +52,7 @@ pub struct SqsSourceConfig {
 #[derive(Debug)]
 pub struct SqsNack {
     pub receipt_handle: Bytes,
-    pub visibility_timeout: Option<i32>,
+    pub visibility_timeout: i32,
 }
 /// Internal message types for the actor implementation.
 ///
@@ -364,15 +364,12 @@ impl SqsActor {
                 SqsSourceError::from(Error::Other("failed to parse receipt handle".to_string()))
             })?;
 
-            let mut request = self
+            let request = self
                 .client
                 .change_message_visibility()
                 .queue_url(&self.queue_url)
-                .receipt_handle(receipt_handle);
-
-            if let Some(timeout) = nack.visibility_timeout {
-                request = request.visibility_timeout(timeout);
-            }
+                .receipt_handle(receipt_handle)
+                .visibility_timeout(nack.visibility_timeout);
 
             if let Err(err) = request.send().await {
                 error!(

--- a/rust/numaflow-core/src/source/sqs.rs
+++ b/rust/numaflow-core/src/source/sqs.rs
@@ -136,22 +136,20 @@ impl source::SourceAcker for SqsSource {
                 )));
             };
 
-            let visibility_timeout = nack
-            .option
-            .and_then(|opts| opts.delay)
-            .map(|delay_ms| {
-                let visibility_timeout = delay_ms.div_ceil(1000) as i32;
+            // Without an explicit delay there is no visibility timeout to change, so skip
+            // calling the SQS API for this offset entirely
+            let Some(delay_ms) = nack.option.and_then(|opts| opts.delay) else {
+                continue;
+            };
 
-                if delay_ms % 1000 != 0 {
-                    tracing::warn!(
-                        requested_delay_ms = delay_ms,
-                        visibility_timeout_secs = visibility_timeout,
-                        "SQS visibility timeout only supports whole seconds; rounding requested delay up"
-                    );
-                }
-
-                visibility_timeout
-            });
+            let visibility_timeout = delay_ms.div_ceil(1000) as i32;
+            if delay_ms % 1000 != 0 {
+                tracing::warn!(
+                    requested_delay_ms = delay_ms,
+                    visibility_timeout_secs = visibility_timeout,
+                    "SQS visibility timeout only supports whole seconds; rounding requested delay up"
+                );
+            }
 
             sqs_offsets.push(SqsNack {
                 receipt_handle: string_offset.offset,
@@ -292,7 +290,14 @@ pub mod tests {
             let mut responses = Vec::new();
             while let Some(datum) = input.recv().await {
                 if self.first.swap(false, Ordering::SeqCst) {
-                    responses.push(sink::Response::nack(datum.id, None));
+                    // Nack with an explicit delay so the source changes the message's visibility timeout
+                    responses.push(sink::Response::nack(
+                        datum.id,
+                        Some(numaflow::shared::NackOptions {
+                            delay: Some(30_000),
+                            ..Default::default()
+                        }),
+                    ));
                 } else {
                     responses.push(sink::Response::ok(datum.id));
                 }
@@ -489,6 +494,8 @@ pub mod tests {
         .match_requests(|inp| {
             inp.queue_url().unwrap()
                 == "https://sqs.us-west-2.amazonaws.com/926113353675/test-q/"
+                // The nack carried a 30_000ms delay, which must be sent as a 30s visibility timeout.
+                && inp.visibility_timeout() == Some(30)
         })
         .then_output(|| {
             aws_sdk_sqs::operation::change_message_visibility::ChangeMessageVisibilityOutput::builder()


### PR DESCRIPTION
### What this PR does / why we need it
While checking how we should integrate DLQ functionality for SQS, I revisited how nack has been implemented for it. 
Small refactor to call SQS API, to change visibility timeout during nack, only for messages that contain the delay value in nack options. Avoids unnecessary calls to the SQS API. 

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
