### PR TITLE
feat(ui): add Focus logs modal for larger pod log viewing

### DIFF
--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/index.test.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/index.test.tsx
@@ -228,6 +228,22 @@ describe("Pods", () => {
     });
     expect(screen.getByRole("dialog")).toBeInTheDocument();
 
+    // Switching pods keeps the previously selected container when present.
+    const podInput = within(dialog).getByLabelText("Select pod");
+    await act(async () => {
+      fireEvent.change(podInput, {
+        target: { value: "simple-pipeline-infer-1-xah5w" },
+      });
+      fireEvent.keyDown(podInput, { key: "ArrowDown" });
+      fireEvent.keyDown(podInput, { key: "Enter" });
+    });
+
+    await waitFor(() => {
+      expect(within(dialog).getByTestId("log-source-badge")).toHaveTextContent(
+        "infer-1/udf"
+      );
+    });
+
     await act(async () => {
       fireEvent.click(within(dialog).getByTestId("focus-logs-button"));
     });
@@ -237,7 +253,7 @@ describe("Pods", () => {
     });
     expect(screen.queryByTestId("logs-focus-context")).not.toBeInTheDocument();
     expect(screen.getByTestId("log-source-badge")).toHaveTextContent(
-      "infer-0/udf"
+      "infer-1/udf"
     );
   });
 

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/index.test.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/index.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { useEffect } from "react";
 import { Pods } from "./index";
 import { usePodsViewFetch } from "../../../../../../../../../utils/fetcherHooks/podsViewFetch";
 import {
@@ -140,6 +141,106 @@ describe("Pods", () => {
     });
     expect(mockedFetch).toBeCalledTimes(7);
   });
+
+  it("shows pod and container selectors only inside focus mode", async () => {
+    mockedUsePodsViewFetch.mockImplementation(
+      (
+        _namespaceId,
+        _pipelineId,
+        _vertexId,
+        _selectedPod,
+        _type,
+        setSelectedPod,
+        setSelectedContainer
+      ) => {
+        useEffect(() => {
+          setSelectedPod(pods[0]);
+          setSelectedContainer(pods[0].containers[0]);
+        }, [setSelectedPod, setSelectedContainer]);
+        return {
+          pods,
+          podsDetails,
+          podsErr: undefined,
+          podsDetailsErr: undefined,
+          loading: false,
+        };
+      }
+    );
+
+    const mRes = {
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            Buffer.from(
+              `{"level":"info","ts":"2023-09-04T11:50:19.712416709Z","logger":"numaflow.Source-processor","caller":"publish/publisher.go:180","msg":"focus-select-line","pipeline":"simple-pipeline","vertex":"infer"}`
+            )
+          );
+          controller.close();
+        },
+      }),
+      ok: true,
+    };
+    (global as any).fetch = jest.fn().mockResolvedValue(mRes as any);
+
+    await act(async () => {
+      render(
+        <Pods
+          namespaceId={"numaflow-system"}
+          pipelineId={"simple-pipeline"}
+          vertexId={"infer"}
+          type={"pipeline"}
+        />
+      );
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("focus-logs-button")).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId("logs-focus-context")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("logs-focus-containers")).not.toBeInTheDocument();
+    expect(screen.getByTestId("log-source-badge")).toHaveTextContent(
+      "infer-0/numa"
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("focus-logs-button"));
+    });
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByTestId("logs-focus-context")).toBeInTheDocument();
+    expect(
+      within(dialog).getByTestId("logs-focus-containers")
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByTestId("logs-focus-pod-select")
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(
+        within(dialog).getByTestId("simple-pipeline-infer-0-xah5w-udf")
+      );
+    });
+
+    await waitFor(() => {
+      expect(within(dialog).getByTestId("log-source-badge")).toHaveTextContent(
+        "infer-0/udf"
+      );
+    });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(within(dialog).getByTestId("focus-logs-button"));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("logs-focus-context")).not.toBeInTheDocument();
+    expect(screen.getByTestId("log-source-badge")).toHaveTextContent(
+      "infer-0/udf"
+    );
+  });
+
   it("pods error screen - api errors", async () => {
     mockedUsePodsViewFetch.mockReturnValue({
       pods: pods,

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/index.tsx
@@ -30,6 +30,27 @@ import {
   PodsProps,
 } from "../../../../../../../../../types/declarations/pods";
 
+/** API order puts Always-restart init (user/UD) containers first, then main. */
+function getDefaultContainerName(pod: Pod | undefined): string | undefined {
+  return pod?.containers?.[0];
+}
+
+function resolveContainerForPod(
+  pod: Pod | undefined,
+  preferredContainer: string | undefined
+): string | undefined {
+  if (!pod) {
+    return undefined;
+  }
+  if (
+    preferredContainer &&
+    pod.containers?.includes(preferredContainer)
+  ) {
+    return preferredContainer;
+  }
+  return getDefaultContainerName(pod);
+}
+
 export function Pods(props: PodsProps) {
   const { host } = useContext<AppContextProps>(AppContext);
   const { namespaceId, pipelineId, vertexId, type } = props;
@@ -162,8 +183,9 @@ export function Pods(props: PodsProps) {
   }, [podsDetailsErr]);
 
   const handlePodClick = useCallback((e: Element | EventType, p: Hexagon) => {
-    setSelectedPod(p?.data?.pod);
-    setSelectedContainer(p?.data?.pod?.containers[0]);
+    const nextPod = p?.data?.pod;
+    setSelectedPod(nextPod);
+    setSelectedContainer(getDefaultContainerName(nextPod));
   }, []);
 
   const handleContainerClick = useCallback((containerName: string) => {
@@ -180,7 +202,7 @@ export function Pods(props: PodsProps) {
         return;
       }
       setSelectedPod(nextPod);
-      setSelectedContainer(nextPod.containers?.[0]);
+      setSelectedContainer((prev) => resolveContainerForPod(nextPod, prev));
     },
     [pods]
   );
@@ -202,9 +224,9 @@ export function Pods(props: PodsProps) {
     );
   }, [selectedPod, selectedContainer, handleContainerClick]);
 
-  const defaultProps = useMemo(() => {
+  const podAutocompleteProps = useMemo(() => {
     return {
-      options: pods?.map((pod) => pod.name) as string[],
+      options: pods?.map((pod) => pod.name) ?? [],
       getOptionLabel: (option: string) => option,
     };
   }, [pods]);
@@ -218,7 +240,7 @@ export function Pods(props: PodsProps) {
         <Box className="PodLogs-focus-context-pod">
           <span className="PodLogs-focus-context-label">Pod</span>
           <Autocomplete
-            {...defaultProps}
+            {...podAutocompleteProps}
             disableClearable
             id="focus-pod-select"
             data-testid="logs-focus-pod-select"
@@ -283,7 +305,7 @@ export function Pods(props: PodsProps) {
     pods,
     selectedPod,
     selectedContainer,
-    defaultProps,
+    podAutocompleteProps,
     handleFocusPodChange,
     handleContainerClick,
   ]);
@@ -341,7 +363,7 @@ export function Pods(props: PodsProps) {
         <Box>
           {pods && selectedPod && (
             <Autocomplete
-              {...defaultProps}
+              {...podAutocompleteProps}
               disablePortal
               disableClearable
               id="pod-select"

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/index.tsx
@@ -170,6 +170,21 @@ export function Pods(props: PodsProps) {
     setSelectedContainer(containerName);
   }, []);
 
+  const handleFocusPodChange = useCallback(
+    (_event: ChangeEvent<HTMLInputElement>, newValue: string | null) => {
+      if (!newValue || !pods) {
+        return;
+      }
+      const nextPod = pods.find((pod) => pod.name === newValue);
+      if (!nextPod) {
+        return;
+      }
+      setSelectedPod(nextPod);
+      setSelectedContainer(nextPod.containers?.[0]);
+    },
+    [pods]
+  );
+
   const containerSelector = useMemo(() => {
     return (
       <Box sx={{ display: "flex", width: "100%" }}>
@@ -185,7 +200,93 @@ export function Pods(props: PodsProps) {
         </Box>
       </Box>
     );
-  }, [selectedPod, selectedContainer]);
+  }, [selectedPod, selectedContainer, handleContainerClick]);
+
+  const defaultProps = useMemo(() => {
+    return {
+      options: pods?.map((pod) => pod.name) as string[],
+      getOptionLabel: (option: string) => option,
+    };
+  }, [pods]);
+
+  const focusControls = useMemo(() => {
+    if (!pods || !selectedPod) {
+      return null;
+    }
+    return (
+      <>
+        <Box className="PodLogs-focus-context-pod">
+          <span className="PodLogs-focus-context-label">Pod</span>
+          <Autocomplete
+            {...defaultProps}
+            disableClearable
+            id="focus-pod-select"
+            data-testid="logs-focus-pod-select"
+            ListboxProps={{
+              sx: {
+                fontSize: "1.2rem",
+                // Cap height so a large pod fleet scrolls instead of filling the dialog.
+                maxHeight: "24rem",
+                overflow: "auto",
+              },
+            }}
+            componentsProps={{
+              popper: {
+                sx: { zIndex: (theme) => theme.zIndex.modal + 4 },
+              },
+            }}
+            sx={{
+              width: "100%",
+              minWidth: 0,
+              "& .MuiOutlinedInput-root": {
+                height: "3.2rem",
+                fontSize: "1.2rem",
+                paddingTop: 0,
+                paddingBottom: 0,
+              },
+              "& .MuiAutocomplete-input": {
+                textOverflow: "ellipsis",
+              },
+            }}
+            autoHighlight
+            onChange={handleFocusPodChange}
+            value={selectedPod.name}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                variant="outlined"
+                size="small"
+                title={selectedPod.name}
+                inputProps={{
+                  ...params.inputProps,
+                  "aria-label": "Select pod",
+                  autoComplete: "new-password",
+                  style: { fontSize: "1.2rem" },
+                }}
+              />
+            )}
+          />
+        </Box>
+        <Box className="PodLogs-focus-context-container">
+          <span className="PodLogs-focus-context-label">Container</span>
+          <Box data-testid="logs-focus-containers">
+            <Containers
+              pod={selectedPod}
+              containerName={selectedContainer}
+              handleContainerClick={handleContainerClick}
+            />
+          </Box>
+        </Box>
+      </>
+    );
+  }, [
+    pods,
+    selectedPod,
+    selectedContainer,
+    defaultProps,
+    handleFocusPodChange,
+    handleContainerClick,
+  ]);
 
   const podDetail = useMemo(() => {
     return (
@@ -200,10 +301,19 @@ export function Pods(props: PodsProps) {
           containerName={selectedContainer}
           pod={selectedPod}
           vertexId={vertexId}
+          focusControls={focusControls}
         />
       </Box>
     );
-  }, [namespaceId, pipelineId, type, selectedContainer, selectedPod, vertexId]);
+  }, [
+    namespaceId,
+    pipelineId,
+    type,
+    selectedContainer,
+    selectedPod,
+    vertexId,
+    focusControls,
+  ]);
 
   const handleSearchChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>, newValue: string | null) => {
@@ -215,13 +325,6 @@ export function Pods(props: PodsProps) {
     },
     [pods]
   );
-
-  const defaultProps = useMemo(() => {
-    return {
-      options: pods?.map((pod) => pod.name) as string[],
-      getOptionLabel: (option: string) => option,
-    };
-  }, [pods]);
 
   const podSearchDetails = (
     <Box

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/index.tsx
@@ -8,6 +8,7 @@ export function PodDetail({
   type,
   containerName,
   pod,
+  focusControls,
 }: PodDetailProps) {
   if (!pod) return null;
 
@@ -26,6 +27,7 @@ export function PodDetail({
         podName={pod.name}
         containerName={containerName}
         type={type}
+        focusControls={focusControls}
       />
     </Box>
   );

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/LogVirtualList.test.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/LogVirtualList.test.tsx
@@ -112,6 +112,8 @@ describe("LogVirtualList", () => {
     expect(activeRow.className).toContain("PodLogs-row--active");
     expect(ref.current).not.toBeNull();
     expect(() => ref.current?.scrollToIndex(1)).not.toThrow();
+    expect(typeof ref.current?.getScrollOffset()).toBe("number");
+    expect(() => ref.current?.scrollToOffset(80)).not.toThrow();
   });
 
   it("renders the complete raw log line without field trimming", () => {

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/LogVirtualList.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/LogVirtualList.tsx
@@ -24,6 +24,8 @@ export type LogVirtualListProps = {
 
 export type LogVirtualListHandle = {
   scrollToIndex: (index: number) => void;
+  getScrollOffset: () => number;
+  scrollToOffset: (offset: number) => void;
 };
 
 export const LogVirtualList = forwardRef<
@@ -61,6 +63,17 @@ export const LogVirtualList = forwardRef<
     () => ({
       scrollToIndex: (index: number) => {
         virtualizer.scrollToIndex(index, { align: "center", behavior: "auto" });
+      },
+      getScrollOffset: () =>
+        parentRef.current?.scrollTop ?? virtualizer.scrollOffset ?? 0,
+      scrollToOffset: (offset: number) => {
+        if (parentRef.current) {
+          parentRef.current.scrollTop = offset;
+        }
+        virtualizer.scrollToOffset(offset, {
+          align: "start",
+          behavior: "auto",
+        });
       },
     }),
     [virtualizer]

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.test.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.test.tsx
@@ -559,6 +559,72 @@ describe("PodLogs", () => {
     expect(mockedFetch).toBeCalledTimes(1);
   });
 
+  it("restores saved scroll offset when toggling Focus logs", async () => {
+    const lines = Array.from({ length: 40 }, (_, i) =>
+      JSON.stringify({
+        level: "info",
+        msg: `scroll-line-${i}`,
+      })
+    ).join("\n");
+    const mRes = {
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(Buffer.from(lines));
+          controller.close();
+        },
+      }),
+      ok: true,
+    };
+    (global as any).fetch = jest.fn().mockResolvedValue(mRes as any);
+
+    await act(async () => {
+      render(
+        <PodLogs
+          namespaceId={"numaflow-system"}
+          containerName={"numa"}
+          podName={"simple-pipeline-in-0-abcde"}
+        />
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("log-virtual-list")).toBeInTheDocument();
+    });
+
+    const listBefore = screen.getByTestId("log-virtual-list") as HTMLElement;
+    Object.defineProperty(listBefore, "scrollTop", {
+      configurable: true,
+      writable: true,
+      value: 220,
+    });
+    fireEvent.scroll(listBefore);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("focus-logs-button"));
+    });
+
+    const dialog = await screen.findByRole("dialog");
+    const listInDialog = within(dialog).getByTestId(
+      "log-virtual-list"
+    ) as HTMLElement;
+
+    await waitFor(() => {
+      // Restored offset should be applied after remount into the dialog.
+      expect(listInDialog.scrollTop).toBe(220);
+    });
+
+    await act(async () => {
+      fireEvent.click(within(dialog).getByTestId("focus-logs-button"));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("log-virtual-list").scrollTop).toBe(220);
+    });
+  });
+
   it("shows the N-lines menu above the focused dialog and keeps focusControls focus-only", async () => {
     const mRes = {
       body: new ReadableStream({

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.test.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { act } from "react-test-renderer";
 import { TextEncoder, TextDecoder } from "util";
 import { PodLogs } from "./index";
@@ -96,6 +96,7 @@ describe("PodLogs", () => {
     expect(screen.getByTestId("wrap-lines-button")).toHaveClass(
       "PodLogs-icon-btn--active"
     );
+    expect(screen.getByTestId("focus-logs-button")).toBeInTheDocument();
     expect(screen.getByTestId("color-mode-button")).not.toHaveClass(
       "PodLogs-icon-btn--active"
     );
@@ -197,6 +198,15 @@ describe("PodLogs", () => {
     expect(screen.getByTestId("search-match-count")).toHaveTextContent("1 / 2");
     fireEvent.keyDown(searchInput, { key: "Enter", shiftKey: true });
     expect(screen.getByTestId("search-match-count")).toHaveTextContent("2 / 2");
+
+    // Enter must navigate matches even when focus is on the N-lines button,
+    // instead of opening the tail-size dropdown.
+    screen.getByTestId("log-tail-size-button").focus();
+    fireEvent.keyDown(screen.getByTestId("log-tail-size-button"), {
+      key: "Enter",
+    });
+    expect(screen.getByTestId("search-match-count")).toHaveTextContent("1 / 2");
+    expect(screen.queryByTestId("log-tail-size-menu")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("negate-search"));
     expect(screen.queryByTestId("search-match-count")).not.toBeInTheDocument();
@@ -482,5 +492,138 @@ describe("PodLogs", () => {
       expect(lastUrl).not.toContain("previous=true");
       expect(screen.getByText("live-again")).toBeInTheDocument();
     });
+  });
+
+  it("opens and closes the focus logs dialog without a second stream", async () => {
+    const mRes = {
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            Buffer.from(
+              `{"level":"info","ts":"2023-09-04T11:50:19.712416709Z","logger":"numaflow.Source-processor","caller":"publish/publisher.go:180","msg":"focus-dialog-log-line","pipeline":"simple-pipeline","vertex":"in"}`
+            )
+          );
+          controller.close();
+        },
+      }),
+      ok: true,
+    };
+    const mockedFetch = jest.fn().mockResolvedValue(mRes as any);
+    (global as any).fetch = mockedFetch;
+
+    await act(async () => {
+      render(
+        <PodLogs
+          namespaceId={"numaflow-system"}
+          containerName={"numa"}
+          podName={"simple-pipeline-in-0-abcde"}
+        />
+      );
+    });
+
+    expect(screen.getByTestId("focus-logs-button")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("logs-focus-placeholder")).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("focus-logs-button"));
+    });
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByTestId("logs-focus-dialog")).toBeInTheDocument();
+    expect(screen.getByTestId("logs-focus-placeholder")).toHaveTextContent(
+      "Logs are open in the focused view"
+    );
+    expect(
+      within(dialog).getByTestId("log-virtual-list")
+    ).toBeInTheDocument();
+    expect(within(dialog).getByTestId("focus-logs-button")).toHaveClass(
+      "PodLogs-icon-btn--active"
+    );
+    // Still a single PodLogs instance / stream — no second fetch from opening focus.
+    expect(mockedFetch).toBeCalledTimes(1);
+
+    await act(async () => {
+      fireEvent.click(within(dialog).getByTestId("focus-logs-button"));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("logs-focus-placeholder")).not.toBeInTheDocument();
+    expect(screen.getByTestId("log-virtual-list")).toBeInTheDocument();
+    expect(screen.getByTestId("focus-logs-button")).not.toHaveClass(
+      "PodLogs-icon-btn--active"
+    );
+    expect(mockedFetch).toBeCalledTimes(1);
+  });
+
+  it("shows the N-lines menu above the focused dialog and keeps focusControls focus-only", async () => {
+    const mRes = {
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            Buffer.from(
+              `{"level":"info","ts":"2023-09-04T11:50:19.712416709Z","logger":"numaflow.Source-processor","caller":"publish/publisher.go:180","msg":"focus-menu-line","pipeline":"simple-pipeline","vertex":"in"}`
+            )
+          );
+          controller.close();
+        },
+      }),
+      ok: true,
+    };
+    const mockedFetch = jest.fn().mockResolvedValue(mRes as any);
+    (global as any).fetch = mockedFetch;
+
+    await act(async () => {
+      render(
+        <PodLogs
+          namespaceId={"numaflow-system"}
+          containerName={"numa"}
+          podName={"simple-pipeline-in-0-abcde"}
+          focusControls={
+            <div data-testid="logs-focus-controls-probe">Focus controls</div>
+          }
+        />
+      );
+    });
+
+    expect(screen.queryByTestId("logs-focus-context")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("logs-focus-controls-probe")
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("focus-logs-button"));
+    });
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByTestId("logs-focus-context")).toBeInTheDocument();
+    expect(
+      within(dialog).getByTestId("logs-focus-controls-probe")
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(within(dialog).getByTestId("log-tail-size-menu-button"));
+    });
+
+    expect(await screen.findByTestId("log-tail-size-menu")).toBeVisible();
+    expect(screen.getByTestId("log-tail-size-5000")).toBeInTheDocument();
+    // Level Select menu uses the same elevated z-index as the N-lines menu
+    // so options are not hidden under the Focus dialog.
+    expect(within(dialog).getByTestId("log-level-select")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(within(dialog).getByTestId("focus-logs-button"));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("logs-focus-context")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("logs-focus-controls-probe")
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
@@ -20,6 +20,8 @@ import Button from "@mui/material/Button";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import InputBase from "@mui/material/InputBase";
 import IconButton from "@mui/material/IconButton";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
 import ClearIcon from "@mui/icons-material/Clear";
 import PauseIcon from "@mui/icons-material/Pause";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
@@ -31,6 +33,8 @@ import LightMode from "@mui/icons-material/LightMode";
 import DarkMode from "@mui/icons-material/DarkMode";
 import Download from "@mui/icons-material/Download";
 import WrapTextIcon from "@mui/icons-material/WrapText";
+import OpenInFull from "@mui/icons-material/OpenInFull";
+import CloseFullscreen from "@mui/icons-material/CloseFullscreen";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import { ClockIcon } from "@mui/x-date-pickers";
@@ -102,6 +106,7 @@ export function PodLogs({
   podName,
   containerName,
   type,
+  focusControls,
 }: PodLogsProps) {
   const [search, setSearch] = useState<string>("");
   const [negateSearch, setNegateSearch] = useState<boolean>(false);
@@ -116,6 +121,7 @@ export function PodLogs({
   const [tailMenuAnchor, setTailMenuAnchor] = useState<null | HTMLElement>(
     null
   );
+  const [focused, setFocused] = useState(false);
   const { host } = useContext<AppContextProps>(AppContext);
 
   // New container/pod: resume live with the default tail window.
@@ -198,9 +204,51 @@ export function PodLogs({
       }
 
       event.preventDefault();
+      event.stopPropagation();
       handleSearchNavigation(event.shiftKey ? goPrev : goNext);
     },
     [goNext, goPrev, handleSearchNavigation]
+  );
+
+  // Capture Enter/Shift+Enter for match navigation so it is not consumed by
+  // toolbar Buttons (e.g. the N-lines selector) when focus is elsewhere in
+  // the focused Dialog. Skip other text fields (pod Autocomplete, etc.).
+  const handleLogsKeyDownCapture = useCallback(
+    (event) => {
+      if (event.key !== "Enter" || event.nativeEvent.isComposing) {
+        return;
+      }
+      if (!searchNavigationEnabled) {
+        return;
+      }
+
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+
+      if (
+        target.closest(".PodLogs-focus-context-pod") ||
+        target.closest(".PodLogs-level-select") ||
+        target.closest(".MuiMenu-root") ||
+        target.closest('[role="listbox"]')
+      ) {
+        return;
+      }
+
+      const isLogSearch = Boolean(target.closest(".PodLogs-search"));
+      const tag = target.tagName;
+      const isOtherTextInput =
+        (tag === "INPUT" || tag === "TEXTAREA") && !isLogSearch;
+      if (isOtherTextInput) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      handleSearchNavigation(event.shiftKey ? goPrev : goNext);
+    },
+    [searchNavigationEnabled, goNext, goPrev, handleSearchNavigation]
   );
 
   const handleNegateSearchChange = useCallback(
@@ -293,6 +341,14 @@ export function PodLogs({
     });
   }, []);
 
+  const handleOpenFocus = useCallback(() => {
+    setFocused(true);
+  }, []);
+
+  const handleCloseFocus = useCallback(() => {
+    setFocused(false);
+  }, []);
+
   const logSourceLabel = `${getShortPodName(podName)}/${containerName}`;
   const tailSelectorTooltip = showPreviousLogs
     ? "Choose how many previous log lines to show"
@@ -305,8 +361,10 @@ export function PodLogs({
       ? { testId: "logs-paused-banner", label: "Logs paused" }
       : null;
 
-  return (
-    <Box className="PodLogs-root">
+  // Single viewer tree: rendered in the sidebar or (when focused) inside the Dialog.
+  // Do not mount a second PodLogs — that would open a second /logs stream.
+  const logsViewer = (
+    <Box className="PodLogs-root" onKeyDownCapture={handleLogsKeyDownCapture}>
       <div className="PodLogs-toolbar">
         <div className="PodLogs-header">
           <div className="PodLogs-header-left">
@@ -340,6 +398,7 @@ export function PodLogs({
                   size="small"
                 >
                   <Button
+                    type="button"
                     data-testid="log-tail-size-button"
                     className="PodLogs-tail-size-main"
                     onClick={handleOpenTailMenu}
@@ -347,6 +406,7 @@ export function PodLogs({
                     {`${tailLines.toLocaleString()} lines`}
                   </Button>
                   <Button
+                    type="button"
                     data-testid="log-tail-size-menu-button"
                     className="PodLogs-tail-size-menu-btn"
                     aria-label="Choose how many recent log lines to show"
@@ -362,6 +422,8 @@ export function PodLogs({
               open={Boolean(tailMenuAnchor)}
               onClose={() => setTailMenuAnchor(null)}
               data-testid="log-tail-size-menu"
+              // Above Focus logs Dialog (modal + 2); keep selectable in focus mode.
+              sx={{ zIndex: (theme) => theme.zIndex.modal + 4 }}
             >
               {LOG_TAIL_SIZES.map((size) => (
                 <MenuItem
@@ -374,6 +436,14 @@ export function PodLogs({
                 </MenuItem>
               ))}
             </Menu>
+            <ToolbarIconButton
+              testId="focus-logs-button"
+              title={focused ? "Exit focus" : "Open a larger log view"}
+              onClick={focused ? handleCloseFocus : handleOpenFocus}
+              active={focused}
+            >
+              {focused ? <CloseFullscreen /> : <OpenInFull />}
+            </ToolbarIconButton>
           </div>
         </div>
         <div className="PodLogs-controls">
@@ -507,6 +577,14 @@ export function PodLogs({
             className="PodLogs-level-select"
             sx={{ minWidth: "11rem" }}
             size="small"
+            data-testid="log-level-select"
+            MenuProps={{
+              // Above Focus logs Dialog (modal + 2); keep options visible in focus mode.
+              sx: { zIndex: (theme) => theme.zIndex.modal + 4 },
+              PaperProps: {
+                "data-testid": "log-level-menu",
+              },
+            }}
           >
             <MenuItem sx={{ fontSize: "1.2rem" }} value={"all"}>
               All levels
@@ -538,5 +616,54 @@ export function PodLogs({
         />
       </Box>
     </Box>
+  );
+
+  return (
+    <>
+      {focused ? (
+        <Box
+          className="PodLogs-focus-placeholder"
+          data-testid="logs-focus-placeholder"
+        >
+          Logs are open in the focused view
+        </Box>
+      ) : (
+        logsViewer
+      )}
+      <Dialog
+        open={focused}
+        onClose={handleCloseFocus}
+        fullWidth
+        maxWidth={false}
+        className="PodLogs-focus-dialog"
+        aria-labelledby="pod-logs-focus-title"
+        // Allow nested Select/Menu/Autocomplete popovers to take focus and
+        // paint above this Dialog while Focus logs is open.
+        disableEnforceFocus
+        BackdropProps={{
+          "data-testid": "logs-focus-backdrop",
+        }}
+        PaperProps={{
+          className: "PodLogs-focus-dialog-paper",
+          "data-testid": "logs-focus-dialog",
+        }}
+        sx={{ zIndex: (theme) => theme.zIndex.modal + 2 }}
+      >
+        <DialogContent className="PodLogs-focus-dialog-content">
+          <span id="pod-logs-focus-title" className="PodLogs-sr-only">
+            Container Logs
+          </span>
+          {focused && focusControls ? (
+            <Box
+              className="PodLogs-focus-context"
+              data-testid="logs-focus-context"
+            >
+              {focusControls}
+            </Box>
+          ) : null}
+          {focused ? logsViewer : null}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/index.tsx
@@ -7,6 +7,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -162,6 +163,8 @@ export function PodLogs({
     [filteredLogs, logsOrder]
   );
   const logVirtualListRef = useRef<LogVirtualListHandle>(null);
+  // Preserve scroll across Focus open/close remounts of LogVirtualList.
+  const scrollOffsetRef = useRef(0);
   const {
     enabled: searchNavigationEnabled,
     matchCount,
@@ -175,6 +178,20 @@ export function PodLogs({
     negateSearch,
     resetKey: `${namespaceId}-${podName}-${containerName}-${showPreviousLogs}-${logsOrder}-${search}-${negateSearch}-${tailLines}`,
   });
+
+  useLayoutEffect(() => {
+    const offset = scrollOffsetRef.current;
+    if (offset <= 0) {
+      return;
+    }
+    const restore = () => {
+      logVirtualListRef.current?.scrollToOffset(offset);
+    };
+    restore();
+    // Remounted list may not have a measured scroll element on the first paint.
+    const frame = requestAnimationFrame(restore);
+    return () => cancelAnimationFrame(frame);
+  }, [focused]);
 
   const handleSearchChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -342,10 +359,14 @@ export function PodLogs({
   }, []);
 
   const handleOpenFocus = useCallback(() => {
+    scrollOffsetRef.current =
+      logVirtualListRef.current?.getScrollOffset() ?? 0;
     setFocused(true);
   }, []);
 
   const handleCloseFocus = useCallback(() => {
+    scrollOffsetRef.current =
+      logVirtualListRef.current?.getScrollOffset() ?? 0;
     setFocused(false);
   }, []);
 

--- a/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/style.css
+++ b/ui/src/components/pages/Pipeline/partials/Graph/partials/NodeInfo/partials/Pods/partials/PodDetails/partials/PodLogs/style.css
@@ -235,6 +235,92 @@
   min-height: 0;
 }
 
+.PodLogs-focus-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 12.8rem;
+  padding: 1.6rem;
+  color: #64748b;
+  font-size: 1.4rem;
+  text-align: center;
+}
+
+.PodLogs-focus-context {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.2rem 2rem;
+  flex-shrink: 0;
+  padding: 0.8rem 1.6rem;
+  background: #ffffff;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.PodLogs-focus-context-label {
+  flex-shrink: 0;
+  color: #0f172a;
+  font-size: 1.2rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.PodLogs-focus-context-pod {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  min-width: 0;
+  width: min(40rem, 45%);
+  flex: 1 1 22rem;
+}
+
+.PodLogs-focus-context-container {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  min-width: 0;
+  flex: 1 1 28rem;
+}
+
+.PodLogs-focus-dialog-paper {
+  width: 90vw !important;
+  max-width: 90vw !important;
+  height: 85vh !important;
+  max-height: 85vh !important;
+  margin: 0 !important;
+  border-radius: 1rem !important;
+  overflow: hidden !important;
+  display: flex !important;
+  flex-direction: column !important;
+}
+
+.PodLogs-focus-dialog-content {
+  flex: 1;
+  min-height: 0;
+  padding: 0 !important;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.PodLogs-focus-dialog .PodLogs-root {
+  height: 100%;
+  min-height: 0;
+}
+
+.PodLogs-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .PodLogs-virtual-list {
   height: 100%;
   overflow: auto;

--- a/ui/src/types/declarations/pods.d.ts
+++ b/ui/src/types/declarations/pods.d.ts
@@ -1,4 +1,5 @@
 import { EventType } from "@visx/event/lib/types";
+import type { ReactNode } from "react";
 
 export interface Pod {
   name: string;
@@ -97,6 +98,7 @@ export interface PodDetailProps {
   containerName: string;
   pod: Pod;
   vertexId: string;
+  focusControls?: ReactNode;
 }
 export interface ContainerInfoProps {
   state: string;
@@ -141,6 +143,8 @@ export interface PodLogsProps {
   podName: string;
   containerName: string;
   type: string;
+  /** Rendered only inside the Focus logs dialog, never in the sidebar view. */
+  focusControls?: ReactNode;
 }
 
 export interface ResourceUsage {


### PR DESCRIPTION
### What this PR does / why we need it

Adds a Focus logs button that opens the pod log viewer in a larger dialog so logs are easier to read in the sidebar. Pod and container can still be switched while focused, without starting a second log stream.

### Related issues

Fixes #2322

### Testing

- `yarn --cwd ui test --watchAll=false PodLogs/index.test Pods/index.test`

### Notes for reviewers

- N.A.
<img width="2564" height="1296" alt="Screenshot 2026-08-18 at 3 05 40 PM" src="https://github.com/user-attachments/assets/32cc8e06-4c3b-42d3-be52-480f96f354a0" />
