### PR TITLE
fix: bound pipeline buffer clean up job lifetime

### DIFF
--- a/pkg/reconciler/pipeline/controller.go
+++ b/pkg/reconciler/pipeline/controller.go
@@ -57,6 +57,8 @@ const (
 	deprecatedFinalizerName = dfv1.ControllerPipeline
 
 	pauseTimestampPath = `/metadata/annotations/numaflow.numaproj.io~1pause-timestamp`
+
+	cleanUpJobActiveDeadlineSeconds = int64(600)
 )
 
 // pipelineReconciler reconciles a pipeline object.
@@ -632,6 +634,7 @@ func (r *pipelineReconciler) cleanUpBuffers(ctx context.Context, pl *dfv1.Pipeli
 
 		batchJob := buildISBBatchJob(pl, r.image, isbSvc.Status.Config, "isbsvc-delete", args, "cln")
 		batchJob.OwnerReferences = []metav1.OwnerReference{}
+		batchJob.Spec.ActiveDeadlineSeconds = ptr.To(cleanUpJobActiveDeadlineSeconds)
 		if err := r.client.Create(ctx, batchJob); err != nil && !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create buffer clean up job, err: %w", err)
 		}

--- a/pkg/reconciler/pipeline/controller_test.go
+++ b/pkg/reconciler/pipeline/controller_test.go
@@ -917,6 +917,8 @@ func Test_cleanupBuffers(t *testing.T) {
 		assert.Equal(t, 1, len(jobs.Items))
 		assert.Contains(t, jobs.Items[0].Name, "cln")
 		assert.Equal(t, 0, len(jobs.Items[0].OwnerReferences))
+		assert.NotNil(t, jobs.Items[0].Spec.ActiveDeadlineSeconds)
+		assert.Equal(t, cleanUpJobActiveDeadlineSeconds, *jobs.Items[0].Spec.ActiveDeadlineSeconds)
 	})
 }
 


### PR DESCRIPTION
### What this PR does

Sets `activeDeadlineSeconds` on the pipeline buffer clean up job (`isbsvc-delete`, job type `cln`) so it always reaches a terminal state.

### The problem

Refs #2759. When an ISB Service and its Pipelines are deleted together, the ISB Service can delete the `js-client-auth` Secret it owns before the clean up job runs. The job Pod then can't start:

```
state:
  waiting:
    message: secret "isbsvc-<name>-js-client-auth" not found
    reason: CreateContainerConfigError
```

Because the container never *starts*, the Pod never reaches a terminal state and `restartCount` stays at 0. The job stays `active`, so `ttlSecondsAfterFinished: 30` never applies and the job is never garbage collected. Meanwhile the kubelet retries container creation indefinitely.


`backoffLimit: 20` doesn't rescue this. `.status.failed` only advances when something external evicts the Pending Pod, which we measured at a median of ~86 hours per increment — so these jobs would take months to terminate on their own.

### Why activeDeadlineSeconds

It's evaluated by the job controller on wall-clock time and doesn't depend on Pod state, so it terminates the job regardless of how the deletion ordering races. Per the Kubernetes docs it also takes precedence over `backoffLimit`. The clean up job only has work to do while the ISB Service is alive, so one that can't finish within 10 minutes never will.

Set at the `cln` call site rather than in `buildISBBatchJob`, so the `cre` and `del` jobs are unaffected.

### Testing

`Test_cleanupBuffers` asserts the deadline is set. Verified the assertion fails without the change.
