### PR TITLE
fix: harden daemon error cache retention (mvtx) for failed trial rollouts

### DIFF
--- a/pkg/mvtxdaemon/server/service/mvtx_service.go
+++ b/pkg/mvtxdaemon/server/service/mvtx_service.go
@@ -99,9 +99,15 @@ func (mvs *MonoVertexService) GetMonoVertexStatus(ctx context.Context, empty *em
 // Errors are retrieved for all active replicas for a given mono vertex.
 // A list of replica errors for a given mono vertex is returned.
 func (mvs *MonoVertexService) GetMonoVertexErrors(ctx context.Context, request *mvtxdaemon.GetMonoVertexErrorsRequest) (*mvtxdaemon.GetMonoVertexErrorsResponse, error) {
+	logger := logging.FromContext(ctx).Named("monoVertexErrors")
 	monoVertex := request.GetMonoVertex()
 	resp := new(mvtxdaemon.GetMonoVertexErrorsResponse)
 	localCache := mvs.monoVertexRuntimeCache.GetLocalCache()
+
+	cacheKeys := make([]string, 0, len(localCache))
+	for key := range localCache {
+		cacheKeys = append(cacheKeys, key)
+	}
 
 	// If the errors are present in the local cache, return the errors.
 	if errors, ok := localCache[monoVertex]; ok {
@@ -123,9 +129,45 @@ func (mvs *MonoVertexService) GetMonoVertexErrors(ctx context.Context, request *
 			}
 		}
 		resp.Errors = replicaErrors
+		logger.Infow("[error-retention] serving cached mono vertex errors",
+			"requestedMonoVertex", monoVertex,
+			"embeddedMonoVertex", mvs.monoVtx.Name,
+			"cacheHit", true,
+			"cacheKeys", cacheKeys,
+			"replicaCount", len(replicaErrors),
+			"errors", summarizeCachedErrorsForLog(errors),
+		)
+	} else {
+		logger.Infow("[error-retention] serving cached mono vertex errors",
+			"requestedMonoVertex", monoVertex,
+			"embeddedMonoVertex", mvs.monoVtx.Name,
+			"cacheHit", false,
+			"cacheKeys", cacheKeys,
+			"replicaCount", 0,
+		)
 	}
 
 	return resp, nil
+}
+
+func summarizeCachedErrorsForLog(errors []runtimePkg.ReplicaErrors) []map[string]interface{} {
+	summary := make([]map[string]interface{}, 0, len(errors))
+	for _, replica := range errors {
+		containers := make([]map[string]interface{}, 0, len(replica.ContainerErrors))
+		for _, containerError := range replica.ContainerErrors {
+			containers = append(containers, map[string]interface{}{
+				"container": containerError.Container,
+				"timestamp": containerError.Timestamp,
+				"code":      containerError.Code,
+				"message":   containerError.Message,
+			})
+		}
+		summary = append(summary, map[string]interface{}{
+			"replica":         replica.Replica,
+			"containerErrors": containers,
+		})
+	}
+	return summary
 }
 
 // StartHealthCheck starts the health check for the MonoVertex using the health checker

--- a/pkg/mvtxdaemon/server/service/runtime/pod_tracker.go
+++ b/pkg/mvtxdaemon/server/service/runtime/pod_tracker.go
@@ -31,19 +31,50 @@ import (
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 )
 
+const (
+	defaultRefreshInterval        = 30 * time.Second
+	defaultInitialRefreshInterval = 3 * time.Second
+)
+
+// PodTrackerOption configures a PodTracker.
+type PodTrackerOption func(*PodTracker)
+
+// WithRefreshInterval sets how often to refresh active pods once workers are discovered.
+func WithRefreshInterval(d time.Duration) PodTrackerOption {
+	return func(pt *PodTracker) {
+		pt.refreshInterval = d
+	}
+}
+
+// WithInitialRefreshInterval sets how often to refresh active pods while waiting for workers.
+func WithInitialRefreshInterval(d time.Duration) PodTrackerOption {
+	return func(pt *PodTracker) {
+		pt.initialRefreshInterval = d
+	}
+}
+
+// WithPodTrackerHTTPClient sets the HTTP client used for pod discovery probes.
+func WithPodTrackerHTTPClient(client runtimeHTTPClient) PodTrackerOption {
+	return func(pt *PodTracker) {
+		pt.httpClient = client
+	}
+}
+
 // PodTracker tracks the active pods for a MonoVertex.
 type PodTracker struct {
-	monoVertex          *v1alpha1.MonoVertex
-	log                 *zap.SugaredLogger
-	httpClient          runtimeHTTPClient
-	activePodsCount     int
-	activePodsMutex     sync.RWMutex
-	refreshInterval     time.Duration
-	firstPodsUpdateChan chan struct{} // Channel to signal the first active pods update is done
+	monoVertex             *v1alpha1.MonoVertex
+	log                    *zap.SugaredLogger
+	httpClient             runtimeHTTPClient
+	activePodsCount        int
+	activePodsMutex        sync.RWMutex
+	refreshInterval        time.Duration
+	initialRefreshInterval time.Duration
+	firstPodsUpdateChan    chan struct{} // Channel to signal the first active pods update is done
+	firstPodsUpdateOnce    sync.Once
 }
 
 // NewPodTracker creates a new pod tracker instance.
-func NewPodTracker(ctx context.Context, mv *v1alpha1.MonoVertex) *PodTracker {
+func NewPodTracker(ctx context.Context, mv *v1alpha1.MonoVertex, opts ...PodTrackerOption) *PodTracker {
 	pt := &PodTracker{
 		monoVertex: mv,
 		log:        logging.FromContext(ctx).Named("RuntimePodTracker"),
@@ -53,8 +84,14 @@ func NewPodTracker(ctx context.Context, mv *v1alpha1.MonoVertex) *PodTracker {
 			},
 			Timeout: time.Second,
 		},
-		refreshInterval:     30 * time.Second,
-		firstPodsUpdateChan: make(chan struct{}),
+		refreshInterval:        defaultRefreshInterval,
+		initialRefreshInterval: defaultInitialRefreshInterval,
+		firstPodsUpdateChan:    make(chan struct{}),
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(pt)
+		}
 	}
 	return pt
 }
@@ -67,12 +104,12 @@ func (pt *PodTracker) Start(ctx context.Context) error {
 }
 
 func (pt *PodTracker) trackActivePods(ctx context.Context) {
-	// start updating active pods as soon as called and then after every refreshInterval
 	pt.updateActivePods()
-	// close the channel to signal first update
-	close(pt.firstPodsUpdateChan)
-	ticker := time.NewTicker(pt.refreshInterval)
+
+	interval := pt.currentRefreshInterval()
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -80,8 +117,21 @@ func (pt *PodTracker) trackActivePods(ctx context.Context) {
 			return
 		case <-ticker.C:
 			pt.updateActivePods()
+			newInterval := pt.currentRefreshInterval()
+			if newInterval != interval {
+				ticker.Stop()
+				interval = newInterval
+				ticker = time.NewTicker(interval)
+			}
 		}
 	}
+}
+
+func (pt *PodTracker) currentRefreshInterval() time.Duration {
+	if pt.GetActivePodsCount() == 0 {
+		return pt.initialRefreshInterval
+	}
+	return pt.refreshInterval
 }
 
 // updateActivePods checks the status of all pods and updates the count of activePods accordingly.
@@ -136,9 +186,13 @@ func (pt *PodTracker) isActive(podName string) bool {
 // setActivePodsCount sets the activePodsCount.
 func (pt *PodTracker) setActivePodsCount(count int) {
 	pt.activePodsMutex.Lock()
-	defer pt.activePodsMutex.Unlock()
 	pt.log.Debugf("Setting active pods count to %d", count)
 	pt.activePodsCount = count
+	pt.activePodsMutex.Unlock()
+
+	pt.firstPodsUpdateOnce.Do(func() {
+		close(pt.firstPodsUpdateChan)
+	})
 }
 
 // GetActivePodsCount returns the number of active pods.

--- a/pkg/mvtxdaemon/server/service/runtime/pod_tracker.go
+++ b/pkg/mvtxdaemon/server/service/runtime/pod_tracker.go
@@ -186,9 +186,14 @@ func (pt *PodTracker) isActive(podName string) bool {
 // setActivePodsCount sets the activePodsCount.
 func (pt *PodTracker) setActivePodsCount(count int) {
 	pt.activePodsMutex.Lock()
-	pt.log.Debugf("Setting active pods count to %d", count)
+	previous := pt.activePodsCount
 	pt.activePodsCount = count
 	pt.activePodsMutex.Unlock()
+
+	if previous != count {
+		pt.log.Infof("%s active worker pods changed monoVertex=%s previous=%d current=%d",
+			errorRetentionLogPrefix, pt.monoVertex.Name, previous, count)
+	}
 
 	pt.firstPodsUpdateOnce.Do(func() {
 		close(pt.firstPodsUpdateChan)

--- a/pkg/mvtxdaemon/server/service/runtime/pod_tracker_test.go
+++ b/pkg/mvtxdaemon/server/service/runtime/pod_tracker_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -39,47 +40,6 @@ func (m *mockHttpClient) Get(url string) (*http.Response, error) {
 	return nil, nil
 }
 
-func TestNewPodTracker(t *testing.T) {
-	ctx := context.Background()
-	mv := &v1alpha1.MonoVertex{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "p",
-			Namespace: "default",
-		},
-	}
-	pt := NewPodTracker(ctx, mv)
-
-	assert.NotNil(t, pt)
-	assert.Equal(t, mv, pt.monoVertex)
-	assert.NotNil(t, pt.httpClient)
-	assert.Equal(t, 30*time.Second, pt.refreshInterval)
-}
-
-func TestPodTracker_Start(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	mv := &v1alpha1.MonoVertex{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "p",
-			Namespace: "default",
-		},
-	}
-	pt := NewPodTracker(ctx, mv)
-	pt.httpClient = &mockHttpClient{
-		podsCount: 10,
-		lock:      &sync.RWMutex{},
-	}
-
-	err := pt.Start(ctx)
-	assert.NoError(t, err)
-
-	time.Sleep(100 * time.Millisecond)
-
-	// Check if the active pods are being tracked
-	assert.Equal(t, pt.GetActivePodsCount(), 10)
-}
-
 func TestPodTracker_updateActivePods(t *testing.T) {
 	ctx := context.Background()
 	mv := &v1alpha1.MonoVertex{
@@ -94,47 +54,41 @@ func TestPodTracker_updateActivePods(t *testing.T) {
 		lock:      &sync.RWMutex{},
 	}
 	pt.updateActivePods()
-	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, 3, pt.GetActivePodsCount())
 }
 
-func TestPodTracker_isActive(t *testing.T) {
-	ctx := context.Background()
+func TestPodTracker_zeroToActiveTransition(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	mv := &v1alpha1.MonoVertex{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "p",
 			Namespace: "default",
 		},
 	}
-	pt := NewPodTracker(ctx, mv)
-	pt.httpClient = &mockHttpClient{
-		podsCount: 3,
+	mockClient := &mockHttpClient{
+		podsCount: 0,
 		lock:      &sync.RWMutex{},
 	}
+	pt := NewPodTracker(ctx, mv,
+		WithRefreshInterval(time.Millisecond*50),
+		WithInitialRefreshInterval(time.Millisecond*20),
+		WithPodTrackerHTTPClient(mockClient),
+	)
 
-	time.Sleep(100 * time.Millisecond)
-	active := pt.isActive("p-mv-0")
-	assert.True(t, active)
-	active = pt.isActive("p-mv-3")
-	assert.False(t, active)
-}
+	err := pt.Start(ctx)
+	require.NoError(t, err)
 
-func TestPodTracker_setActivePodsCount(t *testing.T) {
-	ctx := context.Background()
-	mv := &v1alpha1.MonoVertex{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "p",
-			Namespace: "default",
-		},
-	}
+	assert.Eventually(t, func() bool {
+		return pt.GetActivePodsCount() == 0
+	}, time.Second, time.Millisecond*10)
 
-	pt := NewPodTracker(ctx, mv)
-	pt.httpClient = &mockHttpClient{
-		// active pods would be 3, from index 0..2
-		podsCount: 3,
-		lock:      &sync.RWMutex{},
-	}
-	// set active pods to 4
-	pt.setActivePodsCount(4)
-	assert.Equal(t, pt.GetActivePodsCount(), 4)
+	mockClient.lock.Lock()
+	mockClient.podsCount = 1
+	mockClient.lock.Unlock()
+
+	assert.Eventually(t, func() bool {
+		return pt.GetActivePodsCount() == 1
+	}, time.Second, time.Millisecond*10)
 }

--- a/pkg/mvtxdaemon/server/service/runtime/runtime.go
+++ b/pkg/mvtxdaemon/server/service/runtime/runtime.go
@@ -33,8 +33,8 @@ import (
 )
 
 const (
-	runtimeErrorsPath     = "runtime/errors"
-	runtimeErrorsTimeStep = 60 * time.Second
+	runtimeErrorsPath            = "runtime/errors"
+	defaultRuntimeErrorsTimeStep = 10 * time.Second
 )
 
 // ErrorDetails is used to provide information for a container error
@@ -73,20 +73,46 @@ type runtimeHTTPClient interface {
 	Head(url string) (*http.Response, error)
 }
 
+// RuntimeOption configures a monoVertexRuntimeCache.
+type RuntimeOption func(*monoVertexRuntimeCache)
+
+// WithRuntimeErrorsTimeStep sets how often runtime errors are refreshed from active pods.
+func WithRuntimeErrorsTimeStep(d time.Duration) RuntimeOption {
+	return func(r *monoVertexRuntimeCache) {
+		r.runtimeErrorsTimeStep = d
+	}
+}
+
+// WithPodTrackerOptions configures the pod tracker used by the runtime cache.
+func WithPodTrackerOptions(opts ...PodTrackerOption) RuntimeOption {
+	return func(r *monoVertexRuntimeCache) {
+		r.podTrackerOpts = append(r.podTrackerOpts, opts...)
+	}
+}
+
+// WithRuntimeHTTPClient sets the HTTP client used to fetch runtime errors from worker pods.
+func WithRuntimeHTTPClient(client runtimeHTTPClient) RuntimeOption {
+	return func(r *monoVertexRuntimeCache) {
+		r.httpClient = client
+	}
+}
+
 // monoVertexRuntimeCache is used to store the local cache of runtime errors for a monoVertex.
 // It implements the MonoVertexRuntimeCache interface.
 type monoVertexRuntimeCache struct {
-	monoVtx    *v1alpha1.MonoVertex
-	localCache map[string][]ReplicaErrors
-	cacheMutex sync.RWMutex
-	podTracker *PodTracker
-	log        *zap.SugaredLogger
-	httpClient runtimeHTTPClient
+	monoVtx               *v1alpha1.MonoVertex
+	localCache            map[string][]ReplicaErrors
+	cacheMutex            sync.RWMutex
+	podTracker            *PodTracker
+	log                   *zap.SugaredLogger
+	httpClient            runtimeHTTPClient
+	runtimeErrorsTimeStep time.Duration
+	podTrackerOpts        []PodTrackerOption
 }
 
 // NewRuntime creates a new instance of monoVertexRuntimeCache.
-func NewRuntime(ctx context.Context, mv *v1alpha1.MonoVertex) MonoVertexRuntimeCache {
-	return &monoVertexRuntimeCache{
+func NewRuntime(ctx context.Context, mv *v1alpha1.MonoVertex, opts ...RuntimeOption) MonoVertexRuntimeCache {
+	r := &monoVertexRuntimeCache{
 		monoVtx:    mv,
 		localCache: make(map[string][]ReplicaErrors),
 		cacheMutex: sync.RWMutex{},
@@ -97,8 +123,15 @@ func NewRuntime(ctx context.Context, mv *v1alpha1.MonoVertex) MonoVertexRuntimeC
 			},
 			Timeout: time.Second * 1,
 		},
-		podTracker: NewPodTracker(ctx, mv),
+		runtimeErrorsTimeStep: defaultRuntimeErrorsTimeStep,
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(r)
+		}
+	}
+	r.podTracker = NewPodTracker(ctx, mv, r.podTrackerOpts...)
+	return r
 }
 
 // StartCacheRefresher starts the cache refresher to update the local cache periodically with the runtime errors.
@@ -140,7 +173,7 @@ func (r *monoVertexRuntimeCache) persistRuntimeErrors(ctx context.Context) {
 	fetchAndPersistErrors()
 
 	// Set up a ticker to run periodically
-	ticker := time.NewTicker(runtimeErrorsTimeStep)
+	ticker := time.NewTicker(r.runtimeErrorsTimeStep)
 	defer ticker.Stop()
 	for {
 		select {
@@ -161,7 +194,7 @@ func (r *monoVertexRuntimeCache) fetchAndPersistErrorForPod(podIndex int) {
 
 	res, err := r.httpClient.Get(url)
 	if err != nil {
-		r.log.Warnf("[MonoVertex %s Index %v]: failed reading the runtime endpoint, the pod might have been scaled down: %v", r.monoVtx.Name, podIndex, err.Error())
+		r.log.Debugf("[MonoVertex %s Index %v]: failed reading the runtime endpoint, the pod might have been scaled down: %v", r.monoVtx.Name, podIndex, err.Error())
 		return
 	}
 
@@ -220,7 +253,14 @@ func (r *monoVertexRuntimeCache) GetLocalCache() map[string][]ReplicaErrors {
 	localCacheCopy := make(map[string][]ReplicaErrors, len(r.localCache))
 	for key, value := range r.localCache {
 		localCacheValue := make([]ReplicaErrors, len(value))
-		copy(localCacheValue, value)
+		for i, replicaErrors := range value {
+			containerErrors := make([]ErrorDetails, len(replicaErrors.ContainerErrors))
+			copy(containerErrors, replicaErrors.ContainerErrors)
+			localCacheValue[i] = ReplicaErrors{
+				Replica:         replicaErrors.Replica,
+				ContainerErrors: containerErrors,
+			}
+		}
 		localCacheCopy[key] = localCacheValue
 	}
 	return localCacheCopy

--- a/pkg/mvtxdaemon/server/service/runtime/runtime.go
+++ b/pkg/mvtxdaemon/server/service/runtime/runtime.go
@@ -35,6 +35,7 @@ import (
 const (
 	runtimeErrorsPath            = "runtime/errors"
 	defaultRuntimeErrorsTimeStep = 10 * time.Second
+	errorRetentionLogPrefix      = "[error-retention]"
 )
 
 // ErrorDetails is used to provide information for a container error
@@ -131,7 +132,38 @@ func NewRuntime(ctx context.Context, mv *v1alpha1.MonoVertex, opts ...RuntimeOpt
 		}
 	}
 	r.podTracker = NewPodTracker(ctx, mv, r.podTrackerOpts...)
+	r.log.Infof("%s runtime cache initialized for monoVertex=%s namespace=%s scrapeInterval=%s",
+		errorRetentionLogPrefix, mv.Name, mv.Namespace, r.runtimeErrorsTimeStep)
 	return r
+}
+
+func summarizeReplicaErrors(replicas []ReplicaErrors) []map[string]interface{} {
+	summary := make([]map[string]interface{}, 0, len(replicas))
+	for _, replica := range replicas {
+		containers := make([]map[string]interface{}, 0, len(replica.ContainerErrors))
+		for _, containerError := range replica.ContainerErrors {
+			containers = append(containers, map[string]interface{}{
+				"container": containerError.Container,
+				"timestamp": containerError.Timestamp,
+				"code":      containerError.Code,
+				"message":   containerError.Message,
+			})
+		}
+		summary = append(summary, map[string]interface{}{
+			"replica":          replica.Replica,
+			"containerErrors":  containers,
+			"containerCount":   len(replica.ContainerErrors),
+		})
+	}
+	return summary
+}
+
+func summarizeLocalCache(cache map[string][]ReplicaErrors) map[string]interface{} {
+	result := make(map[string]interface{}, len(cache))
+	for key, replicas := range cache {
+		result[key] = summarizeReplicaErrors(replicas)
+	}
+	return result
 }
 
 // StartCacheRefresher starts the cache refresher to update the local cache periodically with the runtime errors.
@@ -154,10 +186,14 @@ func (r *monoVertexRuntimeCache) StartCacheRefresher(ctx context.Context) (err e
 
 // persistRuntimeErrors updates the local cache with the runtime errors
 func (r *monoVertexRuntimeCache) persistRuntimeErrors(ctx context.Context) {
-	fetchAndPersistErrors := func() {
+	fetchAndPersistErrors := func(trigger string) {
+		activePods := r.podTracker.GetActivePodsCount()
+		r.log.Infof("%s starting error scrape trigger=%s monoVertex=%s activePods=%d cachedKeys=%v",
+			errorRetentionLogPrefix, trigger, r.monoVtx.Name, activePods, r.localCacheKeys())
+
 		var wg sync.WaitGroup
 
-		for i := range r.podTracker.GetActivePodsCount() {
+		for i := range activePods {
 			wg.Add(1)
 			go func(podIndex int) {
 				defer wg.Done()
@@ -167,10 +203,13 @@ func (r *monoVertexRuntimeCache) persistRuntimeErrors(ctx context.Context) {
 
 		// Wait for all goroutines to finish
 		wg.Wait()
+
+		r.log.Infof("%s completed error scrape trigger=%s monoVertex=%s activePods=%d cacheSnapshot=%v",
+			errorRetentionLogPrefix, trigger, r.monoVtx.Name, activePods, summarizeLocalCache(r.GetLocalCache()))
 	}
 
 	// invoke once and then periodically update the cache
-	fetchAndPersistErrors()
+	fetchAndPersistErrors("initial")
 
 	// Set up a ticker to run periodically
 	ticker := time.NewTicker(r.runtimeErrorsTimeStep)
@@ -178,7 +217,7 @@ func (r *monoVertexRuntimeCache) persistRuntimeErrors(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			fetchAndPersistErrors()
+			fetchAndPersistErrors("ticker")
 		// If the context is done, return.
 		case <-ctx.Done():
 			r.log.Info("Context canceled, stopping PersistRuntimeErrors")
@@ -194,7 +233,8 @@ func (r *monoVertexRuntimeCache) fetchAndPersistErrorForPod(podIndex int) {
 
 	res, err := r.httpClient.Get(url)
 	if err != nil {
-		r.log.Debugf("[MonoVertex %s Index %v]: failed reading the runtime endpoint, the pod might have been scaled down: %v", r.monoVtx.Name, podIndex, err.Error())
+		r.log.Infof("%s fetch failed monoVertex=%s podIndex=%d url=%s err=%v",
+			errorRetentionLogPrefix, r.monoVtx.Name, podIndex, url, err)
 		return
 	}
 
@@ -202,19 +242,23 @@ func (r *monoVertexRuntimeCache) fetchAndPersistErrorForPod(podIndex int) {
 	body, err := io.ReadAll(res.Body)
 	_ = res.Body.Close()
 	if err != nil {
-		r.log.Errorf("Error reading response body from %s: %v", url, err)
+		r.log.Errorf("%s failed reading response body monoVertex=%s podIndex=%d url=%s err=%v",
+			errorRetentionLogPrefix, r.monoVtx.Name, podIndex, url, err)
 		return
 	}
 
 	// Parse the response body into runtime api response
 	var apiResponse ErrorApiResponse
 	if err := json.Unmarshal(body, &apiResponse); err != nil {
-		r.log.Errorf("Error decoding runtime error response from %s: %v", url, err)
+		r.log.Errorf("%s failed decoding response monoVertex=%s podIndex=%d url=%s body=%s err=%v",
+			errorRetentionLogPrefix, r.monoVtx.Name, podIndex, url, string(body), err)
 		return
 	}
 
 	// return if data array length is 0 or if there is any error in the API call
 	if apiResponse.ErrMessage != "" || len(apiResponse.Data) == 0 {
+		r.log.Infof("%s fetch returned no persistable errors monoVertex=%s podIndex=%d url=%s statusCode=%d apiErrMessage=%q dataCount=%d body=%s",
+			errorRetentionLogPrefix, r.monoVtx.Name, podIndex, url, res.StatusCode, apiResponse.ErrMessage, len(apiResponse.Data), string(body))
 		return
 	}
 
@@ -222,7 +266,8 @@ func (r *monoVertexRuntimeCache) fetchAndPersistErrorForPod(podIndex int) {
 	replica := fmt.Sprintf("%s-mv-%v", cacheKey, podIndex)
 	newMvtxErrors := ReplicaErrors{Replica: replica, ContainerErrors: apiResponse.Data}
 
-	r.log.Debugf("Persisting error in local cache for: %s", cacheKey)
+	r.log.Infof("%s persisting errors monoVertex=%s podIndex=%d replica=%s cacheKey=%s containers=%v",
+		errorRetentionLogPrefix, r.monoVtx.Name, podIndex, replica, cacheKey, summarizeReplicaErrors([]ReplicaErrors{newMvtxErrors}))
 	// Lock the cache before updating
 	r.cacheMutex.Lock()
 	defer r.cacheMutex.Unlock()
@@ -234,14 +279,20 @@ func (r *monoVertexRuntimeCache) fetchAndPersistErrorForPod(podIndex int) {
 			if mvtxError.Replica == replica {
 				mvtxErrors[i] = newMvtxErrors
 				r.localCache[cacheKey] = mvtxErrors
+				r.log.Infof("%s updated existing replica errors monoVertex=%s replica=%s totalReplicas=%d",
+					errorRetentionLogPrefix, cacheKey, replica, len(mvtxErrors))
 				return
 			}
 		}
 		// Append new replica errors if not found
 		r.localCache[cacheKey] = append(mvtxErrors, newMvtxErrors)
+		r.log.Infof("%s appended replica errors monoVertex=%s replica=%s totalReplicas=%d",
+			errorRetentionLogPrefix, cacheKey, replica, len(r.localCache[cacheKey]))
 	} else {
 		// Initialize the cache entry with the new replica errors
 		r.localCache[cacheKey] = []ReplicaErrors{newMvtxErrors}
+		r.log.Infof("%s initialized cache entry monoVertex=%s replica=%s totalReplicas=%d",
+			errorRetentionLogPrefix, cacheKey, replica, len(r.localCache[cacheKey]))
 	}
 }
 
@@ -264,4 +315,14 @@ func (r *monoVertexRuntimeCache) GetLocalCache() map[string][]ReplicaErrors {
 		localCacheCopy[key] = localCacheValue
 	}
 	return localCacheCopy
+}
+
+func (r *monoVertexRuntimeCache) localCacheKeys() []string {
+	r.cacheMutex.RLock()
+	defer r.cacheMutex.RUnlock()
+	keys := make([]string, 0, len(r.localCache))
+	for key := range r.localCache {
+		keys = append(keys, key)
+	}
+	return keys
 }

--- a/pkg/mvtxdaemon/server/service/runtime/runtime_test.go
+++ b/pkg/mvtxdaemon/server/service/runtime/runtime_test.go
@@ -1,0 +1,228 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type runtimeMockHTTPClient struct {
+	lock         sync.RWMutex
+	activePods   int
+	responses    map[int]ErrorApiResponse
+	getCallCount int
+}
+
+func (m *runtimeMockHTTPClient) Head(url string) (*http.Response, error) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	for i := 0; i < m.activePods; i++ {
+		if strings.Contains(url, fmt.Sprintf("mv-mv-%d.mv-mv-headless.default.svc:2470/runtime/errors", i)) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("pod not found")
+}
+
+func (m *runtimeMockHTTPClient) Get(url string) (*http.Response, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.getCallCount++
+	for i := 0; i < m.activePods; i++ {
+		if !strings.Contains(url, fmt.Sprintf("mv-mv-%d.mv-mv-headless.default.svc:2470/runtime/errors", i)) {
+			continue
+		}
+		response, ok := m.responses[i]
+		if !ok {
+			return nil, fmt.Errorf("no response configured for pod %d", i)
+		}
+		body, err := json.Marshal(response)
+		if err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+		}, nil
+	}
+	return nil, fmt.Errorf("pod not found")
+}
+
+func newTestMonoVertex() *v1alpha1.MonoVertex {
+	max := int32(1)
+	return &v1alpha1.MonoVertex{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mv",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.MonoVertexSpec{
+			Scale: v1alpha1.Scale{
+				Max: &max,
+			},
+		},
+	}
+}
+
+func TestRuntimeCache_fetchesOnWorkerDiscovery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mockClient := &runtimeMockHTTPClient{
+		responses: map[int]ErrorApiResponse{
+			0: {
+				Data: []ErrorDetails{{
+					Container: "udf",
+					Timestamp: 123,
+					Code:      "E1",
+					Message:   "failed",
+				}},
+			},
+		},
+	}
+	r := NewRuntime(ctx, newTestMonoVertex(),
+		WithRuntimeErrorsTimeStep(50*time.Millisecond),
+		WithRuntimeHTTPClient(mockClient),
+		WithPodTrackerOptions(
+			WithRefreshInterval(time.Millisecond*50),
+			WithInitialRefreshInterval(time.Millisecond*20),
+			WithPodTrackerHTTPClient(mockClient),
+		),
+	).(*monoVertexRuntimeCache)
+
+	require.NoError(t, r.StartCacheRefresher(ctx))
+
+	mockClient.lock.Lock()
+	mockClient.activePods = 1
+	mockClient.lock.Unlock()
+	r.podTracker.updateActivePods()
+
+	assert.Eventually(t, func() bool {
+		cache := r.GetLocalCache()
+		errors, ok := cache["mv"]
+		return ok && len(errors) == 1 && errors[0].ContainerErrors[0].Container == "udf"
+	}, time.Second, time.Millisecond*10)
+}
+
+func TestRuntimeCache_retainsSnapshotAfterScaleToZero(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mockClient := &runtimeMockHTTPClient{
+		activePods: 1,
+		responses: map[int]ErrorApiResponse{
+			0: {
+				Data: []ErrorDetails{{
+					Container: "udf",
+					Timestamp: 123,
+					Code:      "E1",
+					Message:   "failed",
+				}},
+			},
+		},
+	}
+	r := NewRuntime(ctx, newTestMonoVertex(),
+		WithRuntimeErrorsTimeStep(time.Hour),
+		WithRuntimeHTTPClient(mockClient),
+		WithPodTrackerOptions(WithPodTrackerHTTPClient(mockClient)),
+	).(*monoVertexRuntimeCache)
+
+	require.NoError(t, r.StartCacheRefresher(ctx))
+
+	assert.Eventually(t, func() bool {
+		cache := r.GetLocalCache()
+		errors, ok := cache["mv"]
+		return ok && len(errors) == 1
+	}, time.Second, time.Millisecond*10)
+
+	mockClient.lock.Lock()
+	mockClient.activePods = 0
+	mockClient.lock.Unlock()
+	r.podTracker.setActivePodsCount(0)
+
+	time.Sleep(50 * time.Millisecond)
+
+	cache := r.GetLocalCache()
+	errors, ok := cache["mv"]
+	require.True(t, ok)
+	require.Len(t, errors, 1)
+	assert.Equal(t, "udf", errors[0].ContainerErrors[0].Container)
+}
+
+func TestRuntimeCache_fetchFailureDoesNotClearSnapshot(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mockClient := &runtimeMockHTTPClient{
+		activePods: 1,
+		responses: map[int]ErrorApiResponse{
+			0: {
+				Data: []ErrorDetails{{
+					Container: "udf",
+					Timestamp: 123,
+					Code:      "E1",
+					Message:   "failed",
+				}},
+			},
+		},
+	}
+	r := NewRuntime(ctx, newTestMonoVertex(),
+		WithRuntimeErrorsTimeStep(time.Hour),
+		WithRuntimeHTTPClient(mockClient),
+		WithPodTrackerOptions(WithPodTrackerHTTPClient(mockClient)),
+	).(*monoVertexRuntimeCache)
+
+	require.NoError(t, r.StartCacheRefresher(ctx))
+
+	assert.Eventually(t, func() bool {
+		cache := r.GetLocalCache()
+		errors, ok := cache["mv"]
+		return ok && len(errors) == 1
+	}, time.Second, time.Millisecond*10)
+
+	mockClient.lock.Lock()
+	delete(mockClient.responses, 0)
+	mockClient.lock.Unlock()
+
+	r.fetchAndPersistErrorForPod(0)
+
+	cache := r.GetLocalCache()
+	errors, ok := cache["mv"]
+	require.True(t, ok)
+	require.Len(t, errors, 1)
+	assert.Equal(t, "udf", errors[0].ContainerErrors[0].Container)
+}
+
+func TestRuntimeCache_getLocalCacheReturnsCopy(t *testing.T) {
+	ctx := context.Background()
+	r := NewRuntime(ctx, newTestMonoVertex()).(*monoVertexRuntimeCache)
+
+	r.cacheMutex.Lock()
+	r.localCache["mv"] = []ReplicaErrors{{
+		Replica: "mv-mv-0",
+		ContainerErrors: []ErrorDetails{{
+			Container: "udf",
+		}},
+	}}
+	r.cacheMutex.Unlock()
+
+	cacheCopy := r.GetLocalCache()
+	cacheCopy["mv"][0].ContainerErrors[0].Container = "changed"
+
+	cache := r.GetLocalCache()
+	assert.Equal(t, "udf", cache["mv"][0].ContainerErrors[0].Container)
+}

--- a/test/fixtures/expect.go
+++ b/test/fixtures/expect.go
@@ -158,6 +158,14 @@ func (t *Expect) MonoVertexPodsRunning() *Expect {
 	return t
 }
 
+func (t *Expect) MonoVertexWorkerPodsScaledToZero() *Expect {
+	t.t.Helper()
+	if err := WaitForMonoVertexWorkerPodsScaledToZero(t.kubeClient, Namespace, t.monoVertex.Name, defaultTimeout); err != nil {
+		t.t.Fatalf("Expected mono vertex %q worker pods scaled to zero: %v", t.monoVertex.Name, err)
+	}
+	return t
+}
+
 func (t *Expect) VertexPodRuntimeSnapshot(vertexName string) PodRuntimeSnapshot {
 	t.t.Helper()
 	timeout := 3 * time.Minute

--- a/test/fixtures/util.go
+++ b/test/fixtures/util.go
@@ -419,6 +419,26 @@ func WaitForDaemonPodsRunning(kubeClient kubernetes.Interface, namespace, pipeli
 	}
 }
 
+func WaitForMonoVertexWorkerPodsScaledToZero(kubeClient kubernetes.Interface, namespace, monoVertexName string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s", dfv1.KeyMonoVertexName, monoVertexName, dfv1.KeyComponent, dfv1.ComponentMonoVertex)
+	for {
+		podList, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return fmt.Errorf("error listing mono vertex worker pods: %w", err)
+		}
+		if len(podList.Items) == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout after %v waiting for mono vertex worker pods to scale to zero", timeout)
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
 func WaitForMvtxDaemonPodsRunning(kubeClient kubernetes.Interface, namespace, mvtx string, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/test/fixtures/when.go
+++ b/test/fixtures/when.go
@@ -154,6 +154,26 @@ func (w *When) CreateMonoVertexAndWait() *When {
 	return w
 }
 
+func (w *When) PauseMonoVertexAndWait() *When {
+	w.t.Helper()
+	if w.monoVertex == nil {
+		w.t.Fatal("No MonoVertex to pause")
+	}
+	ctx := context.Background()
+	mv, err := w.monoVertexClient.Get(ctx, w.monoVertex.Name, metav1.GetOptions{})
+	if err != nil {
+		w.t.Fatal(err)
+	}
+	mv.Spec.Lifecycle.DesiredPhase = dfv1.MonoVertexPhasePaused
+	if _, err = w.monoVertexClient.Update(ctx, mv, metav1.UpdateOptions{}); err != nil {
+		w.t.Fatal(err)
+	}
+	if err := WaitForMonoVertexWorkerPodsScaledToZero(w.kubeClient, Namespace, w.monoVertex.Name, defaultTimeout); err != nil {
+		w.t.Fatal(err)
+	}
+	return w
+}
+
 func (w *When) DeletePipelineAndWait() *When {
 	w.t.Helper()
 	if w.pipeline == nil {

--- a/test/redrive-e2e/redrive_test.go
+++ b/test/redrive-e2e/redrive_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
@@ -270,6 +271,53 @@ func (s *RedriveSuite) TestMonoVertexRuntimeErrorsFromSinkCrash() {
 	}, 2*time.Minute, time.Second, "udsink runtime error not reported by the UX server for the monovertex")
 
 	w.Expect().MonoVertexNumaStable(podSnapshot)
+}
+
+func (s *RedriveSuite) TestMonoVertexRuntimeErrorsRetainedAfterScaleToZero() {
+	monoVertexName := "runtime-error-monovertex"
+	w := s.Given().MonoVertex("@testdata/runtime-error-monovertex.yaml").
+		When().CreateMonoVertexAndWait()
+	defer w.DeleteMonoVertexAndWait()
+
+	w.Expect().MonoVertexPodsRunning().MvtxDaemonPodsRunning()
+
+	defer w.MvtxDaemonPodPortForward(3245, dfv1.MonoVertexDaemonServicePort).
+		UXServerPodPortForward(8145, 8443).
+		TerminateAllPodPortForwards()
+
+	client, err := mvtxclient.NewGRPCClient("localhost:3245")
+	require.NoError(s.T(), err)
+	defer func() { assert.NoError(s.T(), client.Close()) }()
+
+	go func() {
+		defer func() {
+			_ = recover()
+		}()
+		w.SendMessageToMvTx(monoVertexName, NewHttpPostRequest().WithBody([]byte("not-json")))
+	}()
+
+	assert.Eventually(s.T(), func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		replicaErrors, err := client.GetMonoVertexErrors(ctx, monoVertexName)
+		return err == nil && monoVertexHasContainerError(replicaErrors, "udf")
+	}, 2*time.Minute, time.Second, "udf runtime error not captured by the monovertex daemon before scale to zero")
+
+	w.PauseMonoVertexAndWait()
+	w.Expect().MvtxDaemonPodsRunning()
+
+	ctx := context.Background()
+	replicaErrors, err := client.GetMonoVertexErrors(ctx, monoVertexName)
+	require.NoError(s.T(), err)
+	assert.True(s.T(), monoVertexHasContainerError(replicaErrors, "udf"), "daemon should retain udf runtime error after worker pods scale to zero")
+
+	assert.Eventually(s.T(), func() bool {
+		return httpBodyContains(
+			"https://localhost:8145",
+			fmt.Sprintf("/api/v1/namespaces/%s/mono-vertices/%s/errors", Namespace, monoVertexName),
+			`"container":"udf"`,
+		)
+	}, 2*time.Minute, time.Second, "udf runtime error not retained by the UX server after worker pods scale to zero")
 }
 
 func TestRedriveSuite(t *testing.T) {


### PR DESCRIPTION
### What this PR does / why we need it

- Aim is to retain MonoVertex runtime errors in the daemon’s in memory cache after pods scale to zero, so trial failures remain visible in the UI (Errors tab) after rollout([using progressive rollout strategy](https://github.com/numaproj/numaplane/blob/f6b9b54ecf6e6629fb39304ed9249a946dda5869/README.md?plain=1#L17)) failure (pods scale down to 0, daemon pod keeps on running for trial MonoVertex) 

- Speed up error capture with 3s worker discovery (while idle) and a 10s scrape interval

- Add unit tests for cache retention and an e2e test that pauses a MonoVertex and verifies errors still flow through the daemon and UX server.

### Related issues
Fixes #

### Testing

Internal testing yet to be done.

### Special notes for reviewers
This is best effort pull solution (from daemon to numa)

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
