### PR TITLE
test: use unique stream name for different js writer tests

### DIFF
--- a/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
+++ b/rust/numaflow-core/src/pipeline/isb/jetstream/js_writer.rs
@@ -825,7 +825,7 @@ mod tests {
         let context = jetstream::new(client);
         let cln_token = CancellationToken::new();
 
-        let stream = Stream::new("test-write-compress", "temp", 0);
+        let stream = Stream::new("test-write-compress-sync", "temp", 0);
         let _ = context.delete_stream(stream.name).await;
         let _stream = context
             .get_or_create_stream(stream::Config {


### PR DESCRIPTION
### What this PR does / why we need it
Fix for a race condition between tests. 

Following error was observed:
```
2026-09-02T02:47:32.927959Z ERROR numaflow_core::pipeline::isb::jetstream::js_writer: awaiting publish ack failed e=Error { kind: StreamNotFound, source: None }
test pipeline::isb::jetstream::js_writer::tests::test_write_with_compression ... FAILED
```


Two js_writer tests use the same stream name `test-write-compress` and operate on it:
- `test_async_write_with_compression`
- `test_write_with_compression`

Both tests delete the streams at the end as part of clean-up. Stream deleted by one test, mid-write for another tests can result in the "StreamNotFound" error. 


### Testing
This is the test

### Special notes for reviewers
Anything notable for review (risk, rollout, follow-ups).

<!--

Before you push your changes:

* Run `make pre-push -B` to fix codegen and lint problems.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" or "Closes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->
