### PR TITLE
fix: cron autoscaling bounds overridden by CalculateReplicas clamping

### DIFF
--- a/pkg/apis/numaflow/v1alpha1/mono_vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/mono_vertex_types.go
@@ -96,16 +96,26 @@ func (mv MonoVertex) getReplicas() int {
 	return int(*mv.Spec.Replicas)
 }
 
+// CalculateReplicas returns the number of pods the reconciler should run,
+// clamped to the parent scale.min/scale.max bounds.
+// Use CalculateReplicasWithBounds when an active cron window may set bounds
+// outside the parent range.
 func (mv MonoVertex) CalculateReplicas() int {
-	// If we are pausing the MonoVertex then we should have the desired replicas as 0
+	return mv.CalculateReplicasWithBounds(mv.Spec.Scale.GetMinReplicas(), mv.Spec.Scale.GetMaxReplicas())
+}
+
+// CalculateReplicasWithBounds returns the desired replica count clamped to
+// [effectiveMin, effectiveMax]. Pass the effective bounds derived from any
+// active cron window so that cron min/max outside the parent scale range are
+// honoured.
+func (mv MonoVertex) CalculateReplicasWithBounds(effectiveMin, effectiveMax int32) int {
 	if mv.Spec.Lifecycle.GetDesiredPhase() == MonoVertexPhasePaused {
 		return 0
 	}
 	desiredReplicas := mv.getReplicas()
-	// Don't allow replicas to be out of the range of min and max when auto scaling is enabled
 	if s := mv.Spec.Scale; !s.Disabled {
-		max := int(s.GetMaxReplicas())
-		min := int(s.GetMinReplicas())
+		min := int(effectiveMin)
+		max := int(effectiveMax)
 		if desiredReplicas < min {
 			desiredReplicas = min
 		} else if desiredReplicas > max {

--- a/pkg/apis/numaflow/v1alpha1/mono_vertex_types_test.go
+++ b/pkg/apis/numaflow/v1alpha1/mono_vertex_types_test.go
@@ -425,6 +425,50 @@ func TestMonoVertex_CalculateReplicas(t *testing.T) {
 	})
 }
 
+func TestMonoVertex_CalculateReplicasWithBounds(t *testing.T) {
+	baseScale := Scale{Min: ptr.To[int32](5), Max: ptr.To[int32](10)}
+
+	t.Run("cronMin below parentMin is honoured", func(t *testing.T) {
+		replicas := int32(2)
+		mv := MonoVertex{Spec: MonoVertexSpec{Replicas: &replicas, Scale: baseScale}}
+		assert.Equal(t, 2, mv.CalculateReplicasWithBounds(2, 15))
+	})
+
+	t.Run("cronMax above parentMax is honoured", func(t *testing.T) {
+		replicas := int32(15)
+		mv := MonoVertex{Spec: MonoVertexSpec{Replicas: &replicas, Scale: baseScale}}
+		assert.Equal(t, 15, mv.CalculateReplicasWithBounds(2, 15))
+	})
+
+	t.Run("spec.replicas below effective min is clamped up", func(t *testing.T) {
+		replicas := int32(1)
+		mv := MonoVertex{Spec: MonoVertexSpec{Replicas: &replicas, Scale: baseScale}}
+		assert.Equal(t, 2, mv.CalculateReplicasWithBounds(2, 15))
+	})
+
+	t.Run("spec.replicas above effective max is clamped down", func(t *testing.T) {
+		replicas := int32(20)
+		mv := MonoVertex{Spec: MonoVertexSpec{Replicas: &replicas, Scale: baseScale}}
+		assert.Equal(t, 15, mv.CalculateReplicasWithBounds(2, 15))
+	})
+
+	t.Run("parent bounds apply when cron is inactive", func(t *testing.T) {
+		replicas := int32(2) // below parentMin=5
+		mv := MonoVertex{Spec: MonoVertexSpec{Replicas: &replicas, Scale: baseScale}}
+		assert.Equal(t, 5, mv.CalculateReplicasWithBounds(5, 10))
+	})
+
+	t.Run("paused returns 0 regardless of bounds", func(t *testing.T) {
+		replicas := int32(5)
+		mv := MonoVertex{Spec: MonoVertexSpec{
+			Replicas:  &replicas,
+			Scale:     baseScale,
+			Lifecycle: MonoVertexLifecycle{DesiredPhase: MonoVertexPhasePaused},
+		}}
+		assert.Equal(t, 0, mv.CalculateReplicasWithBounds(2, 15))
+	})
+}
+
 func TestMonoVertex_GetServiceObj(t *testing.T) {
 	mv := MonoVertex{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/numaflow/v1alpha1/vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/vertex_types.go
@@ -538,16 +538,25 @@ func (v Vertex) getReplicas() int {
 	return int(*v.Spec.Replicas)
 }
 
+// CalculateReplicas returns the desired replica count clamped to the parent
+// scale.min/scale.max bounds. Use CalculateReplicasWithBounds when an active
+// cron window may set bounds outside the parent range.
 func (v Vertex) CalculateReplicas() int {
-	// If we are pausing the Pipeline/Vertex then we should have the desired replicas as 0
+	return v.CalculateReplicasWithBounds(v.Spec.Scale.GetMinReplicas(), v.Spec.Scale.GetMaxReplicas())
+}
+
+// CalculateReplicasWithBounds returns the desired replica count clamped to
+// [effectiveMin, effectiveMax]. Pass the effective bounds derived from any
+// active cron window so that cron min/max outside the parent scale range are
+// honoured.
+func (v Vertex) CalculateReplicasWithBounds(effectiveMin, effectiveMax int32) int {
 	if v.Spec.Lifecycle.GetDesiredPhase() == VertexPhasePaused {
 		return 0
 	}
 	desiredReplicas := v.getReplicas()
-	// Don't allow replicas to be out of the range of min and max when auto scaling is enabled
 	if s := v.Spec.Scale; !s.Disabled {
-		max := int(s.GetMaxReplicas())
-		min := int(s.GetMinReplicas())
+		min := int(effectiveMin)
+		max := int(effectiveMax)
 		if desiredReplicas < min {
 			desiredReplicas = min
 		} else if desiredReplicas > max {

--- a/pkg/apis/numaflow/v1alpha1/vertex_types_test.go
+++ b/pkg/apis/numaflow/v1alpha1/vertex_types_test.go
@@ -168,6 +168,32 @@ func TestGetVertexReplicas(t *testing.T) {
 	assert.Equal(t, 20, v.CalculateReplicas())
 }
 
+func TestVertex_CalculateReplicasWithBounds(t *testing.T) {
+	baseScale := Scale{Min: ptr.To[int32](5), Max: ptr.To[int32](10)}
+
+	t.Run("cronMin below parentMin is honoured", func(t *testing.T) {
+		replicas := int32(2)
+		v := Vertex{Spec: VertexSpec{AbstractVertex: AbstractVertex{Scale: baseScale}, Replicas: &replicas}}
+		assert.Equal(t, 2, v.CalculateReplicasWithBounds(2, 15))
+	})
+
+	t.Run("cronMax above parentMax is honoured", func(t *testing.T) {
+		replicas := int32(15)
+		v := Vertex{Spec: VertexSpec{AbstractVertex: AbstractVertex{Scale: baseScale}, Replicas: &replicas}}
+		assert.Equal(t, 15, v.CalculateReplicasWithBounds(2, 15))
+	})
+
+	t.Run("paused returns 0 regardless of bounds", func(t *testing.T) {
+		replicas := int32(5)
+		v := Vertex{Spec: VertexSpec{
+			AbstractVertex: AbstractVertex{Scale: baseScale},
+			Replicas:       &replicas,
+			Lifecycle:      VertexLifecycle{DesiredPhase: VertexPhasePaused},
+		}}
+		assert.Equal(t, 0, v.CalculateReplicasWithBounds(2, 15))
+	})
+}
+
 func TestGetHeadlessSvcSpec(t *testing.T) {
 	s := testVertex.getServiceObj(testVertex.GetHeadlessServiceName(), true, map[string]int32{VertexMetricsPortName: VertexMetricsPort})
 	assert.Equal(t, s.Name, testVertex.GetHeadlessServiceName())

--- a/pkg/reconciler/monovertex/controller.go
+++ b/pkg/reconciler/monovertex/controller.go
@@ -42,6 +42,7 @@ import (
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaflow/pkg/reconciler"
 	mvtxscaling "github.com/numaproj/numaflow/pkg/reconciler/monovertex/scaling"
+	scalingutil "github.com/numaproj/numaflow/pkg/reconciler/scaling"
 	"github.com/numaproj/numaflow/pkg/reconciler/validator"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 	sharedutil "github.com/numaproj/numaflow/pkg/shared/util"
@@ -193,7 +194,17 @@ func (mr *monoVertexReconciler) orchestrateFixedResources(ctx context.Context, m
 
 func (mr *monoVertexReconciler) orchestratePods(ctx context.Context, monoVtx *dfv1.MonoVertex) error {
 	log := logging.FromContext(ctx)
-	desiredReplicas := monoVtx.CalculateReplicas()
+	// Compute effective scale bounds accounting for any active cron window.
+	var parsedSchedules []scalingutil.ParsedCronSchedule
+	if monoVtx.Spec.Scale.Cron != nil {
+		var err error
+		parsedSchedules, err = scalingutil.ParseCronSchedules(monoVtx.Spec.Scale.Cron)
+		if err != nil {
+			return fmt.Errorf("failed to parse cron schedules: %w", err)
+		}
+	}
+	effectiveMin, effectiveMax, _ := scalingutil.EffectiveScaleBoundsAt(monoVtx.Spec.Scale, parsedSchedules, time.Now())
+	desiredReplicas := monoVtx.CalculateReplicasWithBounds(effectiveMin, effectiveMax)
 	monoVtx.Status.DesiredReplicas = uint32(desiredReplicas)
 
 	// Set metrics

--- a/pkg/reconciler/monovertex/scaling/scaling.go
+++ b/pkg/reconciler/monovertex/scaling/scaling.go
@@ -145,16 +145,6 @@ func (s *Scaler) parsedCronSchedulesFor(monoVtx *dfv1.MonoVertex) ([]scalingutil
 	return parsed, nil
 }
 
-// effectiveScaleBoundsFor returns the effective scale bounds for a MonoVertex at a given time.
-func (s *Scaler) effectiveScaleBoundsFor(monoVtx *dfv1.MonoVertex, at time.Time) (int32, int32, bool, error) {
-	parsed, err := s.parsedCronSchedulesFor(monoVtx)
-	if err != nil {
-		return 0, 0, false, err
-	}
-	minReplicas, maxReplicas, cronActive := scalingutil.EffectiveScaleBoundsAt(monoVtx.Spec.Scale, parsed, at)
-	return minReplicas, maxReplicas, cronActive, nil
-}
-
 // scaleOneMonoVertex implements the detailed logic of scaling up/down a MonoVertex.
 //
 //	desiredReplicas = currentReplicas * pending / (targetProcessingTime * rate)
@@ -206,15 +196,21 @@ func (s *Scaler) scaleOneMonoVertex(ctx context.Context, key string, worker int)
 		log.Info("MonoVertex desiredPhase is not running, skip scaling.")
 		return nil
 	}
-	if int(monoVtx.Status.Replicas) != monoVtx.CalculateReplicas() {
+	// Parse cron schedules once (cached by UID+Generation); used for both the
+	// mismatch guard below and the bounds enforcement that follows.
+	parsed, parseErr := s.parsedCronSchedulesFor(monoVtx)
+	if parseErr != nil {
+		log.Errorw("Failed to parse cron schedules.", zap.Error(parseErr))
+		return parseErr
+	}
+	minReplicas, maxReplicas, cronActive := scalingutil.EffectiveScaleBoundsAt(monoVtx.Spec.Scale, parsed, time.Now())
+
+	// The mismatch guard uses the cron-aware effective bounds so that a cron window
+	// intentionally placing spec.replicas outside [parentMin, parentMax] is not
+	// misidentified as a reconciler convergence gap.
+	if int(monoVtx.Status.Replicas) != monoVtx.CalculateReplicasWithBounds(minReplicas, maxReplicas) {
 		log.Infof("MonoVertex %s might be under processing, replicas mismatch, skip scaling.", monoVtx.Name)
 		return nil
-	}
-
-	minReplicas, maxReplicas, cronActive, boundsErr := s.effectiveScaleBoundsFor(monoVtx, time.Now())
-	if boundsErr != nil {
-		log.Errorw("Failed to parse cron schedules.", zap.Error(boundsErr))
-		return boundsErr
 	}
 	current := int32(monoVtx.Status.Replicas)
 	if cronActive {

--- a/pkg/reconciler/monovertex/scaling/scaling_test.go
+++ b/pkg/reconciler/monovertex/scaling/scaling_test.go
@@ -285,9 +285,10 @@ func TestScaleOneMonoVertex_AppliesActiveCronBoundsBeforeMetrics(t *testing.T) {
 		cronMax              int32
 		replicasPerScaleUp   uint32
 		replicasPerScaleDown uint32
-		expected             int32
+		expected             int32 // spec.replicas after the call; unchanged when autoscaler defers to reconciler
 	}{
 		{
+			// status.replicas=0 < CalculateReplicasWithBounds(cronMin=1)=1 → mismatch → autoscaler skips
 			name:                 "scale up from zero for nightly DLQ drain",
 			current:              0,
 			parentMin:            0,
@@ -296,9 +297,10 @@ func TestScaleOneMonoVertex_AppliesActiveCronBoundsBeforeMetrics(t *testing.T) {
 			cronMax:              5,
 			replicasPerScaleUp:   2,
 			replicasPerScaleDown: 2,
-			expected:             1,
+			expected:             0, // autoscaler defers to reconciler
 		},
 		{
+			// status.replicas=10 > CalculateReplicasWithBounds(cronMax=5)=5 → mismatch → autoscaler skips
 			name:                 "scale down toward cron max",
 			current:              10,
 			parentMin:            0,
@@ -307,7 +309,7 @@ func TestScaleOneMonoVertex_AppliesActiveCronBoundsBeforeMetrics(t *testing.T) {
 			cronMax:              5,
 			replicasPerScaleUp:   2,
 			replicasPerScaleDown: 2,
-			expected:             8,
+			expected:             10, // autoscaler defers to reconciler
 		},
 	}
 
@@ -367,6 +369,68 @@ func TestScaleOneMonoVertex_AppliesActiveCronBoundsBeforeMetrics(t *testing.T) {
 			assert.Equal(t, tc.expected, *updated.Spec.Replicas)
 		})
 	}
+}
+
+func TestScaleOneMonoVertex_CronBoundsAfterReconcilerConverged(t *testing.T) {
+	makeScaler := func(t *testing.T, current int32, parentMin, parentMax, cronMin, cronMax int32, rpsUp, rpsDown uint32) (*Scaler, *dfv1.MonoVertex, client.Client) {
+		t.Helper()
+		location, err := time.LoadLocation("America/Los_Angeles")
+		if err != nil {
+			t.Fatal(err)
+		}
+		now := time.Now().In(location)
+		start := now.Add(-time.Minute)
+		end := now.Add(time.Minute)
+		cronExpression := func(t time.Time) string {
+			return fmt.Sprintf("0 %d %d %d %d *", t.Minute(), t.Hour(), t.Day(), int(t.Month()))
+		}
+		mv := &dfv1.MonoVertex{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-mvtx", Namespace: "default"},
+			Spec: dfv1.MonoVertexSpec{
+				Replicas: ptr.To(current),
+				Scale: dfv1.Scale{
+					Min: ptr.To(parentMin), Max: ptr.To(parentMax),
+					ReplicasPerScaleUp: ptr.To(rpsUp), ReplicasPerScaleDown: ptr.To(rpsDown),
+					Cron: &dfv1.CronScheduling{
+						Timezone: "America/Los_Angeles",
+						Schedules: []dfv1.CronSchedule{{
+							Start: cronExpression(start),
+							End:   cronExpression(end),
+							Min:   ptr.To(cronMin), Max: ptr.To(cronMax),
+						}},
+					},
+				},
+			},
+			Status: dfv1.MonoVertexStatus{
+				Phase:         dfv1.MonoVertexPhaseRunning,
+				Replicas:      uint32(current),
+				ReadyReplicas: 0, // skips the gRPC daemon dial, keeping the test self-contained
+				LastScaledAt:  metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+			},
+		}
+		scheme := runtime.NewScheme()
+		assert.NoError(t, dfv1.AddToScheme(scheme))
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mv).Build()
+		return NewScaler(cl), mv, cl
+	}
+
+	t.Run("at cronMin (below parentMin): autoscaler runs without mismatch", func(t *testing.T) {
+		scaler, mv, cl := makeScaler(t, 2, 5, 10, 2, 15, 2, 2)
+		assert.NoError(t, scaler.scaleOneMonoVertex(context.Background(), "default/test-mvtx", 1))
+		updated := &dfv1.MonoVertex{}
+		assert.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(mv), updated))
+		assert.Equal(t, int32(2), *updated.Spec.Replicas,
+			"spec.replicas should remain at cronMin=2 (autoscaler skips metric phase, no metrics available)")
+	})
+
+	t.Run("at cronMax (above parentMax): autoscaler runs without mismatch", func(t *testing.T) {
+		scaler, mv, cl := makeScaler(t, 15, 5, 10, 2, 15, 2, 2)
+		assert.NoError(t, scaler.scaleOneMonoVertex(context.Background(), "default/test-mvtx", 1))
+		updated := &dfv1.MonoVertex{}
+		assert.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(mv), updated))
+		assert.Equal(t, int32(15), *updated.Spec.Replicas,
+			"spec.replicas should remain at cronMax=15 (autoscaler skips metric phase, no metrics available)")
+	})
 }
 
 func monoVtxWithCronSchedule(uid types.UID, generation int64, start string) *dfv1.MonoVertex {

--- a/pkg/reconciler/scaling/utils_test.go
+++ b/pkg/reconciler/scaling/utils_test.go
@@ -114,3 +114,43 @@ func TestEffectiveScaleBoundsAt(t *testing.T) {
 		assert.Equal(t, int32(3), gotMax)
 	})
 }
+
+func TestEffectiveScaleBoundsAt_CronOverridesParent(t *testing.T) {
+	scale := dfv1.Scale{
+		Min: ptr.To[int32](5),
+		Max: ptr.To[int32](10),
+		Cron: &dfv1.CronScheduling{
+			Timezone: "UTC",
+			Schedules: []dfv1.CronSchedule{
+				{
+					Start: "0 0 2 * * *",
+					End:   "0 0 3 * * *",
+					Min:   ptr.To[int32](2),
+					Max:   ptr.To[int32](15),
+				},
+			},
+		},
+	}
+
+	parsed, err := ParseCronSchedules(scale.Cron)
+	assert.NoError(t, err)
+
+	t.Run("active: cron min below parent min and cron max above parent max", func(t *testing.T) {
+		// 2:30 AM — inside the 2:00–3:00 AM window.
+		now := time.Date(2026, 1, 5, 2, 30, 0, 0, time.UTC)
+		gotMin, gotMax, active := EffectiveScaleBoundsAt(scale, parsed, now)
+		assert.True(t, active)
+		// Cron bounds must fully replace parent bounds.
+		assert.Equal(t, int32(2), gotMin, "cron min=2 should override parent min=5")
+		assert.Equal(t, int32(15), gotMax, "cron max=15 should override parent max=10")
+	})
+
+	t.Run("inactive: parent bounds are restored outside the window", func(t *testing.T) {
+		// 10:00 AM — outside the 2:00–3:00 AM window.
+		now := time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC)
+		gotMin, gotMax, active := EffectiveScaleBoundsAt(scale, parsed, now)
+		assert.False(t, active)
+		assert.Equal(t, int32(5), gotMin, "parent min=5 should be restored when cron is inactive")
+		assert.Equal(t, int32(10), gotMax, "parent max=10 should be restored when cron is inactive")
+	})
+}

--- a/pkg/reconciler/validator/mvtx_validate_test.go
+++ b/pkg/reconciler/validator/mvtx_validate_test.go
@@ -338,6 +338,15 @@ func TestValidateCronScaling(t *testing.T) {
 			},
 		},
 		{
+			name: "cron min below parent min and cron max above parent max are both valid",
+			mutate: func(scale *dfv1.Scale) {
+				scale.Min = ptr.To[int32](5)
+				scale.Max = ptr.To[int32](10)
+				scale.Cron.Schedules[0].Min = ptr.To[int32](2)
+				scale.Cron.Schedules[0].Max = ptr.To[int32](15)
+			},
+		},
+		{
 			name: "cron schedules are empty",
 			mutate: func(scale *dfv1.Scale) {
 				scale.Cron.Schedules = nil

--- a/pkg/reconciler/vertex/controller.go
+++ b/pkg/reconciler/vertex/controller.go
@@ -40,6 +40,7 @@ import (
 
 	dfv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaflow/pkg/reconciler"
+	scalingutil "github.com/numaproj/numaflow/pkg/reconciler/scaling"
 	"github.com/numaproj/numaflow/pkg/reconciler/vertex/scaling"
 	"github.com/numaproj/numaflow/pkg/shared/logging"
 	sharedutil "github.com/numaproj/numaflow/pkg/shared/util"
@@ -187,7 +188,8 @@ func (r *vertexReconciler) reconcile(ctx context.Context, vertex *dfv1.Vertex) (
 		return ctrl.Result{}, fmt.Errorf("failed to get pods of a vertex: %w", err)
 	}
 	readyPods := reconciler.NumOfReadyPods(podList)
-	desiredReplicas := vertex.CalculateReplicas()
+	// orchestratePods already computed and stored the cron-aware desired count.
+	desiredReplicas := int(vertex.Status.DesiredReplicas)
 	if readyPods > desiredReplicas { // It might happen in some corner cases, such as during rollout
 		readyPods = desiredReplicas
 	}
@@ -206,7 +208,10 @@ func (r *vertexReconciler) reconcile(ctx context.Context, vertex *dfv1.Vertex) (
 
 func (r *vertexReconciler) orchestratePods(ctx context.Context, vertex *dfv1.Vertex, pipeline *dfv1.Pipeline, isbSvc *dfv1.InterStepBufferService) error {
 	log := logging.FromContext(ctx)
-	desiredReplicas := vertex.CalculateReplicas()
+	desiredReplicas, err := vertexEffectiveReplicas(vertex)
+	if err != nil {
+		return err
+	}
 	vertex.Status.DesiredReplicas = uint32(desiredReplicas)
 
 	// Set metrics
@@ -618,6 +623,22 @@ func (r *vertexReconciler) findExistingPods(ctx context.Context, vertex *dfv1.Ve
 		}
 	}
 	return result, nil
+}
+
+// vertexEffectiveReplicas returns the cron-aware desired replica count for a Vertex.
+// It parses cron schedules inline (acceptable for the reconciler's call rate) and
+// delegates to CalculateReplicasWithBounds with the effective bounds.
+func vertexEffectiveReplicas(vertex *dfv1.Vertex) (int, error) {
+	var parsedSchedules []scalingutil.ParsedCronSchedule
+	if vertex.Spec.Scale.Cron != nil {
+		var err error
+		parsedSchedules, err = scalingutil.ParseCronSchedules(vertex.Spec.Scale.Cron)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse cron schedules: %w", err)
+		}
+	}
+	effectiveMin, effectiveMax, _ := scalingutil.EffectiveScaleBoundsAt(vertex.Spec.Scale, parsedSchedules, time.Now())
+	return vertex.CalculateReplicasWithBounds(effectiveMin, effectiveMax), nil
 }
 
 func (r *vertexReconciler) isTerminatingPod(pod *corev1.Pod) bool {


### PR DESCRIPTION
### What this PR does / why we need it

`CalculateReplicas()` in `MonoVertex` and `Vertex` always clamped
`spec.replicas` to `[scale.min, scale.max]` (parent bounds), regardless of
any active cron window. This caused a deadlock:

1. The autoscaler correctly patches `spec.replicas = cronMin` (e.g. 2 when
   `parentMin = 5`).
2. The reconciler calls `CalculateReplicas()` → returns `parentMin = 5` →
   creates 5 pods.
3. The autoscaler mismatch guard sees `status.replicas` and the cron-aware
   target diverge → skips.
4. Replicas are permanently stuck at the parent bounds; cron windows have no
   effect.

**Fix:** introduce `CalculateReplicasWithBounds(effectiveMin, effectiveMax int32)`
on both `MonoVertex` and `Vertex`. The reconcilers obtain the effective bounds
from `scalingutil.EffectiveScaleBoundsAt` (respecting any active cron window)
and pass them in. The autoscaler mismatch guard is updated to use the same
cron-aware target, so it no longer misidentifies an intentional
out-of-parent-range value as a convergence gap.

`CalculateReplicas()` is preserved unchanged for callers that do not need
cron awareness.

### Testing

- `go test ./pkg/apis/numaflow/v1alpha1/...`
- `go test ./pkg/reconciler/monovertex/...`
- `go test ./pkg/reconciler/vertex/...`
- `go test ./pkg/reconciler/scaling/...`
- `go test ./pkg/reconciler/validator/...`
- Local kind cluster: deployed MonoVertex with `scale.min=5`, `scale.max=10`,
  cron `min=2`/`max=15` on an active window; confirmed replicas converge to
  the cron-aware target and the "replicas mismatch, skip scaling" deadlock
  log no longer appears.

### Special notes for reviewers

- `CalculateReplicasWithBounds` is the single clamping function; both
  `CalculateReplicas()` (parent bounds) and all cron-aware callers delegate
  to it — no logic is duplicated.
- The vertex reconciler's `vertexEffectiveReplicas` helper is called once per
  reconcile cycle; the pod-status check reuses `vertex.Status.DesiredReplicas`
  (already set by `orchestratePods`) to avoid a second parse.
- The autoscaler's pre-parsed schedule cache (`cronScheduleCache`) is
  unaffected; `parsedCronSchedulesFor` is still the only parse path in the
  hot autoscaler loop.
- `scale.go` in `v1alpha1` is unchanged — no new imports or methods were
  added there.

### Contributors

* @devsarvesh92
* @learncoder4848