### PR TITLE
ci: add weekly grouped dependabot config for go, npm, cargo, and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "weekly"
     groups:
       go-dependencies:
+        applies-to: security-updates
         patterns:
           - "*"
 
@@ -17,6 +18,7 @@ updates:
       interval: "weekly"
     groups:
       ui-dependencies:
+        applies-to: security-updates
         patterns:
           - "*"
 
@@ -27,6 +29,7 @@ updates:
       interval: "weekly"
     groups:
       rust-dependencies:
+        applies-to: security-updates
         patterns:
           - "*"
 
@@ -37,5 +40,6 @@ updates:
       interval: "weekly"
     groups:
       github-actions:
+        applies-to: security-updates
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
       go-dependencies:
         applies-to: security-updates
@@ -16,6 +17,7 @@ updates:
     directory: "/ui"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
       ui-dependencies:
         applies-to: security-updates
@@ -27,6 +29,7 @@ updates:
     directory: "/rust"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
       rust-dependencies:
         applies-to: security-updates
@@ -38,6 +41,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
       github-actions:
         applies-to: security-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  # Go modules (root)
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  # npm (UI)
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+    groups:
+      ui-dependencies:
+        patterns:
+          - "*"
+
+  # Cargo (Rust workspace)
+  - package-ecosystem: "cargo"
+    directory: "/rust"
+    schedule:
+      interval: "weekly"
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions (workflows)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Too many dependabot PRs 