### PR TITLE
fix: remove default replicas value from MonoVertex/Vertex CRD

### DIFF
--- a/config/base/crds/full/numaflow.numaproj.io_monovertices.yaml
+++ b/config/base/crds/full/numaflow.numaproj.io_monovertices.yaml
@@ -2871,7 +2871,6 @@ spec:
               priorityClassName:
                 type: string
               replicas:
-                default: 1
                 format: int32
                 type: integer
               resourceClaims:

--- a/config/base/crds/full/numaflow.numaproj.io_vertices.yaml
+++ b/config/base/crds/full/numaflow.numaproj.io_vertices.yaml
@@ -2533,7 +2533,6 @@ spec:
               priorityClassName:
                 type: string
               replicas:
-                default: 1
                 format: int32
                 type: integer
               resourceClaims:

--- a/config/base/crds/minimal/numaflow.numaproj.io_monovertices.yaml
+++ b/config/base/crds/minimal/numaflow.numaproj.io_monovertices.yaml
@@ -48,7 +48,6 @@ spec:
           spec:
             properties:
               replicas:
-                default: 1
                 format: int32
                 type: integer
             type: object

--- a/pkg/apis/numaflow/v1alpha1/mono_vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/mono_vertex_types.go
@@ -494,7 +494,6 @@ func (mv MonoVertex) GetPodSpec(req GetMonoVertexPodSpecReq) (*corev1.PodSpec, e
 }
 
 type MonoVertexSpec struct {
-	// +kubebuilder:default=1
 	// +optional
 	Replicas *int32  `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 	Source   *Source `json:"source,omitempty" protobuf:"bytes,2,opt,name=source"`

--- a/pkg/apis/numaflow/v1alpha1/vertex_types.go
+++ b/pkg/apis/numaflow/v1alpha1/vertex_types.go
@@ -562,7 +562,6 @@ type VertexSpec struct {
 	PipelineName   string `json:"pipelineName" protobuf:"bytes,2,opt,name=pipelineName"`
 	// +optional
 	InterStepBufferServiceName string `json:"interStepBufferServiceName" protobuf:"bytes,3,opt,name=interStepBufferServiceName"`
-	// +kubebuilder:default=1
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty" protobuf:"varint,4,opt,name=replicas"`
 	// +optional


### PR DESCRIPTION
## Problem
`spec.replicas` on MonoVertex/Vertex has a `+kubebuilder:default=1` (and the same default baked into the generated CRD YAMLs, including the `minimal` variant). Since replicas is managed via the scale subresource by the autoscaler, this schema default causes ArgoCD to materialize a "desired" value of `replicas: 1` even when the field is omitted from Git - leading to a false OutOfSync once the autoscaler updates the live value.

## Fix
Removes the default from:
- Go struct markers in `vertex_types.go` / `monovertex_types.go`
- Generated CRD manifests in `config/base/crds/full/`
- Generated CRD manifests in `config/base/crds/minimal/`

The controller already treats a `nil`/unset `Replicas` as `1` in Go (`getReplicas()` on both `Vertex` and `MonoVertex`), so removing the schema-level default doesn't change runtime behavior.

Pipeline's CRD does not define its own `spec.replicas` (each vertex's replica count is tracked on its own MonoVertex/Vertex object), so no changes were needed there.

Discussed in #3585.
Related: #3576